### PR TITLE
[fix] (ABC-337): Fix input toggle change event and input rich text warning

### DIFF
--- a/src/modules/base/inputRichText/inputRichText.js
+++ b/src/modules/base/inputRichText/inputRichText.js
@@ -278,7 +278,7 @@ export default class InputRichText extends LightningElement {
     }
 
     set value(value) {
-        if (typeof value == 'string' && this.internalValue !== value) {
+        if (value && typeof value == 'string' && this.internalValue !== value) {
             this.internalValue = inputRichTextLibrary.cleanInput(value);
 
             if (!this.internalValue) {

--- a/src/modules/base/inputToggle/inputToggle.js
+++ b/src/modules/base/inputToggle/inputToggle.js
@@ -72,7 +72,7 @@ const DEFAULT_MESSAGE_TOGGLE_INACTIVE = 'Inactive';
 export default class InputToggle extends LightningElement {
     /**
      * Specifies a shortcut key to activate or focus an element.
-     * 
+     *
      * @type {string}
      * @public
      */
@@ -80,7 +80,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Describes the input to assistive technologies.
-     * 
+     *
      * @type {string}
      * @public
      */
@@ -89,7 +89,7 @@ export default class InputToggle extends LightningElement {
     /**
      * Help text detailing the purpose and function of the input.
      * This attribute isn't supported for file, radio, toggle, and checkbox-button types.
-     * 
+     *
      * @type {string}
      * @public
      */
@@ -97,7 +97,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Text label for the input.
-     * 
+     *
      * @type {string}
      * @required
      * @public
@@ -106,7 +106,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Text shown for the active state of a toggle.
-     * 
+     *
      * @type {string}
      * @public
      */
@@ -114,7 +114,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Text shown for the inactive state of a toggle.
-     * 
+     *
      * @type {string}
      * @public
      */
@@ -123,15 +123,15 @@ export default class InputToggle extends LightningElement {
     /**
      * Error message to be displayed when the value is missing.
      * The valueMissing error can be returned when you specify the required attribute for any input type.
-     * 
+     *
      * @type {string}
      * @public
      */
-    @api messageWhenValueMissing
+    @api messageWhenValueMissing;
 
     /**
      * Specifies the name of an input element.
-     * 
+     *
      * @type {string}
      * @public
      */
@@ -139,7 +139,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Specifies the value of an input element.
-     * 
+     *
      * @type {string}
      * @public
      */
@@ -192,7 +192,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * A space-separated list of element IDs whose presence or content is controlled by the input.
-     * 
+     *
      * @type {string}
      * @public
      */
@@ -213,7 +213,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * A space-separated list of element IDs that provide descriptive labels for the input.
-     * 
+     *
      * @type {string}
      * @public
      */
@@ -234,7 +234,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * A space-separated list of element IDs that provide labels for the input.
-     * 
+     *
      * @type {string}
      * @public
      */
@@ -255,7 +255,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * If present, the toggle is selected.
-     * 
+     *
      * @type {boolean}
      * @default false
      * @public
@@ -275,7 +275,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * If present, the input field is disabled and users cannot interact with it.
-     * 
+     *
      * @type {boolean}
      * @default false
      * @public
@@ -291,7 +291,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * If present, hides the mark.
-     * 
+     *
      * @type {boolean}
      * @default false
      * @public
@@ -306,7 +306,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * If present, the input field is read-only and cannot be edited by users.
-     * 
+     *
      * @type {boolean}
      * @default false
      * @public
@@ -322,7 +322,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * If present, the input field must be filled out before the form is submitted.
-     * 
+     *
      * @type {boolean}
      * @default false
      * @public
@@ -339,7 +339,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * The size of the input toggle. Valid values include x-small, small, medium and large.
-     * 
+     *
      * @type {string}
      * @default medium
      * @public
@@ -363,7 +363,7 @@ export default class InputToggle extends LightningElement {
      * Use label-hidden to hide the label but make it available to assistive technology.
      * Use label-inline to horizontally align the label and input field.
      * Use label-stacked to place the label above the input field.
-     * 
+     *
      * @type {string}
      * @default standard
      * @public
@@ -379,7 +379,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Represents the validity states that an element can be in, with respect to constraint validation.
-     * 
+     *
      * @type {string}
      * @public
      */
@@ -390,7 +390,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Removes keyboard focus from the input element.
-     * 
+     *
      * @public
      */
     @api
@@ -402,7 +402,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Checks if the input is valid.
-     * 
+     *
      * @returns {boolean} Indicates whether the element meets all constraint validations.
      * @public
      */
@@ -413,7 +413,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Sets focus on the input element.
-     * 
+     *
      * @public
      */
     @api
@@ -426,7 +426,7 @@ export default class InputToggle extends LightningElement {
     /**
      * Displays the error messages and returns false if the input is invalid.
      * If the input is valid, reportValidity() clears displayed error messages and returns true.
-     * 
+     *
      * @returns {boolean} - The validity status of the input fields.
      * @public
      */
@@ -439,7 +439,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Sets a custom error message to be displayed when a form is submitted.
-     * 
+     *
      * @param {string} message - The string that describes the error.
      * If message is an empty string, the error message is reset.
      * @public
@@ -452,7 +452,7 @@ export default class InputToggle extends LightningElement {
     /**
      * Displays error messages on invalid fields.
      * An invalid field fails at least one constraint validation and returns false when checkValidity() is called.
-     * 
+     *
      * @public
      */
     @api
@@ -469,7 +469,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Computed Wrapper Class styling.
-     * 
+     *
      * @type {string}
      */
     get computedWrapperClass() {
@@ -481,7 +481,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Computed Faux Toggle Class styling.
-     * 
+     *
      * @type {string}
      */
     get computedFauxToggleClass() {
@@ -495,7 +495,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Computed Label Class styling.
-     * 
+     *
      * @type {string}
      */
     get computedLabelClass() {
@@ -575,7 +575,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Gets input element.
-     * 
+     *
      * @type {element}
      */
     get _inputElement() {
@@ -606,7 +606,7 @@ export default class InputToggle extends LightningElement {
 
     /**
      * Updates proxy input attributes.
-     * 
+     *
      * @param {string} attributes
      */
     _updateProxyInputAttributes(attributes) {
@@ -623,7 +623,7 @@ export default class InputToggle extends LightningElement {
 
         /**
          * The event fired when the focus is removed from the input toggle.
-         * 
+         *
          * @event
          * @name blur
          * @public
@@ -639,7 +639,7 @@ export default class InputToggle extends LightningElement {
 
         /**
          * The event fired when you focus the input toggle.
-         * 
+         *
          * @event
          * @name focus
          * @public
@@ -651,6 +651,8 @@ export default class InputToggle extends LightningElement {
      * Dispatches the change event.
      */
     handleChange(event) {
+        event.stopPropagation();
+
         if (this.readOnly) {
             this._inputElement.checked = this.checked;
             return;
@@ -661,7 +663,7 @@ export default class InputToggle extends LightningElement {
 
         /**
          * The event fired when a value is changed in the input toggle.
-         * 
+         *
          * @event
          * @name change
          * @param {boolean} checked For input types checkbox and checkbox-button, the value of checked attribute.


### PR DESCRIPTION
- Stop propagation of default `<input>` change event in inputToggle.
- Prevent console warning when an empty string value is given to the inputRichText