### PR TITLE
[feat] (ABC-508): Add option to select parent w/o children in tree

### DIFF
--- a/jest-mock/components/base/primitiveTreeItem/primitiveTreeItem.js
+++ b/jest-mock/components/base/primitiveTreeItem/primitiveTreeItem.js
@@ -9,6 +9,7 @@ export default class PrimitiveTreeItem extends LightningElement {
     @api avatar;
     @api childItems;
     @api disabled;
+    @api disableSelectionCascade;
     @api editableFields;
     @api fields;
     @api href;

--- a/src/modules/base/primitiveTreeItem/__tests__/primitiveTreeItem.test.js
+++ b/src/modules/base/primitiveTreeItem/__tests__/primitiveTreeItem.test.js
@@ -138,6 +138,7 @@ describe('Primitive Tree Item', () => {
         expect(element.avatar).toBeUndefined();
         expect(element.childItems).toEqual([]);
         expect(element.disabled).toBeFalsy();
+        expect(element.disableSelectionCascade).toBeFalsy();
         expect(element.editableFields).toEqual([
             'label',
             'metatext',
@@ -724,9 +725,10 @@ describe('Primitive Tree Item', () => {
         });
     });
 
-    // selected and show-checkbox
+    // selected, disable-selection-cascade and show-checkbox
     // Depends on childItems
-    it('selected and showCheckbox, with some selected childItems', () => {
+    it('selected = false, with showCheckbox and some selected childItems', () => {
+        element.disableSelectionCascade = false;
         element.selected = false;
         element.showCheckbox = true;
         element.childItems = [
@@ -752,7 +754,35 @@ describe('Primitive Tree Item', () => {
         });
     });
 
-    it('selected and showCheckbox, with all selected childItems', () => {
+    it('selected = false, with showCheckbox, some selected childItems and disableSelectionCascade', () => {
+        element.disableSelectionCascade = true;
+        element.selected = false;
+        element.showCheckbox = true;
+        element.childItems = [
+            {
+                label: 'not selected',
+                name: 'notSelected'
+            },
+            {
+                label: 'selected',
+                name: 'selected',
+                selected: true
+            }
+        ];
+
+        return Promise.resolve().then(() => {
+            expect(element.selected).toBeFalsy();
+            expect(element.ariaSelected).toBe('false');
+            const checkbox = element.shadowRoot.querySelector(
+                '[data-element-id="input-checkbox"]'
+            );
+            expect(checkbox.indeterminate).toBeFalsy();
+            expect(checkbox.checked).toBeFalsy();
+        });
+    });
+
+    it('selected = false, with showCheckbox and all selected childItems', () => {
+        element.disableSelectionCascade = false;
         element.selected = false;
         element.showCheckbox = true;
         element.childItems = [
@@ -776,6 +806,34 @@ describe('Primitive Tree Item', () => {
             );
             expect(checkbox.indeterminate).toBeFalsy();
             expect(checkbox.checked).toBeTruthy();
+        });
+    });
+
+    it('selected = false, with showCheckbox, all selected childItems and disableSelectionCascade', () => {
+        element.disableSelectionCascade = true;
+        element.selected = false;
+        element.showCheckbox = true;
+        element.childItems = [
+            {
+                label: 'selected too',
+                name: 'selectedToo',
+                selected: true
+            },
+            {
+                label: 'selected',
+                name: 'selected',
+                selected: true
+            }
+        ];
+
+        return Promise.resolve().then(() => {
+            expect(element.selected).toBeFalsy();
+            expect(element.ariaSelected).toBe('false');
+            const checkbox = element.shadowRoot.querySelector(
+                '[data-element-id="input-checkbox"]'
+            );
+            expect(checkbox.indeterminate).toBeFalsy();
+            expect(checkbox.checked).toBeFalsy();
         });
     });
 

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.html
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.html
@@ -338,6 +338,7 @@
                     aria-level={item.level}
                     avatar={item.avatar}
                     child-items={item.children}
+                    disable-selection-cascade={disableSelectionCascade}
                     disabled={item.disabled}
                     editable-fields={editableFields}
                     expanded={item.expanded}

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
@@ -78,6 +78,7 @@ export default class PrimitiveTreeItem extends LightningElement {
     _avatar;
     _childItems = [];
     _disabled = false;
+    _disableSelectionCascade = false;
     _editableFields = DEFAULT_EDIT_FIELDS;
     _fields = [];
     _href;
@@ -300,6 +301,22 @@ export default class PrimitiveTreeItem extends LightningElement {
     set disabled(value) {
         this._disabled = normalizeBoolean(value);
         if (this.isConnected) this.splitActions();
+    }
+
+    /**
+     * If present, the item selection will not extend to its children.
+     *
+     * @type {boolean}
+     * @default false
+     * @public
+     */
+    @api
+    get disableSelectionCascade() {
+        return this._disableSelectionCascade;
+    }
+    set disableSelectionCascade(value) {
+        this._disableSelectionCascade = normalizeBoolean(value);
+        if (this.isConnected) this.computeSelection();
     }
 
     /**
@@ -639,7 +656,12 @@ export default class PrimitiveTreeItem extends LightningElement {
      * Compute the selection state of the item, depending on the selection state of its children.
      */
     computeSelection() {
-        if (!this.selected && this.showCheckbox && this.childItems.length) {
+        if (
+            !this.selected &&
+            this.showCheckbox &&
+            this.childItems.length &&
+            !this.disableSelectionCascade
+        ) {
             const selectedChildren = this.childItems.filter(
                 (child) => child.selected
             );

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
@@ -986,7 +986,7 @@ export default class PrimitiveTreeItem extends LightningElement {
      * @param {Event} event
      */
     handleCheckboxClick(event) {
-        if (this.allowInlineEdit) event.stopPropagation();
+        event.stopPropagation();
     }
 
     /**
@@ -1293,7 +1293,7 @@ export default class PrimitiveTreeItem extends LightningElement {
             }
         });
         this.dispatchEvent(customEvent);
-        if (customEvent.defaultPrevented) {
+        if (customEvent.defaultPrevented && event.target.tagName !== 'INPUT') {
             event.preventDefault();
         }
     }

--- a/src/modules/base/storybookWrappers/tree/tree.html
+++ b/src/modules/base/storybookWrappers/tree/tree.html
@@ -4,6 +4,7 @@
             actions={actions}
             actions-when-disabled={actionsWhenDisabled}
             allow-inline-edit={allowInlineEdit}
+            disable-selection-cascade={disableSelectionCascade}
             editable-fields={editableFields}
             header={header}
             is-loading={isLoading}

--- a/src/modules/base/storybookWrappers/tree/tree.js
+++ b/src/modules/base/storybookWrappers/tree/tree.js
@@ -4,6 +4,7 @@ export default class Tree extends LightningElement {
     @api actions;
     @api actionsWhenDisabled;
     @api allowInlineEdit;
+    @api disableSelectionCascade;
     @api editableFields;
     @api header;
     @api isLoading;

--- a/src/modules/base/tree/__docs__/tree.stories.js
+++ b/src/modules/base/tree/__docs__/tree.stories.js
@@ -74,6 +74,18 @@ export default {
                 defaultValue: { summary: 'false' }
             }
         },
+        disableSelectionCascade: {
+            name: 'disable-selection-cascade',
+            control: {
+                type: 'boolean'
+            },
+            description:
+                'Used only if `is-multi-select` is true. If present, the parent and children nodes will be selected independently of each other. If empty, when all children of a node are selected, the node is selected automatically. If a node is selected, all its children are also selected by default.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' }
+            }
+        },
         editableFields: {
             name: 'editable-fields',
             control: {
@@ -162,6 +174,7 @@ export default {
     },
     args: {
         allowInlineEdit: false,
+        disableSelectionCascade: false,
         editableFields: [
             'label',
             'metatext',
@@ -236,4 +249,13 @@ MultiSelect.args = {
     isMultiSelect: true,
     sortable: true,
     selectedItems: ['node1-2-1', 'node1-1', 'node2', 'node1-1-1-2', 'node6']
+};
+
+export const MultiSelectNoCascade = Template.bind({});
+MultiSelectNoCascade.args = {
+    items: ITEMS,
+    header: 'Multi Select Tree With no Selection Cascade',
+    isMultiSelect: true,
+    selectedItems: ['node1-2-1', 'node1-1', 'node2', 'node1-1-1-2', 'node6'],
+    disableSelectionCascade: true
 };

--- a/src/modules/base/tree/__examples__/multiSelectNoCascade/multiSelectNoCascade.html
+++ b/src/modules/base/tree/__examples__/multiSelectNoCascade/multiSelectNoCascade.html
@@ -1,0 +1,11 @@
+<template>
+    <div style="max-width: 300px">
+        <avonni-tree
+            disable-selection-cascade
+            header="Multi Select Tree With no Selection Cascade"
+            is-multi-select
+            items={items}
+            selected-items={selectedItems}
+        ></avonni-tree>
+    </div>
+</template>

--- a/src/modules/base/tree/__examples__/multiSelectNoCascade/multiSelectNoCascade.js
+++ b/src/modules/base/tree/__examples__/multiSelectNoCascade/multiSelectNoCascade.js
@@ -1,0 +1,104 @@
+import { LightningElement } from 'lwc';
+
+export default class TreeMultiSelectNoCascade extends LightningElement {
+    items = [
+        {
+            label: 'Go to Record 1',
+            href: '#record1',
+            name: 'node1',
+            metatext: 'example of metatext',
+            items: [
+                {
+                    label: 'Go to Record 1.1',
+                    href: '#record1',
+                    name: 'node1-1',
+                    items: [
+                        {
+                            label: 'Go to Record 1.1.1',
+                            href: '#record1',
+                            name: 'node1-1-1',
+                            items: [
+                                {
+                                    label: 'Go to Record 1.1.1.1',
+                                    href: '#record1',
+                                    name: 'node1-1-1-1'
+                                },
+                                {
+                                    label: 'Go to Record 1.1.1.2',
+                                    href: '#record1',
+                                    name: 'node1-1-1-2'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    label: 'Go to Record 1.2',
+                    href: '#record1',
+                    name: 'node1-2',
+                    items: [
+                        {
+                            label: 'Go to Record 1.2.1',
+                            href: '#record1',
+                            name: 'node1-2-1',
+                            items: [
+                                {
+                                    label: 'Go to Record 1.2.1.1',
+                                    href: '#record1',
+                                    name: 'node1-2-1-1'
+                                }
+                            ],
+                            expanded: true
+                        },
+                        {
+                            label: 'Go to Record 1.2.2',
+                            href: '#record1',
+                            name: 'node1-2-2'
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            label: 'Loading Record',
+            href: '#record2',
+            isLoading: true,
+            name: 'node2',
+            items: [
+                {
+                    label: 'Already loaded record',
+                    name: 'loaded-record'
+                }
+            ]
+        },
+        {
+            label: 'Go to Record 3',
+            href: '#record3',
+            name: 'node3'
+        },
+        {
+            label: 'Disabled Record',
+            href: '#record4',
+            name: 'node4',
+            disabled: true,
+            isLoading: true
+        },
+        {
+            label: 'Go to Record 5',
+            href: '#record5',
+            name: 'node5'
+        },
+        {
+            label: 'Go to Record 6',
+            href: '#record6',
+            name: 'node6'
+        },
+        {
+            label: 'Go to Record 7',
+            href: '#record7',
+            name: 'node7'
+        }
+    ];
+
+    selectedItems = ['node1-2-1', 'node1-1', 'node2', 'node1-1-1-2', 'node6'];
+}

--- a/src/modules/base/tree/__examples__/tree.js
+++ b/src/modules/base/tree/__examples__/tree.js
@@ -38,6 +38,7 @@ export const Tree = ({
     actions,
     actionsWhenDisabled,
     allowInlineEdit,
+    disableSelectionCascade,
     editableFields,
     header,
     isLoading,
@@ -51,6 +52,7 @@ export const Tree = ({
     element.actions = actions;
     element.actionsWhenDisabled = actionsWhenDisabled;
     element.allowInlineEdit = allowInlineEdit;
+    element.disableSelectionCascade = disableSelectionCascade;
     element.editableFields = editableFields;
     element.header = header;
     element.isLoading = isLoading;

--- a/src/modules/base/tree/tree.html
+++ b/src/modules/base/tree/tree.html
@@ -78,6 +78,7 @@
                     aria-level={item.level}
                     avatar={item.avatar}
                     child-items={item.children}
+                    disable-selection-cascade={disableSelectionCascade}
                     disabled={item.disabled}
                     editable-fields={editableFields}
                     expanded={item.expanded}

--- a/src/modules/base/tree/treeData.js
+++ b/src/modules/base/tree/treeData.js
@@ -125,16 +125,19 @@ export class TreeData {
      *
      * @param {string} name Name of the item to select.
      * @param {string[]} selectedItems Array of selected item names, the new selected items' names should be added to.
+     * @param {boolean} cascadeSelection If true, cascade the selection to the children and parents of the item.
      */
-    computeSelection(name, selectedItems) {
+    computeSelection(name, selectedItems, cascadeSelection) {
         const item = this.getItemFromName(name);
         if (!item) return;
 
         item.treeNode.selected = true;
-        this.cascadeSelectionDown(item.treeNode, selectedItems);
-        const parent = this.getItem(item.parent);
-        if (parent) {
-            this.cascadeSelectionUp(parent, selectedItems);
+        if (cascadeSelection) {
+            this.cascadeSelectionDown(item.treeNode, selectedItems);
+            const parent = this.getItem(item.parent);
+            if (parent) {
+                this.cascadeSelectionUp(parent, selectedItems);
+            }
         }
     }
 
@@ -467,14 +470,15 @@ export class TreeData {
      *
      * @param {object} node The item to select.
      * @param {string[]} selectedItems Selected item names.
+     * @param {boolean} cascadeSelection If true, select all children of the item.
      */
-    selectNode(node, selectedItems) {
+    selectNode(node, selectedItems, cascadeSelection) {
         node.selected = true;
         if (!selectedItems.includes(node.name)) {
             selectedItems.push(node.name);
         }
 
-        if (node.children) {
+        if (cascadeSelection && node.children) {
             node.children.forEach((child) =>
                 this.selectNode(child, selectedItems)
             );
@@ -486,15 +490,16 @@ export class TreeData {
      *
      * @param {object} node The item to unselect.
      * @param {string[]} selectedItems Selected item names, from which the item name is removed from.
+     * @param {boolean} cascadeSelection If true, unselect all children of the item.
      */
-    unselectNode(node, selectedItems) {
+    unselectNode(node, selectedItems, cascadeSelection) {
         node.selected = false;
         const selectedIndex = selectedItems.indexOf(node.name);
         if (selectedIndex > -1) {
             selectedItems.splice(selectedIndex, 1);
         }
 
-        if (node.children) {
+        if (cascadeSelection && node.children) {
             node.children.forEach((child) =>
                 this.unselectNode(child, selectedItems)
             );


### PR DESCRIPTION
### Features
**Tree**
- Add `disable-selection-cascade` attribute
### Fixes
**Tree**
- Fix the selection of an item through a click on its checkbox.