### PR TITLE
[fix] (ABC-510): Fix tree multi select and rename disable selection cascade

### DIFF
--- a/jest-mock/components/base/primitiveTreeItem/primitiveTreeItem.js
+++ b/jest-mock/components/base/primitiveTreeItem/primitiveTreeItem.js
@@ -9,10 +9,10 @@ export default class PrimitiveTreeItem extends LightningElement {
     @api avatar;
     @api childItems;
     @api disabled;
-    @api disableSelectionCascade;
     @api editableFields;
     @api fields;
     @api href;
+    @api independentMultiSelect;
     @api expanded;
     @api isLeaf;
     @api isLoading;

--- a/src/modules/base/primitiveTreeItem/__tests__/primitiveTreeItem.test.js
+++ b/src/modules/base/primitiveTreeItem/__tests__/primitiveTreeItem.test.js
@@ -138,7 +138,7 @@ describe('Primitive Tree Item', () => {
         expect(element.avatar).toBeUndefined();
         expect(element.childItems).toEqual([]);
         expect(element.disabled).toBeFalsy();
-        expect(element.disableSelectionCascade).toBeFalsy();
+        expect(element.independentMultiSelect).toBeFalsy();
         expect(element.editableFields).toEqual([
             'label',
             'metatext',
@@ -725,10 +725,10 @@ describe('Primitive Tree Item', () => {
         });
     });
 
-    // selected, disable-selection-cascade and show-checkbox
+    // selected, independent-multi-select and show-checkbox
     // Depends on childItems
     it('selected = false, with showCheckbox and some selected childItems', () => {
-        element.disableSelectionCascade = false;
+        element.independentMultiSelect = false;
         element.selected = false;
         element.showCheckbox = true;
         element.childItems = [
@@ -754,8 +754,8 @@ describe('Primitive Tree Item', () => {
         });
     });
 
-    it('selected = false, with showCheckbox, some selected childItems and disableSelectionCascade', () => {
-        element.disableSelectionCascade = true;
+    it('selected = false, with showCheckbox, some selected childItems and independentMultiSelect', () => {
+        element.independentMultiSelect = true;
         element.selected = false;
         element.showCheckbox = true;
         element.childItems = [
@@ -782,7 +782,7 @@ describe('Primitive Tree Item', () => {
     });
 
     it('selected = false, with showCheckbox and all selected childItems', () => {
-        element.disableSelectionCascade = false;
+        element.independentMultiSelect = false;
         element.selected = false;
         element.showCheckbox = true;
         element.childItems = [
@@ -809,8 +809,8 @@ describe('Primitive Tree Item', () => {
         });
     });
 
-    it('selected = false, with showCheckbox, all selected childItems and disableSelectionCascade', () => {
-        element.disableSelectionCascade = true;
+    it('selected = false, with showCheckbox, all selected childItems and independentMultiSelect', () => {
+        element.independentMultiSelect = true;
         element.selected = false;
         element.showCheckbox = true;
         element.childItems = [

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.html
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.html
@@ -338,7 +338,7 @@
                     aria-level={item.level}
                     avatar={item.avatar}
                     child-items={item.children}
-                    disable-selection-cascade={disableSelectionCascade}
+                    independent-multi-select={independentMultiSelect}
                     disabled={item.disabled}
                     editable-fields={editableFields}
                     expanded={item.expanded}

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
@@ -78,11 +78,11 @@ export default class PrimitiveTreeItem extends LightningElement {
     _avatar;
     _childItems = [];
     _disabled = false;
-    _disableSelectionCascade = false;
     _editableFields = DEFAULT_EDIT_FIELDS;
     _fields = [];
     _href;
     _expanded = false;
+    _independentMultiSelect = false;
     _isLeaf = false;
     _isLoading = false;
     _label;
@@ -311,11 +311,11 @@ export default class PrimitiveTreeItem extends LightningElement {
      * @public
      */
     @api
-    get disableSelectionCascade() {
-        return this._disableSelectionCascade;
+    get independentMultiSelect() {
+        return this._independentMultiSelect;
     }
-    set disableSelectionCascade(value) {
-        this._disableSelectionCascade = normalizeBoolean(value);
+    set independentMultiSelect(value) {
+        this._independentMultiSelect = normalizeBoolean(value);
         if (this.isConnected) this.computeSelection();
     }
 
@@ -660,7 +660,7 @@ export default class PrimitiveTreeItem extends LightningElement {
             !this.selected &&
             this.showCheckbox &&
             this.childItems.length &&
-            !this.disableSelectionCascade
+            !this.independentMultiSelect
         ) {
             const selectedChildren = this.childItems.filter(
                 (child) => child.selected

--- a/src/modules/base/storybookWrappers/tree/tree.html
+++ b/src/modules/base/storybookWrappers/tree/tree.html
@@ -4,9 +4,9 @@
             actions={actions}
             actions-when-disabled={actionsWhenDisabled}
             allow-inline-edit={allowInlineEdit}
-            disable-selection-cascade={disableSelectionCascade}
             editable-fields={editableFields}
             header={header}
+            independent-multi-select={independentMultiSelect}
             is-loading={isLoading}
             is-multi-select={isMultiSelect}
             items={items}

--- a/src/modules/base/storybookWrappers/tree/tree.js
+++ b/src/modules/base/storybookWrappers/tree/tree.js
@@ -4,9 +4,9 @@ export default class Tree extends LightningElement {
     @api actions;
     @api actionsWhenDisabled;
     @api allowInlineEdit;
-    @api disableSelectionCascade;
     @api editableFields;
     @api header;
+    @api independentMultiSelect;
     @api isLoading;
     @api isMultiSelect;
     @api items;

--- a/src/modules/base/tree/__docs__/tree.stories.js
+++ b/src/modules/base/tree/__docs__/tree.stories.js
@@ -74,8 +74,8 @@ export default {
                 defaultValue: { summary: 'false' }
             }
         },
-        disableSelectionCascade: {
-            name: 'disable-selection-cascade',
+        independentMultiSelect: {
+            name: 'independent-multi-select',
             control: {
                 type: 'boolean'
             },
@@ -174,7 +174,7 @@ export default {
     },
     args: {
         allowInlineEdit: false,
-        disableSelectionCascade: false,
+        independentMultiSelect: false,
         editableFields: [
             'label',
             'metatext',
@@ -251,11 +251,11 @@ MultiSelect.args = {
     selectedItems: ['node1-2-1', 'node1-1', 'node2', 'node1-1-1-2', 'node6']
 };
 
-export const MultiSelectNoCascade = Template.bind({});
-MultiSelectNoCascade.args = {
+export const IndependentMultiSelect = Template.bind({});
+IndependentMultiSelect.args = {
     items: ITEMS,
     header: 'Multi Select Tree With no Selection Cascade',
     isMultiSelect: true,
     selectedItems: ['node1-2-1', 'node1-1', 'node2', 'node1-1-1-2', 'node6'],
-    disableSelectionCascade: true
+    independentMultiSelect: true
 };

--- a/src/modules/base/tree/__examples__/independentMultiSelect/independentMultiSelect.html
+++ b/src/modules/base/tree/__examples__/independentMultiSelect/independentMultiSelect.html
@@ -1,8 +1,8 @@
 <template>
     <div style="max-width: 300px">
         <avonni-tree
-            disable-selection-cascade
             header="Multi Select Tree With no Selection Cascade"
+            independent-multi-select
             is-multi-select
             items={items}
             selected-items={selectedItems}

--- a/src/modules/base/tree/__examples__/independentMultiSelect/independentMultiSelect.js
+++ b/src/modules/base/tree/__examples__/independentMultiSelect/independentMultiSelect.js
@@ -1,6 +1,6 @@
 import { LightningElement } from 'lwc';
 
-export default class TreeMultiSelectNoCascade extends LightningElement {
+export default class TreeIndependentMultiSelect extends LightningElement {
     items = [
         {
             label: 'Go to Record 1',

--- a/src/modules/base/tree/__examples__/tree.js
+++ b/src/modules/base/tree/__examples__/tree.js
@@ -38,9 +38,9 @@ export const Tree = ({
     actions,
     actionsWhenDisabled,
     allowInlineEdit,
-    disableSelectionCascade,
     editableFields,
     header,
+    independentMultiSelect,
     isLoading,
     items,
     loadingStateAlternativeText,
@@ -52,9 +52,9 @@ export const Tree = ({
     element.actions = actions;
     element.actionsWhenDisabled = actionsWhenDisabled;
     element.allowInlineEdit = allowInlineEdit;
-    element.disableSelectionCascade = disableSelectionCascade;
     element.editableFields = editableFields;
     element.header = header;
+    element.independentMultiSelect = independentMultiSelect;
     element.isLoading = isLoading;
     element.items = items;
     element.loadingStateAlternativeText = loadingStateAlternativeText;

--- a/src/modules/base/tree/__tests__/tree.test.js
+++ b/src/modules/base/tree/__tests__/tree.test.js
@@ -24,7 +24,7 @@ describe('Tree', () => {
         expect(element.actions).toEqual([]);
         expect(element.actionsWhenDisabled).toEqual([]);
         expect(element.allowInlineEdit).toBeFalsy();
-        expect(element.disableSelectionCascade).toBeFalsy();
+        expect(element.independentMultiSelect).toBeFalsy();
         expect(element.editableFields).toEqual([
             'label',
             'metatext',
@@ -224,9 +224,9 @@ describe('Tree', () => {
         });
     });
 
-    it('isMultiSelect = true, selectedItems and disableSelectionCascade', () => {
+    it('isMultiSelect = true, selectedItems and independentMultiSelect', () => {
         element.isMultiSelect = true;
-        element.disableSelectionCascade = true;
+        element.independentMultiSelect = true;
         const handler = jest.fn();
         element.addEventListener('select', handler);
         const selectedItems = [
@@ -1331,12 +1331,12 @@ describe('Tree', () => {
         });
     });
 
-    it('select event, for multi-select tree with disableCascadeSelection = true', () => {
+    it('select event, for multi-select tree with independent-multi-select = true', () => {
         const fakeRegisters = generateFakeRegisters();
         const handler = jest.fn();
         element.addEventListener('select', handler);
 
-        element.disableSelectionCascade = true;
+        element.independentMultiSelect = true;
         element.items = ITEMS;
         element.selectedItems = ['thirdLevel', 'secondLevel'];
         element.isMultiSelect = true;

--- a/src/modules/base/tree/tree.html
+++ b/src/modules/base/tree/tree.html
@@ -78,7 +78,7 @@
                     aria-level={item.level}
                     avatar={item.avatar}
                     child-items={item.children}
-                    disable-selection-cascade={disableSelectionCascade}
+                    independent-multi-select={independentMultiSelect}
                     disabled={item.disabled}
                     editable-fields={editableFields}
                     expanded={item.expanded}

--- a/src/modules/base/tree/tree.js
+++ b/src/modules/base/tree/tree.js
@@ -72,8 +72,8 @@ export default class Tree extends LightningElement {
     _actions = [];
     _actionsWhenDisabled = [];
     _allowInlineEdit = false;
-    _disableSelectionCascade = false;
     _editableFields = DEFAULT_EDITABLE_FIELDS;
+    _independentMultiSelect = false;
     _isLoading = false;
     _isMultiSelect = false;
     @track _items = [];
@@ -164,24 +164,6 @@ export default class Tree extends LightningElement {
     }
 
     /**
-     * Used only if `is-multi-select` is true.
-     * If present, the parent and children nodes will be selected independently of each other.
-     * If empty, when all children of a node are selected, the node is selected automatically. If a node is selected, all its children are also selected by default.
-     *
-     * @type {boolean}
-     * @default false
-     * @public
-     */
-    @api
-    get disableSelectionCascade() {
-        return this._disableSelectionCascade;
-    }
-
-    set disableSelectionCascade(value) {
-        this._disableSelectionCascade = normalizeBoolean(value);
-    }
-
-    /**
      * Array of fields that should be visible in the item edit form. The item edit form can be opened through the standard ``edit`` action.
      *
      * @type {string[]}
@@ -195,6 +177,24 @@ export default class Tree extends LightningElement {
 
     set editableFields(value) {
         this._editableFields = normalizeArray(value);
+    }
+
+    /**
+     * Used only if `is-multi-select` is true.
+     * If present, the parent and children nodes will be selected independently of each other.
+     * If empty, when all children of a node are selected, the node is selected automatically. If a node is selected, all its children are also selected by default.
+     *
+     * @type {boolean}
+     * @default false
+     * @public
+     */
+    @api
+    get independentMultiSelect() {
+        return this._independentMultiSelect;
+    }
+
+    set independentMultiSelect(value) {
+        this._independentMultiSelect = normalizeBoolean(value);
     }
 
     /**
@@ -463,7 +463,7 @@ export default class Tree extends LightningElement {
         const selectedItems = [...this.selectedItems];
         for (let i = 0; i < selectedItems.length; i++) {
             const name = selectedItems[i];
-            const cascadeSelection = !this.disableSelectionCascade;
+            const cascadeSelection = !this.independentMultiSelect;
             this.treedata.computeSelection(
                 name,
                 selectedItems,
@@ -1026,7 +1026,7 @@ export default class Tree extends LightningElement {
             } else if (target === 'anchor') {
                 if (this.isMultiSelect) {
                     const node = item.treeNode;
-                    const cascadeSelection = !this.disableSelectionCascade;
+                    const cascadeSelection = !this.independentMultiSelect;
                     if (!node.selected) {
                         this.treedata.selectNode(
                             node,
@@ -1041,7 +1041,7 @@ export default class Tree extends LightningElement {
                         );
                     }
 
-                    if (!this.disableSelectionCascade) {
+                    if (!this.independentMultiSelect) {
                         this.updateParentsSelection(item);
                         this.forceChildrenSelectionUpdate();
                     }

--- a/src/modules/base/tree/treeData.js
+++ b/src/modules/base/tree/treeData.js
@@ -479,9 +479,9 @@ export class TreeData {
         }
 
         if (cascadeSelection && node.children) {
-            node.children.forEach((child) =>
-                this.selectNode(child, selectedItems)
-            );
+            node.children.forEach((child) => {
+                this.selectNode(child, selectedItems, cascadeSelection);
+            });
         }
     }
 
@@ -500,9 +500,9 @@ export class TreeData {
         }
 
         if (cascadeSelection && node.children) {
-            node.children.forEach((child) =>
-                this.unselectNode(child, selectedItems)
-            );
+            node.children.forEach((child) => {
+                this.unselectNode(child, selectedItems, cascadeSelection);
+            });
         }
     }
 


### PR DESCRIPTION
Fixes for pull request [#274](https://github.com/avonni/base-components/pull/274):
- Rename `disable-selection-cascade` to `independent-multi-select`.
- Fix multi-selection not cascading through more than one level.