### PR TITLE
(feat) (abc 200) Crop Size property / Image crop properties

### DIFF
--- a/src/modules/base/image/__docs__/image.stories.js
+++ b/src/modules/base/image/__docs__/image.stories.js
@@ -258,8 +258,7 @@ BaseSmall.args = {
         'https://trailblazers.salesforce.com/resource/1618442007000/tdxlib/img/header_about_background_2x.jpg',
     alt: 'Alt text',
     blankColor: 'transparent',
-    width: '150',
-    height: '75'
+    width: '150'
 };
 
 export const Base = Template.bind({});
@@ -276,8 +275,7 @@ BaseLarge.args = {
         'https://trailblazers.salesforce.com/resource/1618442007000/tdxlib/img/header_about_background_2x.jpg',
     alt: 'Alt text',
     blankColor: 'transparent',
-    width: '600',
-    height: '300'
+    width: '600'
 };
 
 export const BaseBlankGrayLarge = Template.bind({});

--- a/src/modules/base/image/__docs__/image.stories.js
+++ b/src/modules/base/image/__docs__/image.stories.js
@@ -41,7 +41,7 @@ export default {
                 type: { summary: 'string' }
             }
         },
-        ratio: {
+        cropSize: {
             control: {
                 type: 'select'
             },

--- a/src/modules/base/image/__docs__/image.stories.js
+++ b/src/modules/base/image/__docs__/image.stories.js
@@ -41,6 +41,17 @@ export default {
                 type: { summary: 'string' }
             }
         },
+        ratio: {
+            control: {
+                type: 'select'
+            },
+            options: ['1x1', '4x3', '16x9'],
+            description:
+                'Specifies the cropping ratio for the image, which is constrained to the parents width.',
+            table: {
+                type: { summary: 'string' }
+            }
+        },
         width: {
             control: {
                 type: 'text'

--- a/src/modules/base/image/__docs__/image.stories.js
+++ b/src/modules/base/image/__docs__/image.stories.js
@@ -423,9 +423,9 @@ CropImageCircleThumbnail.args = {
     width: '300',
     cropSize: '1x1',
     rounded: 'circle',
-    cropFit: 'cover',
-    cropPositionX: '18',
-    cropPositionY: '50',
+    cropFit: 'none',
+    cropPositionX: '23',
+    cropPositionY: '80',
     thumbnail: true,
     center: true
 };

--- a/src/modules/base/image/__docs__/image.stories.js
+++ b/src/modules/base/image/__docs__/image.stories.js
@@ -286,7 +286,7 @@ BaseBlankGrayLarge.args = {
     blankColor: 'gray',
     width: '600',
     height: '300',
-    blank: 'true'
+    blank: true
 };
 
 export const Thumbnail = Template.bind({});
@@ -295,7 +295,7 @@ Thumbnail.args = {
         'https://trailblazers.salesforce.com/resource/1618442007000/tdxlib/img/header_about_background_2x.jpg',
     alt: 'Alt text',
     blankColor: 'transparent',
-    thumbnail: 'true'
+    thumbnail: true
 };
 
 export const CenterCornerRounded = Template.bind({});
@@ -305,7 +305,7 @@ CenterCornerRounded.args = {
     alt: 'Alt text',
     rounded: 'true',
     blankColor: 'transparent',
-    center: 'true'
+    center: true
 };
 
 export const RightCornerTop = Template.bind({});
@@ -315,7 +315,7 @@ RightCornerTop.args = {
     alt: 'Alt text',
     rounded: 'top',
     blankColor: 'transparent',
-    right: 'true'
+    right: true
 };
 
 export const CornerBottom = Template.bind({});
@@ -376,7 +376,7 @@ ThumbnailMediumCircle.args = {
     width: '150',
     rounded: 'circle',
     blankColor: 'transparent',
-    thumbnail: 'true'
+    thumbnail: true
 };
 
 export const LargeCircle = Template.bind({});
@@ -398,6 +398,21 @@ LargeBlankGrayCircle.args = {
     height: '300',
     width: '300',
     rounded: 'circle',
-    blank: 'true',
+    blank: true,
     blankColor: 'gray'
+};
+
+export const CropImageCircleThumbnail = Template.bind({});
+CropImageCircleThumbnail.args = {
+    src:
+        'https://trailblazers.salesforce.com/resource/1618442007000/tdxlib/img/header_about_background_2x.jpg',
+    alt: 'Alt text',
+    width: '300',
+    cropSize: '1x1',
+    rounded: 'circle',
+    cropFit: 'cover',
+    cropPositionX: '18',
+    cropPositionY: '50',
+    thumbnail: true,
+    center: true
 };

--- a/src/modules/base/image/__docs__/image.stories.js
+++ b/src/modules/base/image/__docs__/image.stories.js
@@ -415,8 +415,13 @@ LargeBlankGrayCircle.args = {
     blankColor: 'gray'
 };
 
-export const CropImageCircleThumbnail = Template.bind({});
-CropImageCircleThumbnail.args = {
+export const CropImageStaticCircleThumbnailMobile = Template.bind({});
+CropImageStaticCircleThumbnailMobile.parameters = {
+    viewport: {
+        defaultViewport: 'mobile1'
+    }
+};
+CropImageStaticCircleThumbnailMobile.args = {
     src:
         'https://trailblazers.salesforce.com/resource/1618442007000/tdxlib/img/header_about_background_2x.jpg',
     alt: 'Alt text',
@@ -427,5 +432,5 @@ CropImageCircleThumbnail.args = {
     cropPositionX: '23',
     cropPositionY: '80',
     thumbnail: true,
-    center: true
+    staticImages: true
 };

--- a/src/modules/base/image/__docs__/image.stories.js
+++ b/src/modules/base/image/__docs__/image.stories.js
@@ -45,7 +45,7 @@ export default {
             control: {
                 type: 'select'
             },
-            options: ['1x1', '4x3', '16x9'],
+            options: ['1x1', '4x3', '16x9', 'none'],
             description:
                 'Specifies the cropping ratio for the image, which is constrained to the parents width.',
             table: {

--- a/src/modules/base/image/__docs__/image.stories.js
+++ b/src/modules/base/image/__docs__/image.stories.js
@@ -42,14 +42,62 @@ export default {
             }
         },
         cropSize: {
+            name: 'crop-size',
             control: {
                 type: 'select'
             },
             options: ['1x1', '4x3', '16x9', 'none'],
+            defaultValue: 'none',
             description:
-                'Specifies the cropping ratio for the image, which is constrained to the parents width.',
+                'Specifies the cropping ratio for the image, which is constrained to the parents width. Options : 1:1, 4:3, 16:9, none',
             table: {
-                type: { summary: 'string' }
+                defaultValue: { summary: 'none' },
+                type: { summary: 'string' },
+                category: 'Crop'
+            }
+        },
+        cropFit: {
+            name: 'crop-fit',
+            control: {
+                type: 'select'
+            },
+            options: ['cover', 'contain', 'fill', 'none'],
+            defaultValue: 'cover',
+            description: 'Specifies the cropping ratio fit for the image',
+            table: {
+                defaultValue: { summary: 'cover' },
+                type: { summary: 'string' },
+                category: 'Crop'
+            }
+        },
+        cropPositionX: {
+            name: 'crop-position-X(%)',
+            control: {
+                type: 'text'
+            },
+            defaultValue: '50',
+            description:
+                'Specifies the cropping point of interest on the X axis of the image, in percentage',
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: '50' },
+                category: 'Crop',
+                detail: 'Percent'
+            }
+        },
+        cropPositionY: {
+            name: 'crop-position-Y(%)',
+            control: {
+                type: 'text'
+            },
+            defaultValue: '50',
+            description:
+                'Specifies the cropping point of interest on the Y axis of the image, in percentage',
+            table: {
+                defaultValue: { summary: '50' },
+                type: { summary: 'string' },
+                category: 'Crop',
+                detail: 'Percent'
             }
         },
         width: {

--- a/src/modules/base/image/__docs__/image.stories.js
+++ b/src/modules/base/image/__docs__/image.stories.js
@@ -63,7 +63,8 @@ export default {
             },
             options: ['cover', 'contain', 'fill', 'none'],
             defaultValue: 'cover',
-            description: 'Specifies the cropping ratio fit for the image',
+            description:
+                'Specifies the "fit" behaviour for the cropped image. Options: "cover"(default), "contain", "fill", "none"',
             table: {
                 defaultValue: { summary: 'cover' },
                 type: { summary: 'string' },
@@ -234,6 +235,19 @@ export default {
                 defaultValue: { summary: false },
                 type: { summary: 'boolean' }
             }
+        },
+        staticImages: {
+            name: 'static-images',
+            control: {
+                type: 'boolean'
+            },
+            defaultValue: false,
+            description:
+                'Set Images as Static - images will be fixed dimensions and will not be responsive on resize',
+            table: {
+                default: { summary: false },
+                type: { summary: 'boolean' }
+            }
         }
     },
     args: {
@@ -244,7 +258,8 @@ export default {
         left: false,
         right: false,
         center: false,
-        blank: false
+        blank: false,
+        staticImages: false
     }
 };
 

--- a/src/modules/base/image/__docs__/image.stories.js
+++ b/src/modules/base/image/__docs__/image.stories.js
@@ -73,7 +73,8 @@ export default {
         cropPositionX: {
             name: 'crop-position-X(%)',
             control: {
-                type: 'text'
+                type: 'range'
+                // type: 'text'
             },
             defaultValue: '50',
             description:
@@ -88,7 +89,8 @@ export default {
         cropPositionY: {
             name: 'crop-position-Y(%)',
             control: {
-                type: 'text'
+                type: 'range'
+                // type: 'text'
             },
             defaultValue: '50',
             description:

--- a/src/modules/base/image/__docs__/image.stories.js
+++ b/src/modules/base/image/__docs__/image.stories.js
@@ -74,7 +74,6 @@ export default {
             name: 'crop-position-X(%)',
             control: {
                 type: 'range'
-                // type: 'text'
             },
             defaultValue: '50',
             description:
@@ -90,7 +89,6 @@ export default {
             name: 'crop-position-Y(%)',
             control: {
                 type: 'range'
-                // type: 'text'
             },
             defaultValue: '50',
             description:

--- a/src/modules/base/image/__examples__/image.js
+++ b/src/modules/base/image/__examples__/image.js
@@ -19,7 +19,7 @@ export const Image = ({
     center,
     blank,
     blankColor,
-    ratio
+    cropSize
 }) => {
     const element = document.createElement('ac-base-image');
     element.src = src;
@@ -38,6 +38,6 @@ export const Image = ({
     element.center = center;
     element.blank = blank;
     element.blankColor = blankColor;
-    element.ratio = ratio;
+    element.cropSize = cropSize;
     return element;
 };

--- a/src/modules/base/image/__examples__/image.js
+++ b/src/modules/base/image/__examples__/image.js
@@ -19,7 +19,10 @@ export const Image = ({
     center,
     blank,
     blankColor,
-    cropSize
+    cropSize,
+    cropFit,
+    cropPositionX,
+    cropPositionY
 }) => {
     const element = document.createElement('ac-base-image');
     element.src = src;
@@ -39,5 +42,8 @@ export const Image = ({
     element.blank = blank;
     element.blankColor = blankColor;
     element.cropSize = cropSize;
+    element.cropFit = cropFit;
+    element.cropPositionX = cropPositionX;
+    element.cropPositionY = cropPositionY;
     return element;
 };

--- a/src/modules/base/image/__examples__/image.js
+++ b/src/modules/base/image/__examples__/image.js
@@ -18,7 +18,8 @@ export const Image = ({
     right,
     center,
     blank,
-    blankColor
+    blankColor,
+    ratio
 }) => {
     const element = document.createElement('ac-base-image');
     element.src = src;
@@ -37,5 +38,6 @@ export const Image = ({
     element.center = center;
     element.blank = blank;
     element.blankColor = blankColor;
+    element.ratio = ratio;
     return element;
 };

--- a/src/modules/base/image/__examples__/image.js
+++ b/src/modules/base/image/__examples__/image.js
@@ -22,7 +22,8 @@ export const Image = ({
     cropSize,
     cropFit,
     cropPositionX,
-    cropPositionY
+    cropPositionY,
+    staticImages
 }) => {
     const element = document.createElement('ac-base-image');
     element.src = src;
@@ -45,5 +46,6 @@ export const Image = ({
     element.cropFit = cropFit;
     element.cropPositionX = cropPositionX;
     element.cropPositionY = cropPositionY;
+    element.staticImages = staticImages;
     return element;
 };

--- a/src/modules/base/image/__tests__/image.test.js
+++ b/src/modules/base/image/__tests__/image.test.js
@@ -35,6 +35,10 @@ describe('Image', () => {
         expect(element.center).toBeFalsy();
         expect(element.blank).toBeFalsy();
         expect(element.blankColor).toBe('transparent');
+        expect(element.cropSize).toBeUndefined();
+        expect(element.cropFit).toBe('cover');
+        expect(element.cropPositionX).toBe('50');
+        expect(element.cropPositionY).toBe('50');
     });
 
     /* ----- ATTRIBUTES ----- */
@@ -195,7 +199,9 @@ describe('Image', () => {
 
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
-            expect(img.className).toBe('avonni-display-block');
+            expect(img.className).toBe(
+                'avonni-img_no-crop_no-width avonni-display-block'
+            );
         });
     });
 
@@ -211,7 +217,9 @@ describe('Image', () => {
 
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
-            expect(img.className).toBe('avonni-img-fluid');
+            expect(img.className).toBe(
+                'avonni-img_no-crop_no-width avonni-img-fluid'
+            );
         });
     });
 
@@ -228,7 +236,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img-fluid avonni-img-fluid-grow'
+                'avonni-img_no-crop_no-width avonni-img-fluid avonni-img-fluid-grow'
             );
         });
     });
@@ -245,7 +253,9 @@ describe('Image', () => {
 
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
-            expect(img.className).toBe('avonni-rounded');
+            expect(img.className).toBe(
+                'avonni-img_no-crop_no-width avonni-rounded'
+            );
         });
     });
 
@@ -260,7 +270,9 @@ describe('Image', () => {
 
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
-            expect(img.className).toBe('avonni-rounded-top');
+            expect(img.className).toBe(
+                'avonni-img_no-crop_no-width avonni-rounded-top'
+            );
         });
     });
 
@@ -275,7 +287,9 @@ describe('Image', () => {
 
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
-            expect(img.className).toBe('avonni-rounded-right');
+            expect(img.className).toBe(
+                'avonni-img_no-crop_no-width avonni-rounded-right'
+            );
         });
     });
 
@@ -290,7 +304,9 @@ describe('Image', () => {
 
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
-            expect(img.className).toBe('avonni-rounded-left');
+            expect(img.className).toBe(
+                'avonni-img_no-crop_no-width avonni-rounded-left'
+            );
         });
     });
 
@@ -305,7 +321,9 @@ describe('Image', () => {
 
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
-            expect(img.className).toBe('avonni-rounded-bottom');
+            expect(img.className).toBe(
+                'avonni-img_no-crop_no-width avonni-rounded-bottom'
+            );
         });
     });
 
@@ -320,7 +338,9 @@ describe('Image', () => {
 
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
-            expect(img.className).toBe('avonni-rounded-circle');
+            expect(img.className).toBe(
+                'avonni-img_no-crop_no-width avonni-rounded-circle'
+            );
         });
     });
 
@@ -336,7 +356,9 @@ describe('Image', () => {
 
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
-            expect(img.className).toBe('avonni-img-thumbnail');
+            expect(img.className).toBe(
+                'avonni-img_no-crop_no-width avonni-img-thumbnail'
+            );
         });
     });
 
@@ -352,7 +374,9 @@ describe('Image', () => {
 
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
-            expect(img.className).toBe('avonni-float-left');
+            expect(img.className).toBe(
+                'avonni-img_no-crop_no-width avonni-float-left'
+            );
         });
     });
 
@@ -368,7 +392,9 @@ describe('Image', () => {
 
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
-            expect(img.className).toBe('avonni-float-right');
+            expect(img.className).toBe(
+                'avonni-img_no-crop_no-width avonni-float-right'
+            );
         });
     });
 
@@ -385,8 +411,275 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-margin-auto avonni-display-block'
+                'avonni-img_no-crop_no-width avonni-margin-auto avonni-display-block'
             );
+        });
+    });
+
+    // Image Crop
+    it('Image Crop Size 1x1', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '1x1';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            const container = element.shadowRoot.querySelector(
+                '.avonni-img-container'
+            );
+            expect(img.className).toBe(
+                'avonni-img_cropped avonni-img_cropped_no-width'
+            );
+            expect(container.style.paddingTop).toBe('100%');
+        });
+    });
+
+    it('Image Crop Size 4x3', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '4x3';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            const container = element.shadowRoot.querySelector(
+                '.avonni-img-container'
+            );
+            expect(img.className).toBe(
+                'avonni-img_cropped avonni-img_cropped_no-width'
+            );
+            expect(container.style.paddingTop).toBe('75%');
+        });
+    });
+
+    it('Image Crop Size 16x9', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '16x9';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            const container = element.shadowRoot.querySelector(
+                '.avonni-img-container'
+            );
+            expect(img.className).toBe(
+                'avonni-img_cropped avonni-img_cropped_no-width'
+            );
+            expect(container.style.paddingTop).toBe('56.25%');
+        });
+    });
+
+    // Crop Fit
+    it('Crop Fit Cover', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '16x9';
+        element.cropFit = 'cover';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.style.objectFit).toBe('cover');
+        });
+    });
+
+    it('Crop Fit Contain', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '16x9';
+        element.cropFit = 'contain';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.style.objectFit).toBe('contain');
+        });
+    });
+
+    it('Crop Fit Fill', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '16x9';
+        element.cropFit = 'fill';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.style.objectFit).toBe('fill');
+        });
+    });
+
+    it('Crop Fit None', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '16x9';
+        element.cropFit = 'none';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.style.objectFit).toBe('none');
+        });
+    });
+
+    // Crop Position
+    it('Crop Position', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '16x9';
+        element.cropFit = 'none';
+        element.cropPositionX = '25';
+        element.cropPositionY = '75';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.style.objectPosition).toBe('25% 75%');
+        });
+    });
+
+    // Cropped Img Alignment - left, right, centre
+    it('Cropped Image Left', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '16x9';
+        element.width = '300';
+        element.left = true;
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.className).toBe(
+                'avonni-img_cropped avonni-img_cropped-left avonni-img_cropped_width'
+            );
+        });
+    });
+
+    it('Cropped Image Center', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '16x9';
+        element.width = '300';
+        element.center = true;
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.className).toBe(
+                'avonni-display-block avonni-img_cropped avonni-img_cropped-centered avonni-img_cropped_width'
+            );
+        });
+    });
+
+    it('Cropped Image Right', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '16x9';
+        element.width = '300';
+        element.right = true;
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.className).toBe(
+                'avonni-img_cropped avonni-img_cropped-right avonni-img_cropped_width'
+            );
+        });
+    });
+
+    // Cropped Ratio with width
+    it('Cropped Ratio with Width 1x1', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '1x1';
+        element.width = '400';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.className).toBe(
+                'avonni-img_cropped avonni-img_cropped_width'
+            );
+            expect(img.style.width).toBe('400px');
+            expect(img.style.height).toBe('400px');
+        });
+    });
+
+    it('Cropped Ratio with Width 4x3', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '4x3';
+        element.width = '400';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.className).toBe(
+                'avonni-img_cropped avonni-img_cropped_width'
+            );
+            expect(img.style.width).toBe('400px');
+            expect(img.style.height).toBe('300px');
+        });
+    });
+
+    it('Cropped Ratio with Width 16x9', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '16x9';
+        element.width = '400';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.className).toBe(
+                'avonni-img_cropped avonni-img_cropped_width'
+            );
+            expect(img.style.width).toBe('400px');
+            expect(img.style.height).toBe('225px');
         });
     });
 });

--- a/src/modules/base/image/__tests__/image.test.js
+++ b/src/modules/base/image/__tests__/image.test.js
@@ -3,6 +3,7 @@ import Image from 'c/image';
 
 // not tested
 // blank and blankColor because of canvas
+// cannot test computed images based on layout ( e.g. static Images and certain image states that do not have assigned dimensions ). Jest does not provide a layout system.
 
 const src =
     'https://trailblazers.salesforce.com/resource/1618442007000/tdxlib/img/header_about_background_2x.jpg';
@@ -39,6 +40,7 @@ describe('Image', () => {
         expect(element.cropFit).toBe('cover');
         expect(element.cropPositionX).toBe('50');
         expect(element.cropPositionY).toBe('50');
+        expect(element.staticImages).toBeFalsy();
     });
 
     /* ----- ATTRIBUTES ----- */
@@ -200,7 +202,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img_no-crop_no-width avonni-display-block'
+                'avonni-img_no-crop_no-width_no-height avonni-display-block'
             );
         });
     });
@@ -218,7 +220,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img_no-crop_no-width avonni-img-fluid'
+                'avonni-img_no-crop_no-width_no-height avonni-img-fluid'
             );
         });
     });
@@ -236,7 +238,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img_no-crop_no-width avonni-img-fluid avonni-img-fluid-grow'
+                'avonni-img_no-crop_no-width_no-height avonni-img-fluid avonni-img-fluid-grow'
             );
         });
     });
@@ -254,7 +256,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img_no-crop_no-width avonni-rounded'
+                'avonni-img_no-crop_no-width_no-height avonni-rounded'
             );
         });
     });
@@ -271,7 +273,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img_no-crop_no-width avonni-rounded-top'
+                'avonni-img_no-crop_no-width_no-height avonni-rounded-top'
             );
         });
     });
@@ -288,7 +290,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img_no-crop_no-width avonni-rounded-right'
+                'avonni-img_no-crop_no-width_no-height avonni-rounded-right'
             );
         });
     });
@@ -305,7 +307,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img_no-crop_no-width avonni-rounded-left'
+                'avonni-img_no-crop_no-width_no-height avonni-rounded-left'
             );
         });
     });
@@ -322,7 +324,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img_no-crop_no-width avonni-rounded-bottom'
+                'avonni-img_no-crop_no-width_no-height avonni-rounded-bottom'
             );
         });
     });
@@ -339,7 +341,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img_no-crop_no-width avonni-rounded-circle'
+                'avonni-img_no-crop_no-width_no-height avonni-rounded-circle'
             );
         });
     });
@@ -357,7 +359,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img_no-crop_no-width avonni-img-thumbnail'
+                'avonni-img_no-crop_no-width_no-height avonni-img-thumbnail'
             );
         });
     });
@@ -375,7 +377,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img_no-crop_no-width avonni-float-left'
+                'avonni-img_no-crop_no-width_no-height avonni-float-left'
             );
         });
     });
@@ -393,7 +395,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img_no-crop_no-width avonni-float-right'
+                'avonni-img_no-crop_no-width_no-height avonni-float-right'
             );
         });
     });
@@ -411,7 +413,7 @@ describe('Image', () => {
         return Promise.resolve().then(() => {
             const img = element.shadowRoot.querySelector('img');
             expect(img.className).toBe(
-                'avonni-img_no-crop_no-width avonni-margin-auto avonni-display-block'
+                'avonni-img_no-crop_no-width_no-height avonni-margin-auto avonni-display-block'
             );
         });
     });
@@ -432,7 +434,7 @@ describe('Image', () => {
                 '.avonni-img-container'
             );
             expect(img.className).toBe(
-                'avonni-img_cropped avonni-img_cropped_no-width'
+                'avonni-img_cropped avonni-img_cropped_no-width_no-height'
             );
             expect(container.style.paddingTop).toBe('100%');
         });
@@ -453,7 +455,7 @@ describe('Image', () => {
                 '.avonni-img-container'
             );
             expect(img.className).toBe(
-                'avonni-img_cropped avonni-img_cropped_no-width'
+                'avonni-img_cropped avonni-img_cropped_no-width_no-height'
             );
             expect(container.style.paddingTop).toBe('75%');
         });
@@ -474,7 +476,7 @@ describe('Image', () => {
                 '.avonni-img-container'
             );
             expect(img.className).toBe(
-                'avonni-img_cropped avonni-img_cropped_no-width'
+                'avonni-img_cropped avonni-img_cropped_no-width_no-height'
             );
             expect(container.style.paddingTop).toBe('56.25%');
         });
@@ -622,7 +624,7 @@ describe('Image', () => {
         });
     });
 
-    // Cropped Ratio with width
+    // Cropped Ratio with Width ONLY
     it('Cropped Ratio with Width 1x1', () => {
         const element = createElement('base-image', {
             is: Image
@@ -680,6 +682,206 @@ describe('Image', () => {
             );
             expect(img.style.width).toBe('400px');
             expect(img.style.height).toBe('225px');
+        });
+    });
+
+    // Cropped Ratio with Height ONLY
+    it('Cropped Ratio with Height 1x1', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '1x1';
+        element.height = '200';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.className).toBe(
+                'avonni-img_cropped avonni-img_cropped_no-width_height'
+            );
+            expect(img.style.width).toBe('200px');
+            expect(img.style.height).toBe('200px');
+        });
+    });
+
+    it('Cropped Ratio with Height 4x3', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '4x3';
+        element.height = '300';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.className).toBe(
+                'avonni-img_cropped avonni-img_cropped_no-width_height'
+            );
+            expect(img.style.width).toBe('400px');
+            expect(img.style.height).toBe('300px');
+        });
+    });
+
+    it('Cropped Ratio with Height 16x9', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.cropSize = '16x9';
+        element.height = '225';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.className).toBe(
+                'avonni-img_cropped avonni-img_cropped_no-width_height'
+            );
+            expect(img.style.width).toBe('400px');
+            expect(img.style.height).toBe('225px');
+        });
+    });
+
+    // img NO Crop - Height Only
+    it('No crop - Height Only', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.height = '225';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.className).toBe('avonni-img_no-crop_no-width_height');
+            expect(img.style.width).toBeFalsy();
+            expect(img.style.height).toBe('225px');
+        });
+    });
+
+    // Static Images NO CROP
+    it('Static Image - No Crop - Width - No Height', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.staticImages = true;
+        element.width = '400';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.className).toBeFalsy();
+            expect(img.style.maxWidth).toBe('400px');
+            expect(img.style.height).toBeFalsy();
+        });
+    });
+    it('Static Image - No Crop - No Width - Height', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+
+        element.src = src;
+        element.staticImages = true;
+        element.height = '400';
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(img.className).toBe(
+                'avonni-img_no-crop_no-width_height avonni-img_static_height_no-crop_no-width'
+            );
+            expect(img.style.maxWidth).toBe('undefinedpx');
+            expect(img.style.height).toBe('400px');
+        });
+    });
+    it('Static Image - No Crop - No Width - No Height', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+
+        element.src = src;
+        element.staticImages = true;
+        document.body.appendChild(element);
+
+        return Promise.resolve()
+            .then(() => {})
+            .then(() => {
+                const img = element.shadowRoot.querySelector('img');
+                expect(img.className).toBeFalsy();
+                expect(img.style.minWidth).toBe('0px');
+                expect(img.style.minHeight).toBe('0px');
+                expect(img.style.maxWidth).toBe('0px');
+                expect(img.style.maxHeight).toBe('0px');
+            });
+    });
+    it('Static Image - No Crop - Width - Height', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+
+        document.body.appendChild(element);
+        element.src = src;
+        element.staticImages = true;
+        element.height = 400;
+        element.width = 400;
+
+        return Promise.resolve()
+            .then(() => {})
+            .then(() => {
+                const img = element.shadowRoot.querySelector('img');
+                const container = element.shadowRoot.querySelector(
+                    '.avonni-img-container'
+                );
+                expect(img.className).toBe('avonni-img_width_height');
+                expect(img.style.minWidth).toBe('400px');
+                expect(img.style.minHeight).toBe('400px');
+                expect(img.style.maxWidth).toBe('400px');
+                expect(img.style.maxHeight).toBe('400px');
+                expect(container.style.minWidth).toBe('400px');
+                expect(container.style.minHeight).toBe('400px');
+                expect(container.style.maxWidth).toBe('400px');
+                expect(container.style.maxHeight).toBe('400px');
+                expect(container.style.paddingTop).toBe('100%');
+            });
+    });
+
+    // Static Images - Cropped
+    it('Static Image - Crop 1x1 - Width - No Height', () => {
+        const element = createElement('base-image', {
+            is: Image
+        });
+        document.body.appendChild(element);
+        element.src = src;
+        element.staticImages = true;
+        element.width = '400';
+        element.cropSize = '100';
+
+        const container = element.shadowRoot.querySelector(
+            '.avonni-img-container'
+        );
+        Object.defineProperty(container, 'clientWidth', {
+            writable: true,
+            configurable: true,
+            value: 400
+        });
+
+        return Promise.resolve().then(() => {
+            const img = element.shadowRoot.querySelector('img');
+            expect(container.style.maxWidth).toBeFalsy();
+            expect(container.style.maxHeight).toBeFalsy();
+            expect(container.style.minWidth).toBeFalsy();
+            expect(container.style.minHeight).toBeFalsy();
+            expect(container.style.maxWidth).toBeFalsy();
+            expect(container.style.paddingTop).toBeFalsy();
+            expect(img.style.maxWidth).toBe('400px');
+            expect(img.style.height).toBeFalsy();
         });
     });
 });

--- a/src/modules/base/image/image.css
+++ b/src/modules/base/image/image.css
@@ -1,32 +1,25 @@
 .avonni-img-container {
     width: 100%;
-    height: 100%;
+    height: auto;
     position: relative;
     overflow: hidden;
+    background-color: red;
 }
 
-.avonni-img_aspect-ratio_16-by-9 {
-    aspect-ratio: 16 / 9;
-    object-fit: cover;
-    /* object-position: 80% 50%; */
-}
-.avonni-img_aspect-ratio_4-by-3 {
-    aspect-ratio: 4 / 3;
-    object-fit: cover;
-}
-.avonni-img_aspect-ratio_1-by-1 {
-    aspect-ratio: 1 / 1;
-    object-fit: cover;
-    /* object-position: 20% 10%; */
-}
+/* .avonni-img-container::before {
+        display: block;
+        content: "";
+        width: 100%;
+} */
 
 .avonni-img-fluid {
-    max-width: 100%;
+    max-width: 100% !important;
     height: auto;
 }
 
 .avonni-img-fluid-grow {
-    width: 100%;
+    width: 100% !important;
+    height: auto !important;
 }
 
 .avonni-img-thumbnail {
@@ -91,4 +84,10 @@
 
 .avonni-display-block {
     display: block;
+}
+
+.avonni-img_cropped-centered {
+    transform: translate(50%);
+    right: 50%;
+    margin-left: auto;
 }

--- a/src/modules/base/image/image.css
+++ b/src/modules/base/image/image.css
@@ -87,6 +87,11 @@
     margin-right: 0;
 }
 
+.avonni-img_blank_no-crop_centered {
+    right: 50%;
+    margin-left: auto;
+}
+
 .avonni-img_cropped-right {
     right: 0%;
     margin-left: auto;

--- a/src/modules/base/image/image.css
+++ b/src/modules/base/image/image.css
@@ -106,7 +106,8 @@
     height: 100%;
 }
 
-.avonni-img_cropped_width {
+.avonni-img_cropped_width,
+.avonni-img_width_height {
     max-width: 100%;
     max-height: 100%;
 }
@@ -116,7 +117,7 @@
     height: auto;
 }
 
-.avonni-img_width_height {
-    max-width: 100%;
-    max-height: 100%;
+.avonni-img_static_height_no-crop_no-width {
+    max-width: none;
+    width: auto;
 }

--- a/src/modules/base/image/image.css
+++ b/src/modules/base/image/image.css
@@ -90,3 +90,33 @@
     right: 0%;
     margin-left: auto;
 }
+
+.avonni-img_no-crop_no-width {
+    width: 100%;
+}
+
+.avonni-img_cropped {
+    top: 0;
+    left: 0;
+    position: absolute;
+}
+
+.avonni-img_cropped_no-width {
+    width: 100%;
+    height: 100%;
+}
+
+.avonni-img_cropped_width {
+    max-width: 100%;
+    max-height: 100%;
+}
+
+.avonni-img_no-crop_width_blank {
+    max-width: 100%;
+    height: auto;
+}
+
+.avonni-img_width_height {
+    max-width: 100%;
+    max-height: 100%;
+}

--- a/src/modules/base/image/image.css
+++ b/src/modules/base/image/image.css
@@ -132,7 +132,7 @@
     height: 100%;
 }
 
-.avonni-img_no-crop_width_blank {
+.avonni-img_no-crop_blank_width_height {
     max-width: 100%;
     height: auto;
 }
@@ -148,4 +148,10 @@
 .avonni-img_static_height_no-crop_no-width {
     max-width: none;
     width: auto;
+}
+
+.avonni-img_static_no-crop_blank_height_width {
+    top: 0;
+    left: 0;
+    position: absolute;
 }

--- a/src/modules/base/image/image.css
+++ b/src/modules/base/image/image.css
@@ -84,6 +84,7 @@
     transform: translate(50%);
     right: 50%;
     margin-left: auto;
+    margin-right: 0;
 }
 
 .avonni-img_cropped-right {
@@ -91,8 +92,18 @@
     margin-left: auto;
 }
 
-.avonni-img_no-crop_no-width {
+.avonni-img_no-crop_no-width_no-height {
     width: 100%;
+    max-width: 100%;
+    height: auto;
+}
+
+.avonni-img_no-crop_no-width_height {
+    max-width: 100%;
+    max-height: 100%;
+    top: 0;
+    left: 0;
+    position: absolute;
 }
 
 .avonni-img_cropped {
@@ -106,8 +117,7 @@
     height: 100%;
 }
 
-.avonni-img_cropped_width,
-.avonni-img_width_height {
+.avonni-img_cropped_width {
     max-width: 100%;
     max-height: 100%;
 }
@@ -115,6 +125,14 @@
 .avonni-img_no-crop_width_blank {
     max-width: 100%;
     height: auto;
+}
+
+.avonni-img_width_height {
+    max-width: 100%;
+    max-height: 100%;
+    top: 0;
+    left: 0;
+    position: absolute;
 }
 
 .avonni-img_static_height_no-crop_no-width {

--- a/src/modules/base/image/image.css
+++ b/src/modules/base/image/image.css
@@ -2,6 +2,7 @@
     width: 100%;
     height: 100%;
     position: relative;
+    overflow: hidden;
 }
 
 .avonni-img_aspect-ratio_16-by-9 {

--- a/src/modules/base/image/image.css
+++ b/src/modules/base/image/image.css
@@ -112,9 +112,9 @@
     position: absolute;
 }
 
-.avonni-img_cropped_no-width {
-    width: 100%;
-    height: 100%;
+.avonni-img_cropped_no-width_height {
+    max-width: 100%;
+    max-height: 100%;
 }
 
 .avonni-img_cropped_width {

--- a/src/modules/base/image/image.css
+++ b/src/modules/base/image/image.css
@@ -1,3 +1,21 @@
+.avonni-img-container {
+    width: 100%;
+    height: 100%;
+}
+
+.avonni-img_aspect-ratio_16-by-9 {
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
+}
+.avonni-img_aspect-ratio_4-by-3 {
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
+}
+.avonni-img_aspect-ratio_1-by-1 {
+    aspect-ratio: 1 / 1;
+    object-fit: cover;
+}
+
 .avonni-img-fluid {
     max-width: 100%;
     height: auto;

--- a/src/modules/base/image/image.css
+++ b/src/modules/base/image/image.css
@@ -1,11 +1,13 @@
 .avonni-img-container {
     width: 100%;
     height: 100%;
+    position: relative;
 }
 
 .avonni-img_aspect-ratio_16-by-9 {
     aspect-ratio: 16 / 9;
     object-fit: cover;
+    /* object-position: 80% 50%; */
 }
 .avonni-img_aspect-ratio_4-by-3 {
     aspect-ratio: 4 / 3;
@@ -14,6 +16,7 @@
 .avonni-img_aspect-ratio_1-by-1 {
     aspect-ratio: 1 / 1;
     object-fit: cover;
+    /* object-position: 20% 10%; */
 }
 
 .avonni-img-fluid {

--- a/src/modules/base/image/image.css
+++ b/src/modules/base/image/image.css
@@ -122,6 +122,11 @@
     max-height: 100%;
 }
 
+.avonni-img_cropped_no-width_no-height {
+    width: 100%;
+    height: 100%;
+}
+
 .avonni-img_no-crop_width_blank {
     max-width: 100%;
     height: auto;

--- a/src/modules/base/image/image.css
+++ b/src/modules/base/image/image.css
@@ -3,14 +3,7 @@
     height: auto;
     position: relative;
     overflow: hidden;
-    background-color: red;
 }
-
-/* .avonni-img-container::before {
-        display: block;
-        content: "";
-        width: 100%;
-} */
 
 .avonni-img-fluid {
     max-width: 100% !important;
@@ -73,7 +66,8 @@
 }
 
 .avonni-margin-left-auto,
-.avonni-margin-auto {
+.avonni-margin-auto,
+.avonni-img_cropped-left {
     margin-left: auto;
 }
 
@@ -89,5 +83,10 @@
 .avonni-img_cropped-centered {
     transform: translate(50%);
     right: 50%;
+    margin-left: auto;
+}
+
+.avonni-img_cropped-right {
+    right: 0%;
     margin-left: auto;
 }

--- a/src/modules/base/image/image.html
+++ b/src/modules/base/image/image.html
@@ -1,7 +1,5 @@
 <template>
     <div class="avonni-img-container">
-        <!-- <figure class="slds-image"> -->
-        <!-- <div class="slds-image__crop slds-image__crop_4-by-3"> -->
         <img
             src={src}
             srcset={srcset}
@@ -13,43 +11,4 @@
             class={computedImageClass}
         />
     </div>
-    <!-- <br>16:9
-    <div class="avonni-img-container">
-        <img
-            src={src}
-            srcset={srcset}
-            sizes={sizes}
-            alt={alt}
-            width={width}
-            height={height}
-            class="avonni-img_aspect-ratio_16-by-9"
-        />
-    </div>
-    <br>4:3
-    <div class="avonni-img-container">
-
-        <img
-            src={src}
-            srcset={srcset}
-            sizes={sizes}
-            alt={alt}
-            width={width}
-            height={height}
-            class="avonni-img_aspect-ratio_4-by-3"
-        />
-    </div>
-    <br>1:1
-    <div class="avonni-img-container">
-        <img
-            src={src}
-            srcset={srcset}
-            sizes={sizes}
-            alt={alt}
-            width={width}
-            height={height}
-            class="avonni-img_aspect-ratio_1-by-1"
-        />
-    </div> -->
-    <!-- </div> -->
-    <!-- </figure> -->
 </template>

--- a/src/modules/base/image/image.html
+++ b/src/modules/base/image/image.html
@@ -1,11 +1,44 @@
 <template>
-    <img
-        src={src}
-        srcset={srcset}
-        sizes={sizes}
-        alt={alt}
-        width={width}
-        height={height}
-        class={computedImageClass}
-    />
+    <div class="avonni-img-container">
+        <!-- <figure class="slds-image"> -->
+        <!-- <div class="slds-image__crop slds-image__crop_4-by-3"> -->
+        <img
+            src={src}
+            srcset={srcset}
+            sizes={sizes}
+            alt={alt}
+            width={width}
+            height={height}
+            class={computedImageClass}
+        />
+        <img
+            src={src}
+            srcset={srcset}
+            sizes={sizes}
+            alt={alt}
+            width={width}
+            height={height}
+            class="avonni-img_aspect-ratio_16-by-9"
+        />
+        <img
+            src={src}
+            srcset={srcset}
+            sizes={sizes}
+            alt={alt}
+            width={width}
+            height={height}
+            class="avonni-img_aspect-ratio_4-by-3"
+        />
+        <img
+            src={src}
+            srcset={srcset}
+            sizes={sizes}
+            alt={alt}
+            width={width}
+            height={height}
+            class="avonni-img_aspect-ratio_1-by-1"
+        />
+        <!-- </div> -->
+        <!-- </figure> -->
+    </div>
 </template>

--- a/src/modules/base/image/image.html
+++ b/src/modules/base/image/image.html
@@ -9,8 +9,12 @@
             alt={alt}
             width={width}
             height={height}
+            style={computedImgStyle}
             class={computedImageClass}
         />
+    </div>
+    <!-- <br>16:9
+    <div class="avonni-img-container">
         <img
             src={src}
             srcset={srcset}
@@ -20,6 +24,10 @@
             height={height}
             class="avonni-img_aspect-ratio_16-by-9"
         />
+    </div>
+    <br>4:3
+    <div class="avonni-img-container">
+
         <img
             src={src}
             srcset={srcset}
@@ -29,6 +37,9 @@
             height={height}
             class="avonni-img_aspect-ratio_4-by-3"
         />
+    </div>
+    <br>1:1
+    <div class="avonni-img-container">
         <img
             src={src}
             srcset={srcset}
@@ -38,7 +49,7 @@
             height={height}
             class="avonni-img_aspect-ratio_1-by-1"
         />
-        <!-- </div> -->
-        <!-- </figure> -->
-    </div>
+    </div> -->
+    <!-- </div> -->
+    <!-- </figure> -->
 </template>

--- a/src/modules/base/image/image.html
+++ b/src/modules/base/image/image.html
@@ -1,5 +1,5 @@
 <template>
-    <div class="avonni-img-container">
+    <div style={computedImgContainerStyle} class={computedImgContainerClass}>
         <img
             src={src}
             srcset={srcset}

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -7,7 +7,7 @@ const BLANK_COLOR_DEFAULT = 'transparent';
 
 export default class Image extends LightningElement {
     @api alt;
-    @api ratio;
+    @api cropSize;
 
     _src;
     _width;
@@ -24,7 +24,15 @@ export default class Image extends LightningElement {
     _right = false;
     _center = false;
     _blank = false;
-    _cropSize;
+    _cropSize = 0;
+
+    renderedCallback() {
+        const parentWidth = this.template.querySelector('img').parentNode;
+        console.table(parentWidth);
+
+        this.cropRatio();
+        console.log(this._cropSize);
+    }
 
     @api
     get src() {
@@ -220,19 +228,41 @@ export default class Image extends LightningElement {
     }
 
     cropRatio() {
-        if (this.ratio)
-            switch (this.ratio) {
-                case '1x1':
-                    this._cropSize = 1;
-                    break;
-                case '4x3':
-                    this._cropSize = 4 / 3;
-                    break;
-                case '16x9':
-                    this._cropSize = 16 / 9;
-                    break;
-                default:
-                    this._cropSize = null;
-            }
+        switch (this.cropSize) {
+            case '1x1':
+                this._cropSize = 1;
+                break;
+            case '4x3':
+                this._cropSize = 4 / 3;
+                break;
+            case '16x9':
+                this._cropSize = 16 / 9;
+                break;
+            default:
+                this._cropSize = 0;
+        }
+        console.log(this._cropSize);
+    }
+
+    crop() {
+        //     // use spec width for now
+        //     canvas.width = this.width;
+        //     canvas.height = this.height;
+
+        const inputImage = this._src;
+
+        inputImage.onload = () => {
+            const outputImage = document.createElement('canvas');
+
+            outputImage.width = inputImage.naturalWidth;
+            outputImage.height = inputImage.naturalHeight;
+
+            const ctx = outputImage.getContext('2d');
+            ctx.drawImage(inputImage, 0, 0); // aspectRatio implement
+
+            this._src = outputImage.toDataURL('image/png', '');
+        };
+
+        // this._src = canvas.toDataURL('image/png', '');
     }
 }

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -19,6 +19,7 @@ export default class Image extends LightningElement {
     @api alt;
     @api cropPositionX = CROP_POSITION_X_DEFAULT;
     @api cropPositionY = CROP_POSITION_Y_DEFAULT;
+    @api staticImages;
 
     _src;
     _width;
@@ -37,6 +38,13 @@ export default class Image extends LightningElement {
     _blank = false;
     _cropSize;
     _cropFit = CROP_FIT.default;
+    _imgWidth;
+    _imgHeight;
+
+    renderedCallback() {
+        this.getImageDimensions();
+        console.log(this._imgWidth, this._imgHeight);
+    }
 
     @api get cropSize() {
         return this._cropSize;
@@ -259,7 +267,9 @@ export default class Image extends LightningElement {
                 'avonni-img_no-crop_width_blank':
                     this.width && !this._cropSize && this._blank,
                 'avonni-img_width_height':
-                    this.width && this.height && !this._blank
+                    this.width && this.height && !this._blank,
+                'avonni-img_static_height_no-crop_no-width':
+                    this.staticImages && !this.width && this.height
             })
             .toString();
     }
@@ -305,10 +315,39 @@ export default class Image extends LightningElement {
             return `
             width: ${this.width}px;
             `;
+        } else if (this.staticImages && this.width && this.height) {
+            return `
+            min-width: ${this.width}px;
+            min-height: ${this.height}px;
+            `;
+        } else if (this.staticImages && !this.width && this.height) {
+            return `
+            min-height: ${this.height}px;
+            height: ${this.height}px;
+            `;
+        } else if (this.staticImages && this.width && !this.height) {
+            return `
+            max-width: ${this.width}px;
+            `;
+        } else if (this.staticImages && !this.width && !this.height) {
+            return `
+            max-width: ${this._imgWidth}px;
+            max-height: ${this._imgHeight}px;
+            min-width: ${this._imgWidth}px;
+            min-height: ${this._imgHeight}px;
+            `;
         }
         return ` 
             width: ${this.width}px;
             height: ${this.height}px;
             `;
+    }
+
+    getImageDimensions() {
+        if (this.staticImages && !this.width && !this.height) {
+            const img = this.template.querySelector('img');
+            this._imgWidth = img.clientWidth;
+            this._imgHeight = img.clientHeight;
+        }
     }
 }

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -292,6 +292,11 @@ export default class Image extends LightningElement {
                     this.height &&
                     this._cropSize &&
                     !this.staticImages,
+                'avonni-img_cropped_no-width_no-height':
+                    !this.width &&
+                    !this.height &&
+                    this._cropSize &&
+                    !this.staticImages,
                 'avonni-img_cropped_width':
                     this.width &&
                     !this.height &&

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -287,10 +287,16 @@ export default class Image extends LightningElement {
                         this.height &&
                         !this._cropSize &&
                         !this.staticImages),
-                'avonni-img_cropped_no-width':
-                    !this.width && this._cropSize && !this.staticImages,
+                'avonni-img_cropped_no-width_height':
+                    !this.width &&
+                    this.height &&
+                    this._cropSize &&
+                    !this.staticImages,
                 'avonni-img_cropped_width':
-                    this.width && this._cropSize && !this.staticImages,
+                    this.width &&
+                    !this.height &&
+                    this._cropSize &&
+                    !this.staticImages,
                 'avonni-img_no-crop_no-width_height':
                     !this.width && this.height && !this._cropSize,
                 'avonni-img_no-crop_no-width_no-height':
@@ -372,10 +378,10 @@ export default class Image extends LightningElement {
             padding-top: ${(this.height / this._imgWidth) * 100}%;
             `;
         } else if (
-            !this.width &&
-            this.height &&
             !this._cropSize &&
-            this.staticImages
+            this.staticImages &&
+            !this.width &&
+            this.height
         ) {
             return `
             padding-top: ${(this.height / this._imgWidth) * 100}%;
@@ -384,12 +390,43 @@ export default class Image extends LightningElement {
             min-width: ${this._imgWidth}px;
             min-height: ${this.height}px;
             `;
+        } else if (
+            !this._cropSize &&
+            this.staticImages &&
+            this.width &&
+            this.height
+        ) {
+            return `
+            padding-top: ${(this.height / this.width) * 100}%;
+            max-width: ${this.width}px;
+            max-height: ${this.height}px;
+            min-width: ${this.width}px;
+            min-height: ${this.height}px;
+            `;
+        } else if (
+            this._cropSize &&
+            this.staticImages &&
+            this.height &&
+            !this.width
+        ) {
+            return `
+            padding-top: ${this._cropSize}%;
+            max-height: ${this.height}px;
+            max-width: ${this.height / (this._cropSize / 100)}px;
+            min-height: ${this.height}px;
+            min-width: ${this.height / (this._cropSize / 100)}px;
+            `;
         }
         return '';
     }
 
     get computedImgStyle() {
-        if (!this.width && this._cropSize && !this.staticImages) {
+        if (
+            !this.width &&
+            !this.height &&
+            this._cropSize &&
+            !this.staticImages
+        ) {
             return `
             object-fit: ${this.cropFit};
             object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
@@ -398,6 +435,18 @@ export default class Image extends LightningElement {
             return `
             width: ${this.width}px;
             height: ${this.width * (this._cropSize / 100)}px;
+            object-fit: ${this.cropFit};
+            object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
+            `;
+        } else if (
+            !this.width &&
+            this.height &&
+            this._cropSize &&
+            !this.staticImages
+        ) {
+            return `
+            height: ${this.height}px;
+            width: ${this.height / (this._cropSize / 100)}px;
             object-fit: ${this.cropFit};
             object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
             `;
@@ -470,6 +519,20 @@ export default class Image extends LightningElement {
             max-height: ${this.width * (this._cropSize / 100)}px;
             min-width: ${this.width}px;
             min-height: ${this.width * (this._cropSize / 100)}px;
+            object-fit: ${this.cropFit};
+            object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
+            `;
+        } else if (
+            !this.width &&
+            this.height &&
+            this._cropSize &&
+            this.staticImages
+        ) {
+            return `
+            max-height: ${this.height}px;
+            max-width: ${this.height / (this._cropSize / 100)}px;
+            min-height: ${this.height}px;
+            min-width: ${this.height / (this._cropSize / 100)}px;
             object-fit: ${this.cropFit};
             object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
             `;

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -30,9 +30,15 @@ export default class Image extends LightningElement {
     _cropSize = 0;
 
     renderedCallback() {
-        const parentWidth = this.template.querySelector('img').parentNode
+        const parentWidth = this.template.querySelector('.avonni-img-container')
             .clientWidth;
-        console.table(parentWidth);
+        const parentHeight = this.template.querySelector(
+            '.avonni-img-container'
+        ).clientHeight;
+        console.table(
+            'Container Width:' + parentWidth,
+            'Height:' + parentHeight
+        );
 
         this.cropRatio();
         console.log(this._cropSize);
@@ -210,9 +216,18 @@ export default class Image extends LightningElement {
             'avonni-not-rounded': this.rounded === '0',
             'avonni-float-left': this.left,
             'avonni-float-right': this.right,
-            'avonni-margin-auto': this.center,
+            'avonni-margin-auto': this.center && this._cropSize === null,
             'avonni-display-block': this.center || this.block
-        }).toString();
+        })
+            .add({
+                'avonni-img_cropped-centered':
+                    this.center && this._cropSize !== null
+            })
+            .toString();
+    }
+
+    get computedImgContainerClass() {
+        return classSet('avonni-img-container').toString();
     }
 
     initBlank() {
@@ -234,24 +249,52 @@ export default class Image extends LightningElement {
     cropRatio() {
         switch (this.cropSize) {
             case '1x1':
-                this._cropSize = '1 / 1';
+                this._cropSize = '100';
                 break;
             case '4x3':
-                this._cropSize = '4 / 3';
+                this._cropSize = '75';
                 break;
             case '16x9':
-                this._cropSize = '16 / 9';
+                this._cropSize = '56.25';
                 break;
             default:
                 this._cropSize = null;
         }
     }
 
+    get computedImgContainerStyle() {
+        return this._cropSize !== null
+            ? `padding-top: ${this._cropSize}%;`
+            : '';
+    }
+
     get computedImgStyle() {
+        if (!this.width && this._cropSize === null) {
+            return `width: 100%`;
+        } else if (!this.width && this._cropSize) {
+            return `
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            object-fit: ${this.cropFit};
+            object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
+            position: absolute;
+            `;
+        } else if (this.width && this._cropSize) {
+            return `
+            top: 0;
+            left: 0;
+            width: ${this.width}px;
+            height: ${this.width * (this._cropSize / 100)}px;
+            object-fit: ${this.cropFit};
+            object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
+            position: absolute;
+            `;
+        }
         return `
-        aspect-ratio: ${this._cropSize};
-        object-fit: ${this.cropFit};
-        object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
-        `;
+            width: ${this.width}px;
+            height: ${this.height}px;
+            `;
     }
 }

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -8,6 +8,9 @@ const BLANK_COLOR_DEFAULT = 'transparent';
 export default class Image extends LightningElement {
     @api alt;
     @api cropSize;
+    @api cropFit;
+    @api cropPositionX;
+    @api cropPositionY;
 
     _src;
     _width;
@@ -25,8 +28,8 @@ export default class Image extends LightningElement {
     _center = false;
     _blank = false;
     _cropSize = 0;
-    _inputImage;
-    _imgDataURL = 'https://unsplash.com/photos/EHlp8e-nQ3g';
+    // _inputImage;
+    // _imgDataURL = 'https://unsplash.com/photos/EHlp8e-nQ3g';
 
     connectedCallback() {
         // const inputImage = document.createElement('img');
@@ -274,17 +277,25 @@ export default class Image extends LightningElement {
     cropRatio() {
         switch (this.cropSize) {
             case '1x1':
-                this._cropSize = 1;
+                this._cropSize = '1 / 1';
                 break;
             case '4x3':
-                this._cropSize = 4 / 3;
+                this._cropSize = '4 / 3';
                 break;
             case '16x9':
-                this._cropSize = 16 / 9;
+                this._cropSize = '16 / 9';
                 break;
             default:
-                this._cropSize = 0;
+                this._cropSize = null;
         }
+    }
+
+    get computedImgStyle() {
+        return `
+        aspect-ratio: ${this._cropSize};
+        object-fit: ${this.cropFit};
+        object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
+        `;
     }
 
     crop() {

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -39,9 +39,7 @@ export default class Image extends LightningElement {
             'Container Width:' + parentWidth,
             'Height:' + parentHeight
         );
-
         this.cropRatio();
-        console.log(this._cropSize);
     }
 
     @api
@@ -214,14 +212,15 @@ export default class Image extends LightningElement {
             'avonni-rounded-left': this.rounded === 'left',
             'avonni-rounded-circle': this.rounded === 'circle',
             'avonni-not-rounded': this.rounded === '0',
-            'avonni-float-left': this.left,
-            'avonni-float-right': this.right,
-            'avonni-margin-auto': this.center && this._cropSize === null,
+            'avonni-float-left': this.left && !this._cropSize,
+            'avonni-float-right': this.right && !this._cropSize,
+            'avonni-margin-auto': this.center && !this._cropSize,
             'avonni-display-block': this.center || this.block
         })
             .add({
-                'avonni-img_cropped-centered':
-                    this.center && this._cropSize !== null
+                'avonni-img_cropped-centered': this.center && this._cropSize,
+                'avonni-img_cropped-left': this.left && this._cropSize,
+                'avonni-img_cropped-right': this.right && this._cropSize
             })
             .toString();
     }
@@ -263,13 +262,11 @@ export default class Image extends LightningElement {
     }
 
     get computedImgContainerStyle() {
-        return this._cropSize !== null
-            ? `padding-top: ${this._cropSize}%;`
-            : '';
+        return this._cropSize ? `padding-top: ${this._cropSize}%;` : '';
     }
 
     get computedImgStyle() {
-        if (!this.width && this._cropSize === null) {
+        if (!this.width && !this._cropSize) {
             return `width: 100%`;
         } else if (!this.width && this._cropSize) {
             return `
@@ -280,20 +277,31 @@ export default class Image extends LightningElement {
             object-fit: ${this.cropFit};
             object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
             position: absolute;
+            display: block;
             `;
         } else if (this.width && this._cropSize) {
             return `
             top: 0;
             left: 0;
             width: ${this.width}px;
+            max-width: 100%;
             height: ${this.width * (this._cropSize / 100)}px;
+            max-height: 100%;
             object-fit: ${this.cropFit};
             object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
             position: absolute;
+            display: block;
+            `;
+        } else if (this.width && !this._cropSize && this._blank) {
+            return `
+            max-width: 100%;
+            height: auto;
             `;
         }
         return `
+            max-width: 100%;
             width: ${this.width}px;
+            max-height: 100%;
             height: ${this.height}px;
             `;
     }

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -7,6 +7,7 @@ const BLANK_COLOR_DEFAULT = 'transparent';
 
 export default class Image extends LightningElement {
     @api alt;
+    @api ratio;
 
     _src;
     _width;

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -25,13 +25,57 @@ export default class Image extends LightningElement {
     _center = false;
     _blank = false;
     _cropSize = 0;
+    _inputImage;
+    _imgDataURL = 'https://unsplash.com/photos/EHlp8e-nQ3g';
+
+    connectedCallback() {
+        // const inputImage = document.createElement('img');
+        // // const inputImage = new Image();
+        // // inputImage.src = this._src;
+        // inputImage.crossOrigin = "Anonymous";
+        // inputImage.src = this._imgDataURL + "?not-from-cache-please";
+        // this._inputImage = inputImage;
+        // console.log(this._inputImage);
+        // this.crop();
+        // const url = "https://trailblazers.salesforce.com/resource/1618442007000/tdxlib/img/header_about_background_2x.jpg";
+        // // // const _imgDataURL = "https://unsplash.com/photos/EHlp8e-nQ3g";
+        // // // const url = "https://chrome-cors-testing.s3.eu-central-1.amazonaws.com/hacksoft.svg";
+        // // const image = document.createElement('img');
+        // // image.src = url;
+        // // console.log(image);
+        // const corsImageModified = document.createElement('img');
+        // corsImageModified.crossOrigin = "Anonymous";
+        // corsImageModified.src = url + "?not-from-cache";
+        // console.log(corsImageModified);
+    }
 
     renderedCallback() {
-        const parentWidth = this.template.querySelector('img').parentNode;
+        const parentWidth = this.template.querySelector('img').parentNode
+            .clientWidth;
         console.table(parentWidth);
 
         this.cropRatio();
         console.log(this._cropSize);
+
+        // const inputImage = new Image();
+        // this.inputImage.src = this._src;
+        // this.crop(this.inputImage);
+
+        // const url = "https://trailblazers.salesforce.com/resource/1618442007000/tdxlib/img/header_about_background_2x.jpg";
+        // // const _imgDataURL = "https://unsplash.com/photos/EHlp8e-nQ3g";
+        // // const url = "https://chrome-cors-testing.s3.eu-central-1.amazonaws.com/hacksoft.svg";
+        // const image = document.createElement('img');
+        // image.src = url;
+
+        // console.log(image);
+
+        // this.crop();
+
+        // const corsImageModified = document.createElement('img');
+        // corsImageModified.crossOrigin = "Anonymous";
+        // corsImageModified.src = url + "?not-from-cache";
+
+        // console.log(corsImageModified);
     }
 
     @api
@@ -241,7 +285,6 @@ export default class Image extends LightningElement {
             default:
                 this._cropSize = 0;
         }
-        console.log(this._cropSize);
     }
 
     crop() {
@@ -249,19 +292,33 @@ export default class Image extends LightningElement {
         //     canvas.width = this.width;
         //     canvas.height = this.height;
 
-        const inputImage = this._src;
+        // const inputImage = new Image();
+        const url =
+            'https://trailblazers.salesforce.com/resource/1618442007000/tdxlib/img/header_about_background_2x.jpg';
+        // const _imgDataURL = "https://unsplash.com/photos/EHlp8e-nQ3g";
+        // const url = "https://chrome-cors-testing.s3.eu-central-1.amazonaws.com/hacksoft.svg";
+        const image = document.createElement('img');
+        image.src = url;
 
-        inputImage.onload = () => {
+        const imageMod = document.createElement('img');
+
+        imageMod.onload = () => {
             const outputImage = document.createElement('canvas');
 
-            outputImage.width = inputImage.naturalWidth;
-            outputImage.height = inputImage.naturalHeight;
+            outputImage.width = image.naturalWidth;
+            outputImage.height = image.naturalHeight;
 
             const ctx = outputImage.getContext('2d');
-            ctx.drawImage(inputImage, 0, 0); // aspectRatio implement
+            ctx.drawImage(image, 0, 0); // aspectRatio implement
 
-            this._src = outputImage.toDataURL('image/png', '');
+            // console.log(outputImage.toDataURL('image/png'));
+
+            this._src = outputImage.toDataURL('image/png');
         };
+        imageMod.crossOrigin = 'Anonymous';
+        imageMod.src = url + '?not-cached'; //this._imgDataURL + "?not-from-cache-please";
+        console.log(image);
+        console.log(imageMod);
 
         // this._src = canvas.toDataURL('image/png', '');
     }

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -24,6 +24,7 @@ export default class Image extends LightningElement {
     _right = false;
     _center = false;
     _blank = false;
+    _cropSize;
 
     @api
     get src() {
@@ -216,5 +217,22 @@ export default class Image extends LightningElement {
 
             this._src = canvas.toDataURL('image/png', '');
         }
+    }
+
+    cropRatio() {
+        if (this.ratio)
+            switch (this.ratio) {
+                case '1x1':
+                    this._cropSize = 1;
+                    break;
+                case '4x3':
+                    this._cropSize = 4 / 3;
+                    break;
+                case '16x9':
+                    this._cropSize = 16 / 9;
+                    break;
+                default:
+                    this._cropSize = null;
+            }
     }
 }

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -12,11 +12,13 @@ const CROP_SIZE = {
     default: 'none'
 };
 const BLANK_COLOR_DEFAULT = 'transparent';
+const CROP_POSITION_X_DEFAULT = '50';
+const CROP_POSITION_Y_DEFAULT = '50';
 
 export default class Image extends LightningElement {
     @api alt;
-    @api cropPositionX;
-    @api cropPositionY;
+    @api cropPositionX = CROP_POSITION_X_DEFAULT;
+    @api cropPositionY = CROP_POSITION_Y_DEFAULT;
 
     _src;
     _width;

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -28,29 +28,6 @@ export default class Image extends LightningElement {
     _center = false;
     _blank = false;
     _cropSize = 0;
-    // _inputImage;
-    // _imgDataURL = 'https://unsplash.com/photos/EHlp8e-nQ3g';
-
-    connectedCallback() {
-        // const inputImage = document.createElement('img');
-        // // const inputImage = new Image();
-        // // inputImage.src = this._src;
-        // inputImage.crossOrigin = "Anonymous";
-        // inputImage.src = this._imgDataURL + "?not-from-cache-please";
-        // this._inputImage = inputImage;
-        // console.log(this._inputImage);
-        // this.crop();
-        // const url = "https://trailblazers.salesforce.com/resource/1618442007000/tdxlib/img/header_about_background_2x.jpg";
-        // // // const _imgDataURL = "https://unsplash.com/photos/EHlp8e-nQ3g";
-        // // // const url = "https://chrome-cors-testing.s3.eu-central-1.amazonaws.com/hacksoft.svg";
-        // // const image = document.createElement('img');
-        // // image.src = url;
-        // // console.log(image);
-        // const corsImageModified = document.createElement('img');
-        // corsImageModified.crossOrigin = "Anonymous";
-        // corsImageModified.src = url + "?not-from-cache";
-        // console.log(corsImageModified);
-    }
 
     renderedCallback() {
         const parentWidth = this.template.querySelector('img').parentNode
@@ -59,26 +36,6 @@ export default class Image extends LightningElement {
 
         this.cropRatio();
         console.log(this._cropSize);
-
-        // const inputImage = new Image();
-        // this.inputImage.src = this._src;
-        // this.crop(this.inputImage);
-
-        // const url = "https://trailblazers.salesforce.com/resource/1618442007000/tdxlib/img/header_about_background_2x.jpg";
-        // // const _imgDataURL = "https://unsplash.com/photos/EHlp8e-nQ3g";
-        // // const url = "https://chrome-cors-testing.s3.eu-central-1.amazonaws.com/hacksoft.svg";
-        // const image = document.createElement('img');
-        // image.src = url;
-
-        // console.log(image);
-
-        // this.crop();
-
-        // const corsImageModified = document.createElement('img');
-        // corsImageModified.crossOrigin = "Anonymous";
-        // corsImageModified.src = url + "?not-from-cache";
-
-        // console.log(corsImageModified);
     }
 
     @api
@@ -296,41 +253,5 @@ export default class Image extends LightningElement {
         object-fit: ${this.cropFit};
         object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
         `;
-    }
-
-    crop() {
-        //     // use spec width for now
-        //     canvas.width = this.width;
-        //     canvas.height = this.height;
-
-        // const inputImage = new Image();
-        const url =
-            'https://trailblazers.salesforce.com/resource/1618442007000/tdxlib/img/header_about_background_2x.jpg';
-        // const _imgDataURL = "https://unsplash.com/photos/EHlp8e-nQ3g";
-        // const url = "https://chrome-cors-testing.s3.eu-central-1.amazonaws.com/hacksoft.svg";
-        const image = document.createElement('img');
-        image.src = url;
-
-        const imageMod = document.createElement('img');
-
-        imageMod.onload = () => {
-            const outputImage = document.createElement('canvas');
-
-            outputImage.width = image.naturalWidth;
-            outputImage.height = image.naturalHeight;
-
-            const ctx = outputImage.getContext('2d');
-            ctx.drawImage(image, 0, 0); // aspectRatio implement
-
-            // console.log(outputImage.toDataURL('image/png'));
-
-            this._src = outputImage.toDataURL('image/png');
-        };
-        imageMod.crossOrigin = 'Anonymous';
-        imageMod.src = url + '?not-cached'; //this._imgDataURL + "?not-from-cache-please";
-        console.log(image);
-        console.log(imageMod);
-
-        // this._src = canvas.toDataURL('image/png', '');
     }
 }

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -269,6 +269,7 @@ export default class Image extends LightningElement {
                 'avonni-img_cropped-centered':
                     (this.center && this._cropSize) ||
                     (this.center &&
+                        !this._blank &&
                         this.width &&
                         this.height &&
                         !this._cropSize &&
@@ -287,6 +288,13 @@ export default class Image extends LightningElement {
                         this.height &&
                         !this._cropSize &&
                         !this.staticImages),
+                'avonni-img_blank_no-crop_centered':
+                    this.center &&
+                    this.width &&
+                    this.height &&
+                    this._blank &&
+                    !this._cropSize &&
+                    !this.staticImages,
                 'avonni-img_cropped_no-width_height':
                     !this.width &&
                     this.height &&
@@ -340,207 +348,183 @@ export default class Image extends LightningElement {
     }
 
     get computedImgContainerStyle() {
-        if (this._cropSize && !this.staticImages) {
+        if (!this._cropSize) {
+            return this.imgContainerNoCrop();
+        } else if (this._cropSize) {
+            return this.imgContainerCropped();
+        }
+        return '';
+    }
+
+    imgContainerNoCrop() {
+        if (!this.staticImages) {
+            if (this.width && this.height && !this._blank) {
+                return `
+                padding-top: ${(this.height / this.width) * 100}%;
+                `;
+            } else if (!this.width && this.height) {
+                return `
+                padding-top: ${(this.height / this._imgWidth) * 100}%;
+                `;
+            }
+        } else if (this.staticImages) {
+            if (!this.width && this.height) {
+                return `
+                padding-top: ${(this.height / this._imgWidth) * 100}%;
+                max-width: ${this._imgWidth}px;
+                max-height: ${this.height}px;
+                min-width: ${this._imgWidth}px;
+                min-height: ${this.height}px;
+                `;
+            } else if (this.width && this.height) {
+                return `
+                padding-top: ${(this.height / this.width) * 100}%;
+                max-width: ${this.width}px;
+                max-height: ${this.height}px;
+                min-width: ${this.width}px;
+                min-height: ${this.height}px;
+                `;
+            }
+        }
+        return '';
+    }
+
+    imgContainerCropped() {
+        if (!this.staticImages) {
             return `padding-top: ${this._cropSize}%;`;
-        } else if (
-            this._cropSize &&
-            this.staticImages &&
-            !this.width &&
-            !this.height
-        ) {
-            return `
-            padding-top: ${this._cropSize}%;
-            max-width: ${this._imgWidth}px;
-            max-height: ${this._imgHeight}px;
-            min-width: ${this._imgWidth}px;
-            min-height: ${this._imgHeight}px;
-            `;
-        } else if (this._cropSize && this.staticImages && this.width) {
-            return `
-            padding-top: ${this._cropSize}%;
-            max-width: ${this.width}px;
-            max-height: ${this.width * (this._cropSize / 100)}px;
-            min-width: ${this.width}px;
-            min-height: ${this.width * (this._cropSize / 100)}px;
-            `;
-        } else if (
-            this.width &&
-            this.height &&
-            !this._cropSize &&
-            !this.staticImages &&
-            !this._blank
-        ) {
-            return `
-            padding-top: ${(this.height / this.width) * 100}%;
-            `;
-        } else if (
-            !this.width &&
-            this.height &&
-            !this._cropSize &&
-            !this.staticImages
-        ) {
-            return `
-            padding-top: ${(this.height / this._imgWidth) * 100}%;
-            `;
-        } else if (
-            !this._cropSize &&
-            this.staticImages &&
-            !this.width &&
-            this.height
-        ) {
-            return `
-            padding-top: ${(this.height / this._imgWidth) * 100}%;
-            max-width: ${this._imgWidth}px;
-            max-height: ${this.height}px;
-            min-width: ${this._imgWidth}px;
-            min-height: ${this.height}px;
-            `;
-        } else if (
-            !this._cropSize &&
-            this.staticImages &&
-            this.width &&
-            this.height
-        ) {
-            return `
-            padding-top: ${(this.height / this.width) * 100}%;
-            max-width: ${this.width}px;
-            max-height: ${this.height}px;
-            min-width: ${this.width}px;
-            min-height: ${this.height}px;
-            `;
-        } else if (
-            this._cropSize &&
-            this.staticImages &&
-            this.height &&
-            !this.width
-        ) {
-            return `
-            padding-top: ${this._cropSize}%;
-            max-height: ${this.height}px;
-            max-width: ${this.height / (this._cropSize / 100)}px;
-            min-height: ${this.height}px;
-            min-width: ${this.height / (this._cropSize / 100)}px;
-            `;
+        } else if (this.staticImages) {
+            if (!this.width && !this.height) {
+                return `
+                padding-top: ${this._cropSize}%;
+                max-width: ${this._imgWidth}px;
+                max-height: ${this._imgHeight}px;
+                min-width: ${this._imgWidth}px;
+                min-height: ${this._imgHeight}px;
+                `;
+            } else if (this.width) {
+                return `
+                padding-top: ${this._cropSize}%;
+                max-width: ${this.width}px;
+                max-height: ${this.width * (this._cropSize / 100)}px;
+                min-width: ${this.width}px;
+                min-height: ${this.width * (this._cropSize / 100)}px;
+                `;
+            } else if (!this.width && this.height) {
+                return `
+                padding-top: ${this._cropSize}%;
+                max-height: ${this.height}px;
+                max-width: ${this.height / (this._cropSize / 100)}px;
+                min-height: ${this.height}px;
+                min-width: ${this.height / (this._cropSize / 100)}px;
+                `;
+            }
         }
         return '';
     }
 
     get computedImgStyle() {
-        if (
-            !this.width &&
-            !this.height &&
-            this._cropSize &&
-            !this.staticImages
-        ) {
-            return `
-            object-fit: ${this.cropFit};
-            object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
-            `;
-        } else if (this.width && this._cropSize && !this.staticImages) {
-            return `
-            width: ${this.width}px;
-            height: ${this.width * (this._cropSize / 100)}px;
-            object-fit: ${this.cropFit};
-            object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
-            `;
-        } else if (
-            !this.width &&
-            this.height &&
-            this._cropSize &&
-            !this.staticImages
-        ) {
-            return `
-            height: ${this.height}px;
-            width: ${this.height / (this._cropSize / 100)}px;
-            object-fit: ${this.cropFit};
-            object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
-            `;
+        if (!this._cropSize) {
+            return this.imgHandlerNoCrop();
+        } else if (this._cropSize) {
+            return this.imgHandlerCropped();
         } else if (this.width && this._blank && !this.staticImages) {
+            console.log('%c ?????? ', 'background: #222; color: #bada');
             return `
             width: ${this.width}px;
             `;
-        } else if (
-            this.staticImages &&
-            !this._cropSize &&
-            this.width &&
-            this.height
-        ) {
-            return `
-            min-width: ${this.width}px;
-            min-height: ${this.height}px;
-            max-width: ${this.width}px;
-            max-height: ${this.height}px;
-            `;
-        } else if (
-            this.staticImages &&
-            !this._cropSize &&
-            !this.width &&
-            this.height
-        ) {
-            return `
-            min-height: ${this.height}px;
-            height: ${this.height}px;
-            max-width: ${this._imgWidth}px;
-            min-width: ${this._imgWidth}px;
-            `;
-        } else if (
-            this.staticImages &&
-            !this._cropSize &&
-            this.width &&
-            !this.height
-        ) {
-            return `
-            max-width: ${this.width}px;
-            `;
-        } else if (
-            this.staticImages &&
-            !this._cropSize &&
-            !this.width &&
-            !this.height
-        ) {
-            return `
-            max-width: ${this._imgWidth}px;
-            max-height: ${this._imgHeight}px;
-            min-width: ${this._imgWidth}px;
-            min-height: ${this._imgHeight}px;
-            `;
-        } else if (
-            this.staticImages &&
-            this._cropSize &&
-            !this.width &&
-            !this.height
-        ) {
-            return `
-            max-width: ${this._imgWidth}px;
-            max-height: ${this._imgHeight}px;
-            min-width: ${this._imgWidth}px;
-            min-height: ${this._imgHeight}px;
-            object-fit: ${this.cropFit};
-            object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
-            `;
-        } else if (this.staticImages && this._cropSize && this.width) {
-            return `
-            max-width: ${this.width}px;
-            max-height: ${this.width * (this._cropSize / 100)}px;
-            min-width: ${this.width}px;
-            min-height: ${this.width * (this._cropSize / 100)}px;
-            object-fit: ${this.cropFit};
-            object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
-            `;
-        } else if (
-            !this.width &&
-            this.height &&
-            this._cropSize &&
-            this.staticImages
-        ) {
-            return `
-            max-height: ${this.height}px;
-            max-width: ${this.height / (this._cropSize / 100)}px;
-            min-height: ${this.height}px;
-            min-width: ${this.height / (this._cropSize / 100)}px;
-            object-fit: ${this.cropFit};
-            object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
-            `;
+        }
+        return `
+        width: ${this.width}px;
+        height: ${this.height}px;        
+        `;
+    }
+
+    imgHandlerNoCrop() {
+        if (this.staticImages) {
+            if (this.width && this.height) {
+                return `
+                min-width: ${this.width}px;
+                min-height: ${this.height}px;
+                max-width: ${this.width}px;
+                max-height: ${this.height}px;
+                `;
+            } else if (!this.width && this.height) {
+                return `
+                min-height: ${this.height}px;
+                height: ${this.height}px;
+                max-width: ${this._imgWidth}px;
+                min-width: ${this._imgWidth}px;
+                `;
+            } else if (this.width && !this.height) {
+                return `
+                max-width: ${this.width}px;
+                `;
+            } else if (!this.width && !this.height) {
+                return `
+                max-width: ${this._imgWidth}px;
+                max-height: ${this._imgHeight}px;
+                min-width: ${this._imgWidth}px;
+                min-height: ${this._imgHeight}px;
+                `;
+            }
+        }
+        return `
+        width: ${this.width}px;
+        height: ${this.height}px;        
+        `;
+    }
+
+    imgHandlerCropped() {
+        if (!this.staticImages) {
+            if (!this.width && !this.height) {
+                return `
+                object-fit: ${this.cropFit};
+                object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
+                `;
+            } else if (this.width) {
+                return `
+                width: ${this.width}px;
+                height: ${this.width * (this._cropSize / 100)}px;
+                object-fit: ${this.cropFit};
+                object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
+                `;
+            } else if (!this.width && this.height) {
+                return `
+                height: ${this.height}px;
+                width: ${this.height / (this._cropSize / 100)}px;
+                object-fit: ${this.cropFit};
+                object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
+                `;
+            }
+        } else if (this.staticImages) {
+            if (!this.width && !this.height) {
+                return `
+                max-width: ${this._imgWidth}px;
+                max-height: ${this._imgHeight}px;
+                min-width: ${this._imgWidth}px;
+                min-height: ${this._imgHeight}px;
+                object-fit: ${this.cropFit};
+                object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
+                `;
+            } else if (this.width) {
+                return `
+                max-width: ${this.width}px;
+                max-height: ${this.width * (this._cropSize / 100)}px;
+                min-width: ${this.width}px;
+                min-height: ${this.width * (this._cropSize / 100)}px;
+                object-fit: ${this.cropFit};
+                object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
+                `;
+            } else if (!this.width && this.height) {
+                return `
+                max-height: ${this.height}px;
+                max-width: ${this.height / (this._cropSize / 100)}px;
+                min-height: ${this.height}px;
+                min-width: ${this.height / (this._cropSize / 100)}px;
+                object-fit: ${this.cropFit};
+                object-position: ${this.cropPositionX}% ${this.cropPositionY}%; 
+                `;
+            }
         }
         return `
         width: ${this.width}px;

--- a/src/modules/base/image/image.js
+++ b/src/modules/base/image/image.js
@@ -317,12 +317,21 @@ export default class Image extends LightningElement {
                     !this.height &&
                     !this._cropSize &&
                     !this.staticImages,
-                'avonni-img_no-crop_width_blank':
-                    this.width && !this._cropSize && this._blank,
+                '.avonni-img_no-crop_blank_width_height':
+                    this.width &&
+                    !this._cropSize &&
+                    this._blank &&
+                    !this.staticImages,
                 'avonni-img_width_height':
                     this.width && this.height && !this._blank,
                 'avonni-img_static_height_no-crop_no-width':
-                    this.staticImages && !this.width && this.height
+                    this.staticImages && !this.width && this.height,
+                'avonni-img_static_no-crop_blank_height_width':
+                    this.staticImages &&
+                    this._blank &&
+                    !this._cropSize &&
+                    this.width &&
+                    this.height
             })
             .toString();
     }
@@ -427,11 +436,6 @@ export default class Image extends LightningElement {
             return this.imgHandlerNoCrop();
         } else if (this._cropSize) {
             return this.imgHandlerCropped();
-        } else if (this.width && this._blank && !this.staticImages) {
-            console.log('%c ?????? ', 'background: #222; color: #bada');
-            return `
-            width: ${this.width}px;
-            `;
         }
         return `
         width: ${this.width}px;
@@ -465,6 +469,12 @@ export default class Image extends LightningElement {
                 max-height: ${this._imgHeight}px;
                 min-width: ${this._imgWidth}px;
                 min-height: ${this._imgHeight}px;
+                `;
+            }
+        } else if (!this.staticImages) {
+            if (this._blank && this.width && this.height) {
+                return `
+                width: ${this.width}px;
                 `;
             }
         }


### PR DESCRIPTION
- Added crop-size property: values -> 1x1, 4x3, 16x9, none
- Added crop-fit property : values -> 'cover', 'contain', 'fill', 'none'
- Added crop-position-X and crop-position-Y

Features:
- When no width specified, crops the image based on current container width
- When a width is specified, this becomes the crop width and subsequent 1:1, 4:3, 16:9 dimensions
- Can reposition point of interest in cropped image by using the position-X and Y
- All sizes responsive with or without width specified
- Cover and Contain crop-fit allow for point of interest preservation on resize

Tests : 
- Crop size 16x9, 1x1, 4x3
- Crop fit ‘cover’, ‘contain’, ‘fill’, ‘none’
- Crop Position X - Y
- Cropped Img Alignment - left, right, centre
- Cropped Ratio with width

Fixes :
- When not cropped, the image correctly takes the height property into account when specified
- Fixed some storybook errors

Addendum : 
- Crop-fit None does allow for granular image control on X and Y - however the point of interest coordinates on X and Y are absolute, therefore the image will resize but the point of interest might not follow - compared to 'cover' and 'contain' that preserve relative dimensions when resizing.
( possible x-y reposition feature on crop fit none(?) )
