### PR TITLE
[fix] (ABC-303): Fix JSDoc config

### DIFF
--- a/jsdoc/jsdoc.config.json
+++ b/jsdoc/jsdoc.config.json
@@ -1,5 +1,6 @@
 {
     "plugins": ["plugins/markdown", "./customDictionary.js"],
+    "recurseDepth": 2,
     "markdown": {
         "hardwrap": "true"
     }

--- a/jsdoc/publish.js
+++ b/jsdoc/publish.js
@@ -11,7 +11,9 @@ const hasOwnProp = Object.prototype.hasOwnProperty;
 
 function graft(parentNode, childNodes, parentLongname) {
     childNodes
-        .filter(({ memberof }) => memberof === parentLongname)
+        .filter(
+            ({ memberof }) => !parentLongname || memberof === parentLongname
+        )
         .forEach((element) => {
             let i;
             let len;


### PR DESCRIPTION
- Show properties without a getter/setter in output
- Add recursion to config to simplify JSDoc script