### PR TITLE
[feat][fix] (ABC-484): Improve and fix tree events

### DIFF
--- a/src/modules/base/primitiveTreeItem/__tests__/primitiveTreeItem.test.js
+++ b/src/modules/base/primitiveTreeItem/__tests__/primitiveTreeItem.test.js
@@ -912,28 +912,16 @@ describe('Primitive Tree Item', () => {
                 done.click();
                 expect(element.isLeaf).toBeFalsy();
                 expect(handler).toHaveBeenCalledTimes(1);
-                expect(
-                    handler.mock.calls[0][0].detail.values.disabled
-                ).toBeTruthy();
-                expect(
-                    handler.mock.calls[0][0].detail.values.expanded
-                ).toBeTruthy();
-                expect(
-                    handler.mock.calls[0][0].detail.values.isLoading
-                ).toBeTruthy();
-                expect(handler.mock.calls[0][0].detail.values.href).toBe(
-                    '#link'
-                );
-                expect(handler.mock.calls[0][0].detail.values.label).toBe(
-                    'new label'
-                );
-                expect(handler.mock.calls[0][0].detail.values.metatext).toBe(
-                    'new meta'
-                );
-                expect(handler.mock.calls[0][0].detail.values.name).toBe(
-                    'new name'
-                );
-                expect(handler.mock.calls[0][0].detail.key).toBe('someKey');
+                const detail = handler.mock.calls[0][0].detail;
+                expect(detail.values.disabled).toBeTruthy();
+                expect(detail.values.expanded).toBeTruthy();
+                expect(detail.values.isLoading).toBeTruthy();
+                expect(detail.values.href).toBe('#link');
+                expect(detail.values.label).toBe('new label');
+                expect(detail.values.metatext).toBe('new meta');
+                expect(detail.values.name).toBe('new name');
+                expect(typeof detail.bounds).toBe('object');
+                expect(detail.key).toBe('someKey');
                 expect(handler.mock.calls[0][0].bubbles).toBeTruthy();
                 expect(handler.mock.calls[0][0].composed).toBeTruthy();
                 expect(handler.mock.calls[0][0].cancelable).toBeFalsy();
@@ -1129,6 +1117,9 @@ describe('Primitive Tree Item', () => {
                 buttonAction.click();
 
                 expect(handler).toHaveBeenCalledTimes(1);
+                expect(typeof handler.mock.calls[0][0].detail.bounds).toBe(
+                    'object'
+                );
                 expect(handler.mock.calls[0][0].detail.key).toBe('someKey');
                 expect(handler.mock.calls[0][0].detail.name).toBe('edit');
                 expect(handler.mock.calls[0][0].bubbles).toBeTruthy();
@@ -1171,9 +1162,11 @@ describe('Primitive Tree Item', () => {
         expandButton.click();
 
         expect(handler).toHaveBeenCalled();
-        expect(handler.mock.calls[0][0].detail.key).toBe('someKey');
-        expect(handler.mock.calls[0][0].detail.name).toBe('someName');
-        expect(handler.mock.calls[0][0].detail.target).toBe('chevron');
+        const detail = handler.mock.calls[0][0].detail;
+        expect(typeof detail.bounds).toBe('object');
+        expect(detail.key).toBe('someKey');
+        expect(detail.name).toBe('someName');
+        expect(detail.target).toBe('chevron');
         expect(handler.mock.calls[0][0].bubbles).toBeTruthy();
         expect(handler.mock.calls[0][0].composed).toBeTruthy();
         expect(handler.mock.calls[0][0].cancelable).toBeTruthy();

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
@@ -124,6 +124,7 @@ export default class PrimitiveTreeItem extends LightningElement {
                 bubbles: true,
                 detail: {
                     bounds: this.getBounds,
+                    closePopover: this.closePopover,
                     focus: this.focusChild,
                     removeBorder: this.removeBorder,
                     setBorder: this.setBorder,
@@ -627,6 +628,12 @@ export default class PrimitiveTreeItem extends LightningElement {
         const result = string.replace(/([A-Z])/g, ' $1');
         return result.charAt(0).toUpperCase() + result.slice(1);
     }
+
+    closePopover = () => {
+        if (this.popoverVisible) {
+            this.togglePopoverVisibility();
+        }
+    };
 
     /**
      * Compute the selection state of the item, depending on the selection state of its children.

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
@@ -929,6 +929,7 @@ export default class PrimitiveTreeItem extends LightningElement {
          */
         const actionClickEvent = new CustomEvent('privateactionclick', {
             detail: {
+                bounds: this.itemElement.getBoundingClientRect(),
                 key: this.nodeKey,
                 name
             },
@@ -1221,6 +1222,7 @@ export default class PrimitiveTreeItem extends LightningElement {
         this.dispatchEvent(
             new CustomEvent('change', {
                 detail: {
+                    bounds: this.itemElement.getBoundingClientRect(),
                     values: {
                         disabled: this.disabled,
                         expanded: this.expanded,
@@ -1262,6 +1264,7 @@ export default class PrimitiveTreeItem extends LightningElement {
             composed: true,
             cancelable: true,
             detail: {
+                bounds: this.itemElement.getBoundingClientRect(),
                 name: this.name,
                 key: this.nodeKey,
                 target

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
@@ -929,7 +929,7 @@ export default class PrimitiveTreeItem extends LightningElement {
          */
         const actionClickEvent = new CustomEvent('privateactionclick', {
             detail: {
-                bounds: this.itemElement.getBoundingClientRect(),
+                bounds: this.getBounds(),
                 key: this.nodeKey,
                 name
             },
@@ -1222,7 +1222,7 @@ export default class PrimitiveTreeItem extends LightningElement {
         this.dispatchEvent(
             new CustomEvent('change', {
                 detail: {
-                    bounds: this.itemElement.getBoundingClientRect(),
+                    bounds: this.getBounds(),
                     values: {
                         disabled: this.disabled,
                         expanded: this.expanded,
@@ -1264,7 +1264,7 @@ export default class PrimitiveTreeItem extends LightningElement {
             composed: true,
             cancelable: true,
             detail: {
-                bounds: this.itemElement.getBoundingClientRect(),
+                bounds: this.getBounds(),
                 name: this.name,
                 key: this.nodeKey,
                 target

--- a/src/modules/base/tree/__tests__/data.js
+++ b/src/modules/base/tree/__tests__/data.js
@@ -108,6 +108,7 @@ const makeRegister = (item, key, fakeRegisters, y) => {
             bottom: 10 * y + 10,
             height: 10
         }),
+        closePopover: jest.fn(),
         focus: jest.fn(),
         removeBorder: jest.fn(),
         setBorder: jest.fn(),

--- a/src/modules/base/tree/__tests__/tree.test.js
+++ b/src/modules/base/tree/__tests__/tree.test.js
@@ -326,6 +326,7 @@ describe('Tree', () => {
             );
             const event = new CustomEvent('privateactionclick', {
                 detail: {
+                    bounds: { x: 3, y: 3 },
                     name: 'custom',
                     key: '2'
                 },
@@ -334,13 +335,57 @@ describe('Tree', () => {
             items[1].dispatchEvent(event);
 
             expect(handler).toHaveBeenCalledTimes(1);
-            expect(handler.mock.calls[0][0].detail.name).toBe('custom');
-            expect(handler.mock.calls[0][0].detail.targetName).toBe(
-                ITEMS[1].name
-            );
+            const detail = handler.mock.calls[0][0].detail;
+            expect(detail.bounds).toEqual({ x: 3, y: 3 });
+            expect(detail.levelPath).toEqual([1]);
+            expect(detail.name).toBe('custom');
+            expect(detail.targetName).toBe(ITEMS[1].name);
             expect(handler.mock.calls[0][0].bubbles).toBeFalsy();
             expect(handler.mock.calls[0][0].cancelable).toBeTruthy();
             expect(handler.mock.calls[0][0].composed).toBeFalsy();
+        });
+    });
+
+    it('actionclick event, close edit popover if a standard action is clicked', () => {
+        element.items = ITEMS;
+        element.actions = ACTIONS;
+        const fakeRegisters = generateFakeRegisters();
+
+        return Promise.resolve().then(() => {
+            // Register the items, including the nested ones
+            const items = element.shadowRoot.querySelectorAll(
+                '[data-element-id="avonni-primitive-tree-item"]'
+            );
+            Object.values(fakeRegisters).forEach((register) => {
+                items[0].dispatchEvent(
+                    new CustomEvent('privateregisteritem', {
+                        bubbles: true,
+                        detail: register
+                    })
+                );
+            });
+
+            items[1].dispatchEvent(
+                new CustomEvent('privateactionclick', {
+                    detail: {
+                        name: 'edit',
+                        key: '2'
+                    },
+                    bubbles: true
+                })
+            );
+            items[2].dispatchEvent(
+                new CustomEvent('privateactionclick', {
+                    detail: {
+                        name: 'add',
+                        key: '3'
+                    },
+                    bubbles: true
+                })
+            );
+            expect(
+                fakeRegisters[ITEMS[1].name].closePopover
+            ).toHaveBeenCalled();
         });
     });
 
@@ -394,6 +439,7 @@ describe('Tree', () => {
 
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('expand');
+            expect(handler.mock.calls[0][0].detail.levelPath).toEqual([2]);
             expect(handler.mock.calls[0][0].detail.name).toBe('regular');
             expect(handler.mock.calls[0][0].detail.items[2]).toMatchObject(
                 item
@@ -437,6 +483,7 @@ describe('Tree', () => {
 
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('expand');
+            expect(handler.mock.calls[0][0].detail.levelPath).toEqual([2]);
             expect(handler.mock.calls[0][0].detail.name).toBe('regular');
             expect(handler.mock.calls[0][0].detail.items[2]).toMatchObject(
                 item
@@ -481,6 +528,7 @@ describe('Tree', () => {
 
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('add');
+            expect(handler.mock.calls[0][0].detail.levelPath).toEqual([3]);
             expect(handler.mock.calls[0][0].detail.name).toBe('simple');
             expect(handler.mock.calls[0][0].detail.items[3]).toMatchObject(
                 item
@@ -507,6 +555,9 @@ describe('Tree', () => {
 
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('add');
+            expect(handler.mock.calls[0][0].detail.levelPath).toEqual([
+                ITEMS.length - 1
+            ]);
             expect(handler.mock.calls[0][0].detail.name).toBeNull();
             expect(handler.mock.calls[0][0].detail.items).toHaveLength(5);
             expect(handler.mock.calls[0][0].detail.items[4]).toMatchObject({
@@ -539,6 +590,7 @@ describe('Tree', () => {
 
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('delete');
+            expect(handler.mock.calls[0][0].detail.levelPath).toEqual([3]);
             expect(handler.mock.calls[0][0].detail.name).toBe('simple');
             expect(handler.mock.calls[0][0].detail.items).toHaveLength(3);
             expect(
@@ -568,6 +620,7 @@ describe('Tree', () => {
 
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('duplicate');
+            expect(handler.mock.calls[0][0].detail.levelPath).toEqual([3]);
             expect(handler.mock.calls[0][0].detail.name).not.toBe(
                 ITEMS[3].name
             );
@@ -621,6 +674,7 @@ describe('Tree', () => {
 
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('edit');
+            expect(handler.mock.calls[0][0].detail.levelPath).toEqual([0]);
             expect(handler.mock.calls[0][0].detail.name).toBe('new name');
             expect(handler.mock.calls[0][0].detail.items[0]).toMatchObject(
                 item
@@ -712,6 +766,7 @@ describe('Tree', () => {
             );
             expect(handler).toHaveBeenCalledTimes(2);
             expect(handler.mock.calls[1][0].detail.action).toBe('move');
+            expect(handler.mock.calls[1][0].detail.levelPath).toEqual([1]);
             expect(handler.mock.calls[1][0].detail.name).toBe(ITEMS[1].name);
             expect(
                 handler.mock.calls[1][0].detail.previousName
@@ -788,6 +843,7 @@ describe('Tree', () => {
             );
             expect(handler).toHaveBeenCalledTimes(2);
             expect(handler.mock.calls[1][0].detail.action).toBe('move');
+            expect(handler.mock.calls[1][0].detail.levelPath).toEqual([1]);
             expect(handler.mock.calls[1][0].detail.name).toBe(ITEMS[1].name);
             expect(
                 handler.mock.calls[1][0].detail.previousName
@@ -867,6 +923,7 @@ describe('Tree', () => {
             );
             expect(handler).toHaveBeenCalledTimes(3);
             expect(handler.mock.calls[2][0].detail.action).toBe('move');
+            expect(handler.mock.calls[2][0].detail.levelPath).toEqual([1]);
             expect(handler.mock.calls[2][0].detail.name).toBe(ITEMS[1].name);
             expect(
                 handler.mock.calls[2][0].detail.previousName
@@ -966,6 +1023,7 @@ describe('Tree', () => {
             expect(handler).toHaveBeenCalledTimes(1);
             const detail = handler.mock.calls[0][0].detail;
             expect(detail.action).toBe('move');
+            expect(detail.levelPath).toEqual([3]);
             expect(detail.name).toBe(ITEMS[3].name);
             expect(detail.previousName).toBeUndefined();
             expect(detail.items).toHaveLength(3);
@@ -1156,6 +1214,7 @@ describe('Tree', () => {
             items[1].dispatchEvent(
                 new CustomEvent('privateitemclick', {
                     detail: {
+                        bounds: { x: 5, y: 12 },
                         target: 'anchor',
                         key: '2'
                     },
@@ -1167,6 +1226,11 @@ describe('Tree', () => {
             expect(handler.mock.calls[0][0].bubbles).toBeTruthy();
             expect(handler.mock.calls[0][0].composed).toBeTruthy();
             expect(handler.mock.calls[0][0].cancelable).toBeTruthy();
+            expect(handler.mock.calls[0][0].detail.bounds).toEqual({
+                x: 5,
+                y: 12
+            });
+            expect(handler.mock.calls[0][0].detail.levelPath).toEqual([1]);
             expect(handler.mock.calls[0][0].detail.selectedItems).toEqual([
                 'loading'
             ]);
@@ -1206,14 +1270,22 @@ describe('Tree', () => {
                 new CustomEvent('privateitemclick', {
                     detail: {
                         target: 'anchor',
-                        key: '3.1.2'
+                        key: '3.1.2',
+                        bounds: { x: 5, y: 12 }
                     },
                     bubbles: true
                 })
             );
 
             expect(handler).toHaveBeenCalledTimes(2);
-            expect(handler.mock.calls[0][0].detail.selectedItems).toEqual([
+            expect(handler.mock.calls[1][0].detail.bounds).toEqual({
+                x: 5,
+                y: 12
+            });
+            expect(handler.mock.calls[1][0].detail.levelPath).toEqual([
+                2, 0, 1
+            ]);
+            expect(handler.mock.calls[1][0].detail.selectedItems).toEqual([
                 'thirdLevel',
                 'secondLevel',
                 'secondLevel3',

--- a/src/modules/base/tree/tree.js
+++ b/src/modules/base/tree/tree.js
@@ -911,7 +911,9 @@ export default class Tree extends LightningElement {
         event.stopPropagation();
         const action = event.detail.name || 'add';
         const key = event.detail.key;
-        const levelPath = this.treedata.getLevelPath(key);
+        const levelPath = this.treedata.getLevelPath(
+            key || this.items.length.toString()
+        );
         const item = this.treedata.getItem(key);
         let name = item ? item.treeNode.name : null;
 
@@ -1266,7 +1268,11 @@ export default class Tree extends LightningElement {
      * @param {string} previousName Previous name of the item, if it has changed.
      */
     dispatchChange({ key, name, action, previousName }) {
-        const levelPath = this.treedata.getLevelPath(key);
+        // If no key is given, it's a new item at the root of the tree
+        const levelPath = this.treedata.getLevelPath(
+            (key || this.items.length - 1).toString()
+        );
+
         /**
          * The event fired when a change is made to the tree.
          *

--- a/src/modules/base/tree/tree.js
+++ b/src/modules/base/tree/tree.js
@@ -84,6 +84,7 @@ export default class Tree extends LightningElement {
     @track children = [];
     treedata = new TreeData();
     _dragState;
+    _editedItemKey;
     _focusedItem;
     _mouseDownTimeout;
     _mouseOverItemTimeout;
@@ -522,6 +523,10 @@ export default class Tree extends LightningElement {
                 break;
             }
             case 'edit': {
+                if (this._editedItemKey) {
+                    this.callbackMap[this._editedItemKey].closePopover();
+                }
+                this._editedItemKey = key;
                 return;
             }
             case 'delete': {
@@ -1205,6 +1210,7 @@ export default class Tree extends LightningElement {
         event.stopPropagation();
         const {
             bounds,
+            closePopover,
             key,
             focus,
             removeBorder,
@@ -1215,6 +1221,7 @@ export default class Tree extends LightningElement {
 
         this.callbackMap[key] = {
             bounds,
+            closePopover,
             focus,
             removeBorder,
             setBorder,

--- a/src/modules/base/tree/tree.js
+++ b/src/modules/base/tree/tree.js
@@ -919,8 +919,10 @@ export default class Tree extends LightningElement {
         if (
             actionClickEvent.defaultPrevented ||
             !DEFAULT_ACTION_NAMES.includes(action)
-        )
+        ) {
+            event.preventDefault();
             return;
+        }
 
         this.executeStandardAction(action, item);
     }

--- a/src/modules/base/tree/tree.js
+++ b/src/modules/base/tree/tree.js
@@ -858,8 +858,11 @@ export default class Tree extends LightningElement {
             const selectedItem = this.treedata.getItemFromName(
                 this.computedSelectedItems[0]
             );
-            if (selectedItem) this.treedata.expandTo(selectedItem);
-            this.setFocusToItem(selectedItem);
+            if (selectedItem) {
+                this.treedata.expandTo(selectedItem);
+                this.setFocusToItem(selectedItem);
+            }
+            this.forceChildrenSelectionUpdate();
         }
     }
 

--- a/src/modules/base/tree/treeData.js
+++ b/src/modules/base/tree/treeData.js
@@ -317,6 +317,16 @@ export class TreeData {
     }
 
     /**
+     * Get the path to access the item in the tree, in the form of an array of levels.
+     *
+     * @param {string} key Key of the item.
+     * @returns {number[]} Array of levels of depth.
+     */
+    getLevelPath(key) {
+        return key.split('.').map((level) => parseInt(level, 10) - 1);
+    }
+
+    /**
      * Determine if an item is visible.
      *
      * @param {object} treeItem Item to check.


### PR DESCRIPTION
**Fixes:**
- `edit` action is cancelable.
- Edit popover closes when an action is clicked.
- Switching between single and multi select does not trigger an error.

**Features:**
- Add `levelPath` to `actionclick`, `select` and `change` events.
- Add `bounds` to `select` and `actionclick` events.