### PR TITLE
Feat ABC-437 Complementary adding styling hooks

### DIFF
--- a/src/modules/base/carousel/__docs__/carousel.jsdoc.js
+++ b/src/modules/base/carousel/__docs__/carousel.jsdoc.js
@@ -1,23 +1,23 @@
 /**
-* @typedef {Object} Item
-* @name items
-* @property {string} id Required. Unique id for the item.
-* @property {string} title Primary string that will be used as the heading. 
-* @property {string} description Secondary string that is used to describe the item.
-* @property {object[]} infos List of additional information to display. Fields: [ label: string, href: string ].
-* @property {string} imageAssistiveText Image alt text, if not present the heading will be used instead.
-* @property {string} href Item link.
-* @property {string} src URL of the item image.
-* @property {object[]} actions Array of action objects for the item.
-*/
+ * @typedef {Object} Item
+ * @name items
+ * @property {string} id Required. Unique id for the item.
+ * @property {string} title Primary string that will be used as the heading.
+ * @property {string} description Secondary string that is used to describe the item.
+ * @property {object[]} infos List of additional information to display. Fields: [ label: string, href: string ].
+ * @property {string} imageAssistiveText Image alt text, if not present the heading will be used instead.
+ * @property {string} href Item link.
+ * @property {string} src URL of the item image.
+ * @property {object[]} actions Array of action objects for the item.
+ */
 /**
-* @typedef {Object} Action
-* @name actions
-* @property {string} label Action label.
-* @property {string} name Required.  Unique name of the action. It will be returned by the actionclick event.
-* @property {string} iconName The Lightning Design System name of the icon. Names are written in the format standard:opportunity. The icon is appended to the left of the label.
-* @property {boolean} disabled If present, the action item is shown as disabled. Defaults to false.
-*/
+ * @typedef {Object} Action
+ * @name actions
+ * @property {string} label Action label.
+ * @property {string} name Required.  Unique name of the action. It will be returned by the actionclick event.
+ * @property {string} iconName The Lightning Design System name of the icon. Names are written in the format standard:opportunity. The icon is appended to the left of the label.
+ * @property {boolean} disabled If present, the action item is shown as disabled. Defaults to false.
+ */
 
 /**
  * @namespace stylingHooks
@@ -25,6 +25,60 @@
 /**
  * @memberof stylingHooks
  * @name --avonni-carousel-item-color-background
+ * @default #ffffff
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-carousel-item-title-text-color
+ * @default #080707
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-carousel-item-title-font-size
+ * @default 1rem
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-carousel-item-title-font-style
+ * @default normal
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-carousel-item-title-font-weight
+ * @default 600
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-carousel-item-description-text-color
+ * @default #080707
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-carousel-item-description-font-size
+ * @default 0.8125rem
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-carousel-item-description-font-style
+ * @default normal
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-carousel-item-description-font-weight
+ * @default 400
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-carousel-item-title-text-color
  * @default #ffffff
  * @type color
  */

--- a/src/modules/base/chip/__docs__/chip.jsdoc.js
+++ b/src/modules/base/chip/__docs__/chip.jsdoc.js
@@ -35,6 +35,12 @@
  */
 /**
  * @memberof stylingHooks
+ * @name --avonni-chip-alt-inverse-outline-color
+ * @default #032d60
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
  * @name --avonni-chip-base-color-background
  * @default #032d60
  * @type color
@@ -49,6 +55,12 @@
  * @memberof stylingHooks
  * @name --avonni-chip-base-text-color
  * @default #080707
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-chip-base-outline-color
+ * @default #032d60
  * @type color
  */
 /**
@@ -71,6 +83,12 @@
  */
 /**
  * @memberof stylingHooks
+ * @name --avonni-chip-brand-outline-color
+ * @default #0070d1
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
  * @name --avonni-chip-error-color-background
  * @default #ea001e
  * @type color
@@ -85,6 +103,12 @@
  * @memberof stylingHooks
  * @name --avonni-chip-error-text-color
  * @default #ffffff
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-chip-error-outline-color
+ * @default #ea001e
  * @type color
  */
 /**
@@ -107,6 +131,12 @@
  */
 /**
  * @memberof stylingHooks
+ * @name --avonni-chip-info-outline-color
+ * @default #706e6b
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
  * @name --avonni-chip-inverse-color-background
  * @default #001639
  * @type color
@@ -121,6 +151,12 @@
  * @memberof stylingHooks
  * @name --avonni-chip-inverse-text-color
  * @default #ffffff
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-chip-inverse-outline-color
+ * @default #001639
  * @type color
  */
 /**
@@ -143,6 +179,12 @@
  */
 /**
  * @memberof stylingHooks
+ * @name --avonni-chip-offline-outline-color
+ * @default #444444
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
  * @name --avonni-chip-success-color-background
  * @default #2e844a
  * @type color
@@ -161,6 +203,12 @@
  */
 /**
  * @memberof stylingHooks
+ * @name --avonni-chip-success-outline-color
+ * @default #2e844a
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
  * @name --avonni-chip-warning-color-background
  * @default #fe9339
  * @type color
@@ -175,6 +223,12 @@
  * @memberof stylingHooks
  * @name --avonni-chip-warning-text-color
  * @default #080707
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-chip-warning-outline-color
+ * @default #fe9339
  * @type color
  */
 /**

--- a/src/modules/base/chip/chip.css
+++ b/src/modules/base/chip/chip.css
@@ -95,38 +95,38 @@
     color: var(--avonni-chip-warning-text-color, #080707);
 }
 .avonni-chip_outline.avonni-chip_theme-alt-inverse {
-    color: var(--avonni-chip-alt-inverse-color-background, #032d60);
-    border-color: var(--avonni-chip-alt-inverse-color-background, #032d60);
+    color: var(--avonni-chip-alt-inverse-outline-color, #032d60);
+    border-color: var(--avonni-chip-alt-inverse-outline-color, #032d60);
 }
 .avonni-chip_outline.avonni-chip_theme-base {
-    border-color: var(--avonni-chip-base-color-background, #ecebea);
-    color: var(--avonni-chip-base-color-background, #080707);
+    border-color: var(--avonni-chip-base-outline-color, #ecebea);
+    color: var(--avonni-chip-base-outline-color, #080707);
 }
 .avonni-chip_outline.avonni-chip_theme-brand {
-    border-color: var(--avonni-chip-brand-color-background, #0070d1);
-    color: var(--avonni-chip-brand-color-background, #0070d1);
+    border-color: var(--avonni-chip-brand-outline-color, #0070d1);
+    color: var(--avonni-chip-brand-outline-color, #0070d1);
 }
 .avonni-chip_outline.avonni-chip_theme-error {
-    border-color: var(--avonni-chip-error-color-background, #ea001e);
-    color: var(--avonni-chip-error-color-background, #ea001e);
+    border-color: var(--avonni-chip-error-outline-color, #ea001e);
+    color: var(--avonni-chip-error-outline-color, #ea001e);
 }
 .avonni-chip_outline.avonni-chip_theme-info {
-    border-color: var(--avonni-chip-info-color-background, #706e6b);
-    color: var(--avonni-chip-info-color-background, #706e6b);
+    border-color: var(--avonni-chip-info-outline-color, #706e6b);
+    color: var(--avonni-chip-info-outline-color, #706e6b);
 }
 .avonni-chip_outline.avonni-chip_theme-inverse {
-    border-color: var(--avonni-chip-inverse-color-background, #001639);
-    color: var(--avonni-chip-inverse-color-background, #001639);
+    border-color: var(--avonni-chip-inverse-outline-color, #001639);
+    color: var(--avonni-chip-inverse-outline-color, #001639);
 }
 .avonni-chip_outline.avonni-chip_theme-offline {
-    border-color: var(--avonni-chip-offline-color-background, #444444);
-    color: var(--avonni-chip-offline-color-background, #444444);
+    border-color: var(--avonni-chip-offline-outline-color, #444444);
+    color: var(--avonni-chip-offline-outline-color, #444444);
 }
 .avonni-chip_outline.avonni-chip_theme-success {
-    border-color: var(--avonni-chip-success-color-background, #2e844a);
-    color: var(--avonni-chip-success-color-background, #2e844a);
+    border-color: var(--avonni-chip-success-outline-color, #2e844a);
+    color: var(--avonni-chip-success-outline-color, #2e844a);
 }
 .avonni-chip_outline.avonni-chip_theme-warning {
-    border-color: var(--avonni-chip-warning-color-background, #fe9339);
-    color: var(--avonni-chip-warning-color-background, #fe9339);
+    border-color: var(--avonni-chip-warning-outline-color, #fe9339);
+    color: var(--avonni-chip-warning-outline-color, #fe9339);
 }

--- a/src/modules/base/combobox/combobox.css
+++ b/src/modules/base/combobox/combobox.css
@@ -72,7 +72,7 @@
     );
 }
 
-.avonni-combobox__label_styling {
+.avonni-combobox__label {
     color: var(--avonni-combobox-label-text-color, #3e3e3c);
     font-size: var(--avonni-combobox-label-font-size, 0.75rem);
     font-weight: var(--avonni-combobox-label-font-weight, 400);

--- a/src/modules/base/combobox/combobox.js
+++ b/src/modules/base/combobox/combobox.js
@@ -565,9 +565,7 @@ export default class Combobox extends LightningElement {
      * @type {string}
      */
     get computedLabelClass() {
-        return classSet(
-            'slds-form-element__label avonni-combobox__label_styling'
-        )
+        return classSet('slds-form-element__label avonni-combobox__label')
             .add({ 'slds-assistive-text': this.variant === 'label-hidden' })
             .toString();
     }
@@ -710,7 +708,7 @@ export default class Combobox extends LightningElement {
     handleSearch(event) {
         /**
          * The event fired when a user types into the combobox input.
-         * 
+         *
          * @event
          * @name search
          * @param {string} value The value of the search input.

--- a/src/modules/base/inputCounter/__tests__/inputCounter.test.js
+++ b/src/modules/base/inputCounter/__tests__/inputCounter.test.js
@@ -96,7 +96,9 @@ describe('Input Counter', () => {
         element.name = 'This is a name text';
 
         return Promise.resolve().then(() => {
-            const input = element.shadowRoot.querySelector('[data-element-id="lightning-input"]');
+            const input = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-input"]'
+            );
             expect(input.name).toBe('This is a name text');
         });
     });
@@ -106,8 +108,10 @@ describe('Input Counter', () => {
         element.label = 'This is a label text';
 
         return Promise.resolve().then(() => {
-            const input = element.shadowRoot.querySelector('[data-element-id="lightning-input"]');
-            expect(input.label).toBe('This is a label text');
+            const label = element.shadowRoot.querySelector(
+                '[data-element-id="input-counter-label"]'
+            );
+            expect(label.textContent).toBe('This is a label text');
         });
     });
 
@@ -116,10 +120,8 @@ describe('Input Counter', () => {
         element.variant = 'label-inline';
 
         return Promise.resolve().then(() => {
-            const input = element.shadowRoot.querySelector('[data-element-id="lightning-input"]');
-            expect(input.label).toBe('This is a label text');
             const label = element.shadowRoot.querySelector(
-                '.slds-form-element__label'
+                '[data-element-id="input-counter-label"]'
             );
             expect(label.textContent).toBe('This is a label text');
         });
@@ -130,7 +132,9 @@ describe('Input Counter', () => {
         element.ariaLabel = 'Aria-label';
 
         return Promise.resolve().then(() => {
-            const input = element.shadowRoot.querySelector('[data-element-id="lightning-input"]');
+            const input = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-input"]'
+            );
             expect(input.ariaLabel).toBe('Aria-label');
         });
     });
@@ -158,7 +162,9 @@ describe('Input Counter', () => {
         element.step = 5;
         element.value = 0;
         element.fractionDigits = null;
-        const input = element.shadowRoot.querySelector('[data-element-id="lightning-input"]');
+        const input = element.shadowRoot.querySelector(
+            '[data-element-id="lightning-input"]'
+        );
 
         return Promise.resolve()
             .then(() => {
@@ -178,7 +184,9 @@ describe('Input Counter', () => {
         element.step = 5;
         element.value = 0;
         element.fractionDigits = 2;
-        const input = element.shadowRoot.querySelector('[data-element-id="lightning-input"]');
+        const input = element.shadowRoot.querySelector(
+            '[data-element-id="lightning-input"]'
+        );
 
         return Promise.resolve()
             .then(() => {
@@ -198,7 +206,9 @@ describe('Input Counter', () => {
         element.step = 5.55;
         element.value = 0;
         element.fractionDigits = 2;
-        const input = element.shadowRoot.querySelector('[data-element-id="lightning-input"]');
+        const input = element.shadowRoot.querySelector(
+            '[data-element-id="lightning-input"]'
+        );
 
         return Promise.resolve()
             .then(() => {
@@ -219,7 +229,9 @@ describe('Input Counter', () => {
         element.step = 55.3658;
         element.value = 1256.789;
         element.fractionDigits = 3;
-        const input = element.shadowRoot.querySelector('[data-element-id="lightning-input"]');
+        const input = element.shadowRoot.querySelector(
+            '[data-element-id="lightning-input"]'
+        );
 
         return Promise.resolve()
             .then(() => {
@@ -260,7 +272,9 @@ describe('Input Counter', () => {
         element.type = 'number';
 
         return Promise.resolve().then(() => {
-            const input = element.shadowRoot.querySelector('[data-element-id="lightning-input"]');
+            const input = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-input"]'
+            );
             expect(input.formatter).toBe('number');
         });
     });
@@ -269,7 +283,9 @@ describe('Input Counter', () => {
         element.type = 'percent';
 
         return Promise.resolve().then(() => {
-            const input = element.shadowRoot.querySelector('[data-element-id="lightning-input"]');
+            const input = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-input"]'
+            );
             expect(input.formatter).toBe('percent');
         });
     });
@@ -278,7 +294,9 @@ describe('Input Counter', () => {
         element.type = 'currency';
 
         return Promise.resolve().then(() => {
-            const input = element.shadowRoot.querySelector('[data-element-id="lightning-input"]');
+            const input = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-input"]'
+            );
             expect(input.formatter).toBe('currency');
         });
     });
@@ -288,7 +306,9 @@ describe('Input Counter', () => {
         element.disabled = true;
 
         return Promise.resolve().then(() => {
-            const input = element.shadowRoot.querySelector('[data-element-id="lightning-input"]');
+            const input = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-input"]'
+            );
             expect(input.disabled).toBeTruthy();
         });
     });
@@ -302,7 +322,9 @@ describe('Input Counter', () => {
                 '[data-element-id^="lightning-button-icon"]'
             );
             expect(buttonIcon).toHaveLength(0);
-            const input = element.shadowRoot.querySelector('[data-element-id="lightning-input"]');
+            const input = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-input"]'
+            );
             expect(input.className).toBe('');
         });
     });
@@ -310,10 +332,11 @@ describe('Input Counter', () => {
     // required needs to be label inline
     it('Input Counter required', () => {
         element.required = true;
-        element.variant = 'label-inline';
 
         return Promise.resolve().then(() => {
-            const required = element.shadowRoot.querySelector('[data-element-id="abbr"]');
+            const required = element.shadowRoot.querySelector(
+                '[data-element-id="abbr"]'
+            );
             expect(required).toBeTruthy();
             expect(required.textContent).toBe('*');
         });
@@ -330,18 +353,6 @@ describe('Input Counter', () => {
             );
             expect(helpText).toBeTruthy();
             expect(helpText.content).toBe('This is a field level help');
-        });
-    });
-
-    it('Input Counter field level help label hidden', () => {
-        element.fieldLevelHelp = 'This is a field level help';
-        element.variant = 'label-hidden';
-
-        return Promise.resolve().then(() => {
-            const helpText = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-helptext"]'
-            );
-            expect(helpText).toBeNull();
         });
     });
 

--- a/src/modules/base/inputCounter/inputCounter.html
+++ b/src/modules/base/inputCounter/inputCounter.html
@@ -33,29 +33,29 @@
 -->
 
 <template>
-    <template if:true={isInline}>
-        <label
-            class="
-                slds-form-element__label
-                slds-no-flex
-                avonni-input-counter__label
-            "
-        >
-            <abbr
-                if:true={required}
-                title="required"
-                class="slds-required"
-                data-element-id="abbr"
-                >*</abbr
-            >
-            {label}
-        </label>
-        <lightning-helptext
-            if:true={fieldLevelHelp}
-            content={fieldLevelHelp}
-            data-element-id="lightning-helptext"
-        ></lightning-helptext>
-    </template>
+    <abbr
+        if:true={required}
+        title="required"
+        class="slds-required"
+        data-element-id="abbr"
+        >*</abbr
+    >
+    <label
+        class="
+            slds-form-element__label
+            slds-no-flex
+            avonni-input-counter__label
+        "
+        if:true={hasLabel}
+        data-element-id="input-counter-label"
+    >
+        {label}
+    </label>
+    <lightning-helptext
+        if:true={fieldLevelHelp}
+        content={fieldLevelHelp}
+        data-element-id="lightning-helptext"
+    ></lightning-helptext>
     <div class={formElementClass}>
         <div class="slds-form-element__control">
             <lightning-button-icon
@@ -65,14 +65,14 @@
                 title="Decrement counter"
                 variant="bare"
                 alternative-text="Decrement counter"
-                class={buttonDecrementClass}
+                class="slds-input__button_decrement"
                 disabled={disabled}
                 data-element-id="lightning-button-icon-decrement"
                 onclick={decrementValue}
             ></lightning-button-icon>
             <lightning-input
                 name={name}
-                label={label}
+                label="Counter Input"
                 placeholder="0"
                 aria-label={ariaLabel}
                 aria-controls={computedAriaControls}
@@ -80,9 +80,8 @@
                 aria-describedby={computedAriaDescribedBy}
                 value={value}
                 step={inputStep}
-                field-level-help={labelFieldLevelHelp}
                 accesskey={accessKey}
-                variant={labelVariant}
+                variant="label-hidden"
                 disabled={disabled}
                 readonly={readOnly}
                 required={required}
@@ -103,7 +102,7 @@
                 title="Increment counter"
                 variant="bare"
                 alternative-text="Increment counter"
-                class={buttonIncrementClass}
+                class="slds-input__button_increment"
                 disabled={disabled}
                 data-element-id="lightning-button-icon-increment"
                 onclick={incrementValue}

--- a/src/modules/base/inputCounter/inputCounter.js
+++ b/src/modules/base/inputCounter/inputCounter.js
@@ -166,8 +166,6 @@ export default class InputCounter extends LightningElement {
     _value = null;
     _previousValue;
     helpMessage;
-    labelVariant;
-    labelFieldLevelHelp;
     init = false;
 
     renderedCallback() {
@@ -284,12 +282,7 @@ export default class InputCounter extends LightningElement {
         });
 
         if (this._variant === 'label-inline') {
-            this.labelVariant = 'label-hidden';
             this.classList.add('avonni-input-counter__flex-container');
-        } else {
-            this.labelVariant = this._variant;
-            this.labelFieldLevelHelp =
-                this._variant !== 'label-hidden' ? this.fieldLevelHelp : null;
         }
     }
 
@@ -390,40 +383,6 @@ export default class InputCounter extends LightningElement {
     }
 
     /**
-     * Button Increment class styling.
-     *
-     * @type {string}
-     */
-    get buttonIncrementClass() {
-        return classSet('slds-input__button_increment')
-            .add({
-                'avonni-input-counter_standard-top':
-                    this._variant !== 'label-inline' &&
-                    this._variant !== 'label-hidden',
-                'avonni-input-counter_hidden-top':
-                    this._variant === 'label-hidden'
-            })
-            .toString();
-    }
-
-    /**
-     * Button Decrement class styling.
-     *
-     * @type {string}
-     */
-    get buttonDecrementClass() {
-        return classSet('slds-input__button_decrement')
-            .add({
-                'avonni-input-counter_standard-top':
-                    this._variant !== 'label-inline' &&
-                    this._variant !== 'label-hidden',
-                'avonni-input-counter_hidden-top':
-                    this._variant === 'label-hidden'
-            })
-            .toString();
-    }
-
-    /**
      * Input class if readOnly.
      *
      * @type {string}
@@ -437,8 +396,8 @@ export default class InputCounter extends LightningElement {
      *
      * @type {boolean}
      */
-    get isInline() {
-        return this.variant === 'label-inline';
+    get hasLabel() {
+        return this.label && this._variant !== 'label-hidden';
     }
 
     /**

--- a/src/modules/base/primitiveCarouselItem/primitiveCarouselItem.css
+++ b/src/modules/base/primitiveCarouselItem/primitiveCarouselItem.css
@@ -1,10 +1,14 @@
-.avonni-carousel__content-title {
+.avonni-carousel-item__content-title {
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 1;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: pre-line;
+    color: var(--avonni-carousel-item-title-text-color, #080707);
+    font-size: var(--avonni-carousel-item-title-font-size, 1rem);
+    font-style: var(--avonni-carousel-item-title-font-style, normal);
+    font-weight: var(--avonni-carousel-item-title-font-weight, 600);
 }
 
 .avonni-carousel__actions {
@@ -32,4 +36,11 @@
 
 .avonni-primitive-carousel-item__content_background {
     background-color: var(--avonni-carousel-item-color-background, #ffffff);
+}
+
+.avonni-carousel-item__content-description {
+    color: var(--avonni-carousel-item-description-text-color, #080707);
+    font-size: var(--avonni-carousel-item-description-font-size, 0.8125rem);
+    font-style: var(--avonni-carousel-item-description-font-style, normal);
+    font-weight: var(--avonni-carousel-item-description-font-weight, 400);
 }

--- a/src/modules/base/primitiveCarouselItem/primitiveCarouselItem.html
+++ b/src/modules/base/primitiveCarouselItem/primitiveCarouselItem.html
@@ -244,14 +244,14 @@
                 <h2
                     class="
                         slds-carousel__content-title
-                        avonni-carousel__content-title
+                        avonni-carousel-item__content-title
                     "
                 >
                     {title}
                 </h2>
                 <p
                     class="
-                        avonni-carousel__content-description
+                        avonni-carousel-item__content-description
                         slds-line-clamp_x-small
                     "
                 >

--- a/src/modules/base/qrcode/__docs__/qrcode.jsdoc.js
+++ b/src/modules/base/qrcode/__docs__/qrcode.jsdoc.js
@@ -3,13 +3,13 @@
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-qr-code-color
+ * @name --avonni-qrcode-color
  * @default #000000
  * @type color
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-qr-code-color-background
+ * @name --avonni-qrcode-color-background
  * @default #ffffff
  * @type color
  */

--- a/src/modules/base/qrcode/__docs__/qrcode.stories.js
+++ b/src/modules/base/qrcode/__docs__/qrcode.stories.js
@@ -49,7 +49,6 @@ export default {
             control: {
                 type: 'color'
             },
-            defaultValue: '#000000',
             description:
                 'The color of the QR code. Accepts a valid CSS color string, including hex and rgb.',
             table: {
@@ -63,7 +62,6 @@ export default {
             },
             description:
                 'Background color of the qr-code. Accepts a valid CSS color string, including hex and rgb.',
-            defaultValue: '#ffffff',
             table: {
                 defaultValue: { summary: '#ffffff' },
                 type: { summary: 'string' }

--- a/src/modules/base/qrcode/__tests__/qrcode.test.js
+++ b/src/modules/base/qrcode/__tests__/qrcode.test.js
@@ -63,10 +63,10 @@ describe('Qrcode', () => {
     });
 
     it('Qrcode: Default attributes', () => {
-        expect(element.background).toBe('#ffffff');
+        expect(element.background).toBeUndefined();
         expect(element.borderColor).toBeUndefined();
         expect(element.borderWidth).toBe(0);
-        expect(element.color).toBe('#000000');
+        expect(element.color).toBeUndefined();
         expect(element.encoding).toBe('ISO_8859_1');
         expect(element.errorCorrection).toBe('L');
         expect(element.padding).toBe(0);
@@ -77,14 +77,6 @@ describe('Qrcode', () => {
 
     /* ----- ATTRIBUTES ----- */
     // background
-    it('Qrcode: background null', () => {
-        element.background = null;
-
-        return Promise.resolve().then(() => {
-            expect(element.background).toBe('#ffffff');
-        });
-    });
-
     it('Qrcode: background', () => {
         element.background = '#000000';
 
@@ -110,14 +102,6 @@ describe('Qrcode', () => {
     });
 
     // color
-    it('Qrcode: color null', () => {
-        element.color = null;
-
-        return Promise.resolve().then(() => {
-            expect(element.color).toBe('#000000');
-        });
-    });
-
     it('Qrcode: color', () => {
         element.color = '#ffffff';
 

--- a/src/modules/base/qrcode/qrcode.css
+++ b/src/modules/base/qrcode/qrcode.css
@@ -31,9 +31,9 @@
  */
 
 .avonni-qrcode__svg_color {
-    fill: var(--avonni-qr-code-color, #000000);
+    fill: var(--avonni-qrcode-color, #000000);
 }
 
 .avonni-qrcode__svg_background {
-    fill: var(--avonni-qr-code-color-background, #ffffff);
+    fill: var(--avonni-qrcode-color-background, #ffffff);
 }

--- a/src/modules/base/qrcode/qrcode.js
+++ b/src/modules/base/qrcode/qrcode.js
@@ -51,10 +51,10 @@ const DEFAULT_BACKGROUND_COLOR = '#ffffff';
  * @public
  */
 export default class Qrcode extends LightningElement {
-    _background = DEFAULT_BACKGROUND_COLOR;
+    _background;
     _borderColor;
     _borderWidth = DEFAULT_BORDER_WIDTH;
-    _color = DEFAULT_COLOR;
+    _color;
     _encoding = QR_ENCODINGS.default;
     _errorCorrection = QR_ERROR_CORRECTIONS.default;
     _padding = DEFAULT_PADDING;
@@ -272,6 +272,13 @@ export default class Qrcode extends LightningElement {
             fallbackValue: QR_RENDER_AS.default,
             validValues: QR_RENDER_AS.valid
         });
+
+        this._color =
+            this._renderAs === 'canvas' && !this._color ? DEFAULT_COLOR : null;
+        this._background =
+            this._renderAs === 'canvas' && !this._background
+                ? DEFAULT_BACKGROUND_COLOR
+                : null;
 
         if (this._rendered) {
             this.redraw();

--- a/src/modules/base/range/__docs__/range.jsdoc.js
+++ b/src/modules/base/range/__docs__/range.jsdoc.js
@@ -15,25 +15,25 @@
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-range-label-text-color
+ * @name --avonni-range-header-text-color
  * @default #080707
  * @type color
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-range-label-font-size
+ * @name --avonni-range-header-font-size
  * @default 0.75rem
  * @type font
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-range-label-font-style
+ * @name --avonni-range-header-font-style
  * @default normal
  * @type font
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-range-label-font-weight
+ * @name --avonni-range-header-font-weight
  * @default 400
  * @type font
  */

--- a/src/modules/base/range/range.css
+++ b/src/modules/base/range/range.css
@@ -168,7 +168,7 @@
     transform: rotate(90deg);
 }
 
-.avonni-range__label_styling {
+.avonni-range__label {
     color: var(--avonni-range-label-text-color, #080707);
     font-size: var(--avonni-range-label-font-size, 0.75rem);
     font-style: var(--avonni-range-label-font-style, normal);

--- a/src/modules/base/range/range.css
+++ b/src/modules/base/range/range.css
@@ -169,8 +169,8 @@
 }
 
 .avonni-range__label {
-    color: var(--avonni-range-label-text-color, #080707);
-    font-size: var(--avonni-range-label-font-size, 0.75rem);
-    font-style: var(--avonni-range-label-font-style, normal);
-    font-weight: var(--avonni-range-label-font-weight, 400);
+    color: var(--avonni-range-header-text-color, #080707);
+    font-size: var(--avonni-range-header-font-size, 0.75rem);
+    font-style: var(--avonni-range-header-font-style, normal);
+    font-weight: var(--avonni-range-header-font-weight, 400);
 }

--- a/src/modules/base/range/range.html
+++ b/src/modules/base/range/range.html
@@ -34,7 +34,7 @@
 
 <template>
     <label
-        class="slds-form-element__label avonni-range__label_styling"
+        class="slds-form-element__label avonni-range__label"
         for="input"
         data-element-id="label"
     >

--- a/src/modules/base/separator/__docs__/separator.jsdoc.js
+++ b/src/modules/base/separator/__docs__/separator.jsdoc.js
@@ -43,7 +43,21 @@
  * @default solid
  * @type styling
  */
-
+/**
+ * @memberof stylingHooks
+ * @name --avonni-separator-icon-color-background
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-separator-icon-color-foreground
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-separator-icon-color-foreground-default
+ * @type color
+ */
 /**
  * @namespace examples
  */

--- a/src/modules/base/separator/separator.css
+++ b/src/modules/base/separator/separator.css
@@ -52,3 +52,15 @@
 .avonni-separator__line-two.slds-border_left {
     height: 100%;
 }
+
+.avonni-separator__icon {
+    --sds-c-icon-color-foreground: var(
+        --avonni-separator-icon-color-foreground
+    );
+    --sds-c-icon-color-foreground-default: var(
+        --avonni-separator-icon-color-foreground-default
+    );
+    --sds-c-icon-color-background: var(
+        --avonni-separator-icon-color-background
+    );
+}

--- a/src/modules/base/separator/separator.js
+++ b/src/modules/base/separator/separator.js
@@ -56,24 +56,24 @@ const VALID_ICON_POSITIONS = { valid: ['left', 'right'], default: 'left' };
  */
 export default class Separator extends LightningElement {
     /**
-     * Text to display in the separator.
-     *
-     * @type {string}
-     * @public
-     */
-    @api label;
-    /**
      * The name of the icon to be used in the format 'utility:down'.
      *
      * @type {string}
      * @public
      */
     @api iconName;
+    /**
+     * Text to display in the separator.
+     *
+     * @type {string}
+     * @public
+     */
+    @api label;
 
     _alignContent = VALID_ALIGN_CONTENTS;
+    _iconPosition = VALID_ICON_POSITIONS;
     _iconSize = VALID_ICON_SIZES;
     _orientation = VALID_ORIENTATIONS;
-    _iconPosition = VALID_ICON_POSITIONS;
 
     /**
      * Position of the content in the separator. Valid values include start, center and end.
@@ -91,6 +91,25 @@ export default class Separator extends LightningElement {
         this._alignContent = normalizeString(value, {
             fallbackValue: VALID_ALIGN_CONTENTS.default,
             validValues: VALID_ALIGN_CONTENTS.valid
+        });
+    }
+
+    /**
+     * Describes the position of the icon. Valid values include left and right.
+     *
+     * @type {string}
+     * @public
+     * @default left
+     */
+    @api
+    get iconPosition() {
+        return this._iconPosition;
+    }
+
+    set iconPosition(value) {
+        this._iconPosition = normalizeString(value, {
+            fallbackValue: VALID_ICON_POSITIONS.default,
+            validValues: VALID_ICON_POSITIONS.valid
         });
     }
 
@@ -129,24 +148,6 @@ export default class Separator extends LightningElement {
         this._orientation = normalizeString(value, {
             fallbackValue: VALID_ORIENTATIONS.default,
             validValues: VALID_ORIENTATIONS.valid
-        });
-    }
-
-    /**
-     * Describes the position of the icon. Valid values include left and right.
-     *
-     * @type {string}
-     * @public
-     * @default left
-     */
-    @api get iconPosition() {
-        return this._iconPosition;
-    }
-
-    set iconPosition(value) {
-        this._iconPosition = normalizeString(value, {
-            fallbackValue: VALID_ICON_POSITIONS.default,
-            validValues: VALID_ICON_POSITIONS.valid
         });
     }
 
@@ -234,7 +235,7 @@ export default class Separator extends LightningElement {
      * @type {string}
      */
     get computedIconClass() {
-        return classSet('avonni-separator_icon-margin')
+        return classSet('avonni-separator__icon')
             .add({
                 'slds-m-right_x-small':
                     this.label && this.iconPosition === 'left',


### PR DESCRIPTION
- ABC-438: Add text styling hooks to carousel
- ABC-439: Add styling hooks for outline in chip
- ABC-441: Add text styling hooks to input counter
- ABC-442 / ABC-443: Fixed styling hooks for color and background in qrcode
- ABC-444: Add styling hooks for icon in separator
- Change styling hooks name for header in range