### PR TITLE
[feat] (ABC-512): Add label to calendar date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@avonni/base-components",
-    "version": "1.1.1",
+    "version": "1.2.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/modules/base/calendar/__docs__/calendar.jsdoc.js
+++ b/src/modules/base/calendar/__docs__/calendar.jsdoc.js
@@ -73,16 +73,6 @@
  * @default dashed
  * @type styling
  */
-/**
- * @memberof stylingHooks
- * @name --avonni-calendar-cell-sizing-width
- * @type dimension
- */
-/**
- * @memberof stylingHooks
- * @name --avonni-calendar-cell-sizing-height
- * @type dimension
- */
 
 /**
  * @typedef {Object} MarkedDate
@@ -93,7 +83,13 @@
 
 /**
  * @typedef {Object} DateLabel
- * @name DateLabels
+ * @name dateLabels
  * @property {string} date The value of the marked date, which can be a Date object, a timestamp, or an ISO8601 formatted string.
- * @property {string} label Text to appear under a date.
+ * In case a date has more than one label, full dates have priority over month dates, which have priority over week days.
+ * @property {string} label The date label text.
+ * @property {string} variant A valid chip variant.
+ * @property {boolean} outline If true, display a border around the label.
+ * @property {string} iconName A valid lightning icon name.
+ * @property {string} iconPosition The side on which the icon is displayed. Valid values are 'right' or 'left'.
+ * @property {string} iconVariant The color scheme for the icon.
  */

--- a/src/modules/base/calendar/__docs__/calendar.jsdoc.js
+++ b/src/modules/base/calendar/__docs__/calendar.jsdoc.js
@@ -73,10 +73,27 @@
  * @default dashed
  * @type styling
  */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-calendar-cell-sizing-width
+ * @type dimension
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-calendar-cell-sizing-height
+ * @type dimension
+ */
 
 /**
  * @typedef {Object} MarkedDate
  * @name markedDates
  * @property {string} date The value of the marked date, which can be a Date object, a timestamp, or an ISO8601 formatted string.
  * @property {string} color Color of the marker. Defaults to #bf0201.
+ */
+
+/**
+ * @typedef {Object} DateLabel
+ * @name DateLabels
+ * @property {string} date The value of the marked date, which can be a Date object, a timestamp, or an ISO8601 formatted string.
+ * @property {string} label Text to appear under a date.
  */

--- a/src/modules/base/calendar/__docs__/calendar.jsdoc.js
+++ b/src/modules/base/calendar/__docs__/calendar.jsdoc.js
@@ -85,11 +85,11 @@
  * @typedef {Object} DateLabel
  * @name dateLabels
  * @property {string} date The value of the marked date, which can be a Date object, a timestamp, or an ISO8601 formatted string.
- * In case a date has more than one label, full dates have priority over month dates, which have priority over week days.
+ * To prioritize a date label, place it toward the end of the array.
  * @property {string} label The date label text.
- * @property {string} variant A valid chip variant.
+ * @property {string} variant A chip variant. Default is base and accepted variants are base, brand, inverse, alt-inverse, success, info, warning, error, offline.
  * @property {boolean} outline If true, display a border around the label.
  * @property {string} iconName A valid lightning icon name.
- * @property {string} iconPosition The side on which the icon is displayed. Valid values are 'right' or 'left'.
- * @property {string} iconVariant The color scheme for the icon.
+ * @property {string} iconPosition The side on which the icon is displayed. Default is left and accepted values are left and right.
+ * @property {string} iconVariant The color scheme for the icon. Accepted variants include inverse, success, warning, and error.
  */

--- a/src/modules/base/calendar/__docs__/calendar.jsdoc.js
+++ b/src/modules/base/calendar/__docs__/calendar.jsdoc.js
@@ -89,7 +89,8 @@
  * @property {string} label The date label text.
  * @property {string} variant A chip variant. Default is base and accepted variants are base, brand, inverse, alt-inverse, success, info, warning, error, offline.
  * @property {boolean} outline If true, display a border around the label.
- * @property {string} iconName A valid lightning icon name.
+ * @property {string} iconName The Lightning Design System name of the icon to be displayed inside the label.
+ * Names are written in the format 'utility:down' where 'utility' is the category, and 'down' is the specific icon to be displayed.
  * @property {string} iconPosition The side on which the icon is displayed. Default is left and accepted values are left and right.
  * @property {string} iconVariant The color scheme for the icon. Accepted variants include inverse, success, warning, and error.
  */

--- a/src/modules/base/calendar/__docs__/calendar.stories.js
+++ b/src/modules/base/calendar/__docs__/calendar.stories.js
@@ -137,7 +137,7 @@ export default {
         markedDates: [],
         min: new Date(1900, 0, 1),
         max: new Date(2099, 11, 31),
-        selectinMode: 'single',
+        selectionMode: 'single',
         weekNumber: false
     }
 };
@@ -172,8 +172,8 @@ Interval.args = {
     value: ['05/03/2021', '05/08/2021'],
     selectionMode: 'interval',
     dateLabels: [
-        { date: 12, label: 'label label label' },
-        { date: 25, label: 'label' }
+        { date: 12, label: 'day 12 label' },
+        { date: 25, label: 'day 25 label' }
     ]
 };
 

--- a/src/modules/base/calendar/__docs__/calendar.stories.js
+++ b/src/modules/base/calendar/__docs__/calendar.stories.js
@@ -177,14 +177,13 @@ Interval.args = {
             date: 'Tue',
             label: 'Tuesday',
             variant: 'success',
-            outline: 'asdf',
-            iconName: 'standard:contract_line_item',
+            iconName: 'standard:branch_merge',
             iconPosition: 'right',
             iconVariant: 'inverse'
         },
         {
             date: 25,
-            label: '25 label big label',
+            label: '',
             variant: '',
             outline: true,
             iconName: 'standard:branch_merge',
@@ -195,10 +194,9 @@ Interval.args = {
             date: new Date('05/26/2022'),
             label: '26 may',
             variant: 'error',
-            outline: '',
-            // iconName: 'standard:branch_merge',
+            iconName: 'standard:branch_merge',
             iconPosition: 'right',
-            iconVariant: 'success'
+            iconVariant: 'inverse'
         }
     ]
 };

--- a/src/modules/base/calendar/__docs__/calendar.stories.js
+++ b/src/modules/base/calendar/__docs__/calendar.stories.js
@@ -145,6 +145,9 @@ export default {
 const markedDates = [
     { date: new Date('05/09/2021'), color: 'red' },
     { date: new Date('05/26/2021'), color: 'brown' },
+    { date: new Date('05/26/2021'), color: 'blue' },
+    { date: new Date('05/26/2021'), color: 'red' },
+    { date: new Date('05/26/2021'), color: 'yellow' },
     { date: 14, color: 'blue' },
     { date: 20, color: 'yellow' },
     { date: 'Wed', color: 'black' }

--- a/src/modules/base/calendar/__docs__/calendar.stories.js
+++ b/src/modules/base/calendar/__docs__/calendar.stories.js
@@ -150,7 +150,7 @@ const markedDates = [
     { date: new Date('05/26/2022'), color: 'red' },
     { date: new Date('05/26/2022'), color: 'yellow' },
     { date: 14, color: 'blue' },
-    { date: 20, color: 'yellow' },
+    { date: 25, color: 'yellow' },
     { date: 'Wed', color: 'black' }
 ];
 
@@ -174,22 +174,13 @@ Interval.args = {
     selectionMode: 'interval',
     dateLabels: [
         {
-            date: 12,
-            label: 'day 12',
+            date: 'Tue',
+            label: 'Tuesday',
             variant: 'success',
             outline: 'asdf',
-            iconName: 'standard:branch_merge',
+            iconName: 'standard:contract_line_item',
             iconPosition: 'right',
             iconVariant: 'inverse'
-        },
-        {
-            date: new Date('05/26/2022'),
-            label: '26 may',
-            variant: 'success',
-            outline: '',
-            // iconName: 'standard:branch_merge',
-            iconPosition: 'right',
-            iconVariant: 'success'
         },
         {
             date: 25,
@@ -199,6 +190,15 @@ Interval.args = {
             iconName: 'standard:branch_merge',
             iconPosition: 'left',
             iconVariant: 'brand'
+        },
+        {
+            date: new Date('05/26/2022'),
+            label: '26 may',
+            variant: 'error',
+            outline: '',
+            // iconName: 'standard:branch_merge',
+            iconPosition: 'right',
+            iconVariant: 'success'
         }
     ]
 };

--- a/src/modules/base/calendar/__docs__/calendar.stories.js
+++ b/src/modules/base/calendar/__docs__/calendar.stories.js
@@ -170,42 +170,9 @@ Multiple.args = {
 
 export const Interval = Template.bind({});
 Interval.args = {
-    value: ['05/10/2022', '05/30/2022'],
+    value: ['05/10/2022', '05/20/2022'],
     selectionMode: 'interval',
-    dateLabels: [
-        {
-            date: 'Tue',
-            label: 'Tuesday',
-            variant: 'success',
-            iconName: 'standard:branch_merge',
-            iconPosition: 'right',
-            iconVariant: 'inverse'
-        },
-        {
-            date: 6,
-            label: '',
-            variant: 'success',
-            iconName: 'standard:campaign',
-            iconVariant: 'inverse'
-        },
-        {
-            date: new Date('05/25/2022'),
-            label: '25 may',
-            variant: 'error',
-            iconName: 'standard:lightning_component',
-            iconVariant: 'inverse'
-        }
-    ],
-    disabledDates: [
-        new Date(2021, 4, 9),
-        new Date(2021, 4, 26),
-        13,
-        14,
-        20,
-        21,
-        'Wed',
-        'Thu'
-    ]
+    disabledDates: [13, 14, 20, 21]
 };
 
 export const Disabled = Template.bind({});
@@ -234,4 +201,33 @@ MarkedDates.args = {
     value: '05/09/2022',
     disabledDates: [20, 'Sat'],
     markedDates: markedDates
+};
+
+export const DateLabels = Template.bind({});
+DateLabels.args = {
+    value: ['05/10/2022', '05/30/2022'],
+    selectionMode: 'interval',
+    dateLabels: [
+        {
+            date: 'Tue',
+            label: 'Tuesday',
+            variant: 'success',
+            iconName: 'standard:branch_merge',
+            iconPosition: 'right',
+            iconVariant: 'inverse'
+        },
+        {
+            date: 6,
+            variant: 'success',
+            iconName: 'standard:campaign',
+            iconVariant: 'inverse'
+        },
+        {
+            date: new Date('05/25/2022'),
+            label: '25 may',
+            variant: 'error',
+            iconName: 'standard:lightning_component',
+            iconVariant: 'inverse'
+        }
+    ]
 };

--- a/src/modules/base/calendar/__docs__/calendar.stories.js
+++ b/src/modules/base/calendar/__docs__/calendar.stories.js
@@ -170,7 +170,7 @@ Multiple.args = {
 
 export const Interval = Template.bind({});
 Interval.args = {
-    value: ['05/10/2022', '05/17/2022'],
+    value: ['05/10/2022', '05/30/2022'],
     selectionMode: 'interval',
     dateLabels: [
         {
@@ -182,22 +182,29 @@ Interval.args = {
             iconVariant: 'inverse'
         },
         {
-            date: 25,
+            date: 6,
             label: '',
-            variant: '',
-            outline: true,
-            iconName: 'standard:branch_merge',
-            iconPosition: 'left',
-            iconVariant: 'brand'
+            variant: 'success',
+            iconName: 'standard:campaign',
+            iconVariant: 'inverse'
         },
         {
-            date: new Date('05/26/2022'),
-            label: '26 may',
+            date: new Date('05/25/2022'),
+            label: '25 may',
             variant: 'error',
-            iconName: 'standard:branch_merge',
-            iconPosition: 'right',
+            iconName: 'standard:lightning_component',
             iconVariant: 'inverse'
         }
+    ],
+    disabledDates: [
+        new Date(2021, 4, 9),
+        new Date(2021, 4, 26),
+        13,
+        14,
+        20,
+        21,
+        'Wed',
+        'Thu'
     ]
 };
 

--- a/src/modules/base/calendar/__docs__/calendar.stories.js
+++ b/src/modules/base/calendar/__docs__/calendar.stories.js
@@ -177,8 +177,17 @@ Interval.args = {
             date: 12,
             label: 'day 12',
             variant: 'success',
-            outline: '',
+            outline: 'asdf',
             iconName: 'standard:branch_merge',
+            iconPosition: 'right',
+            iconVariant: 'inverse'
+        },
+        {
+            date: new Date('05/26/2022'),
+            label: '26 may',
+            variant: 'success',
+            outline: '',
+            // iconName: 'standard:branch_merge',
             iconPosition: 'right',
             iconVariant: 'success'
         },

--- a/src/modules/base/calendar/__docs__/calendar.stories.js
+++ b/src/modules/base/calendar/__docs__/calendar.stories.js
@@ -39,7 +39,8 @@ export default {
             name: 'date-labels',
             control: {
                 type: 'object'
-            }
+            },
+            description: 'An array of dates and label properties.'
         },
         disabled: {
             control: {
@@ -143,11 +144,11 @@ export default {
 };
 
 const markedDates = [
-    { date: new Date('05/09/2021'), color: 'red' },
-    { date: new Date('05/26/2021'), color: 'brown' },
-    { date: new Date('05/26/2021'), color: 'blue' },
-    { date: new Date('05/26/2021'), color: 'red' },
-    { date: new Date('05/26/2021'), color: 'yellow' },
+    { date: new Date('05/09/2022'), color: 'red' },
+    { date: new Date('05/26/2022'), color: 'brown' },
+    { date: new Date('05/26/2022'), color: 'blue' },
+    { date: new Date('05/26/2022'), color: 'red' },
+    { date: new Date('05/26/2022'), color: 'yellow' },
     { date: 14, color: 'blue' },
     { date: 20, color: 'yellow' },
     { date: 'Wed', color: 'black' }
@@ -157,23 +158,39 @@ const Template = (args) => Calendar(args);
 
 export const Base = Template.bind({});
 Base.args = {
-    value: '05/08/2021',
-    disabledDates: '05/09/2021'
+    value: '05/08/2022',
+    disabledDates: '05/09/2022'
 };
 
 export const Multiple = Template.bind({});
 Multiple.args = {
-    value: ['05/03/2021', '05/08/2021', '05/12/2021', '05/18/2021'],
+    value: ['05/03/2022', '05/08/2022', '05/12/2022', '05/18/2022'],
     selectionMode: 'multiple'
 };
 
 export const Interval = Template.bind({});
 Interval.args = {
-    value: ['05/03/2021', '05/08/2021'],
+    value: ['05/10/2022', '05/17/2022'],
     selectionMode: 'interval',
     dateLabels: [
-        { date: 12, label: 'day 12 label' },
-        { date: 25, label: 'day 25 label' }
+        {
+            date: 12,
+            label: 'day 12',
+            variant: 'success',
+            outline: '',
+            iconName: 'standard:branch_merge',
+            iconPosition: 'right',
+            iconVariant: 'success'
+        },
+        {
+            date: 25,
+            label: '25 label big label',
+            variant: '',
+            outline: true,
+            iconName: 'standard:branch_merge',
+            iconPosition: 'left',
+            iconVariant: 'brand'
+        }
     ]
 };
 
@@ -184,7 +201,7 @@ Disabled.args = {
 
 export const BaseWithWeekNumber = Template.bind({});
 BaseWithWeekNumber.args = {
-    value: '05/09/2021',
+    value: '05/09/2022',
     weekNumber: true,
     disabledDates: [
         new Date(2021, 4, 9),
@@ -200,7 +217,7 @@ BaseWithWeekNumber.args = {
 
 export const MarkedDates = Template.bind({});
 MarkedDates.args = {
-    value: '05/09/2021',
+    value: '05/09/2022',
     disabledDates: [20, 'Sat'],
     markedDates: markedDates
 };

--- a/src/modules/base/calendar/__docs__/calendar.stories.js
+++ b/src/modules/base/calendar/__docs__/calendar.stories.js
@@ -35,11 +35,16 @@ import { Calendar } from '../__examples__/calendar';
 export default {
     title: 'Example/Calendar',
     argTypes: {
+        dateLabels: {
+            name: 'date-labels',
+            control: {
+                type: 'object'
+            }
+        },
         disabled: {
             control: {
                 type: 'boolean'
             },
-            defaultValue: false,
             description: 'If true, the calendar is disabled.',
             table: {
                 type: { summary: 'boolean' },
@@ -53,7 +58,6 @@ export default {
             },
             description:
                 'An array that will be used to determine which dates to be disabled in the calendar.',
-            defaultValue: [],
             table: {
                 type: { summary: 'string|string[]' }
             }
@@ -65,7 +69,6 @@ export default {
             },
             description:
                 'An array that will be used to determine which dates to be marked in the calendar.',
-            defaultValue: [],
             table: {
                 type: { summary: 'object[]' }
             }
@@ -76,7 +79,6 @@ export default {
             },
             description:
                 'Specifies the minimum date, which the calendar can show.',
-            defaultValue: new Date(1900, 0, 1),
             table: {
                 type: { summary: 'object' },
                 defaultValue: { summary: 'Date(1900, 0, 1)' }
@@ -88,7 +90,6 @@ export default {
             },
             description:
                 'Specifies the maximum date, which the calendar can show.',
-            defaultValue: new Date(2099, 11, 31),
             table: {
                 type: { summary: 'object' },
                 defaultValue: { summary: 'Date(2099, 11, 31)' }
@@ -100,7 +101,6 @@ export default {
                 type: 'select'
             },
             options: ['single', 'multiple', 'interval'],
-            defaultValue: 'single',
             description:
                 'Specifies the selection mode of the calendar. Valid values include single, multiple and interval. If single, only one date can be selected at a time. If multiple, the user can select multiple dates. If interval, the user can only select a date range (two dates).',
             table: {
@@ -124,7 +124,6 @@ export default {
                 type: 'boolean'
             },
             description: 'If true, display a week number column',
-            defaultValue: false,
             table: {
                 type: { summary: 'boolean' },
                 defaultValue: { summary: 'false' }
@@ -133,6 +132,12 @@ export default {
     },
     args: {
         disabled: false,
+        dateLabels: [],
+        disabledDates: [],
+        markedDates: [],
+        min: new Date(1900, 0, 1),
+        max: new Date(2099, 11, 31),
+        selectinMode: 'single',
         weekNumber: false
     }
 };
@@ -162,7 +167,11 @@ Multiple.args = {
 export const Interval = Template.bind({});
 Interval.args = {
     value: ['05/03/2021', '05/08/2021'],
-    selectionMode: 'interval'
+    selectionMode: 'interval',
+    dateLabels: [
+        { date: 12, label: 'label label label' },
+        { date: 25, label: 'label' }
+    ]
 };
 
 export const Disabled = Template.bind({});

--- a/src/modules/base/calendar/__examples__/calendar.js
+++ b/src/modules/base/calendar/__examples__/calendar.js
@@ -35,6 +35,7 @@ import Component from 'avonni/calendar';
 customElements.define('ac-base-calendar', Component.CustomElementConstructor);
 
 export const Calendar = ({
+    dateLabels,
     disabled,
     disabledDates,
     markedDates,
@@ -45,6 +46,7 @@ export const Calendar = ({
     weekNumber
 }) => {
     const element = document.createElement('ac-base-calendar');
+    element.dateLabels = dateLabels;
     element.disabled = disabled;
     element.disabledDates = disabledDates;
     element.markedDates = markedDates;

--- a/src/modules/base/calendar/__examples__/labels/labels.html
+++ b/src/modules/base/calendar/__examples__/labels/labels.html
@@ -1,0 +1,7 @@
+<template>
+    <avonni-calendar
+        value={value}
+        date-labels="dateLabels"
+        selection-mode="multiple"
+    ></avonni-calendar>
+</template>

--- a/src/modules/base/calendar/__examples__/labels/labels.html
+++ b/src/modules/base/calendar/__examples__/labels/labels.html
@@ -1,7 +1,7 @@
 <template>
     <avonni-calendar
         value={value}
-        date-labels="dateLabels"
-        selection-mode="multiple"
+        date-labels={dateLabels}
+        selection-mode="interval"
     ></avonni-calendar>
 </template>

--- a/src/modules/base/calendar/__examples__/labels/labels.js
+++ b/src/modules/base/calendar/__examples__/labels/labels.js
@@ -1,0 +1,29 @@
+import { LightningElement } from 'lwc';
+
+export default class CalendarLabels extends LightningElement {
+    value = ['05/03/2022', '05/08/2022', '05/12/2022', '05/18/2022'];
+    dateLabels = [
+        {
+            date: 'Tue',
+            label: 'Tuesday',
+            variant: 'success',
+            iconName: 'standard:branch_merge',
+            iconPosition: 'right',
+            iconVariant: 'inverse'
+        },
+        {
+            date: 25,
+            label: '',
+            variant: 'error',
+            iconName: 'standard:campaign',
+            iconVariant: 'inverse'
+        },
+        {
+            date: new Date('05/26/2022'),
+            label: '26 may',
+            variant: 'error',
+            iconName: 'standard:branch_merge',
+            iconVariant: 'inverse'
+        }
+    ];
+}

--- a/src/modules/base/calendar/__examples__/labels/labels.js
+++ b/src/modules/base/calendar/__examples__/labels/labels.js
@@ -1,7 +1,7 @@
 import { LightningElement } from 'lwc';
 
 export default class CalendarLabels extends LightningElement {
-    value = ['05/03/2022', '05/08/2022', '05/12/2022', '05/18/2022'];
+    value = ['05/10/2022', '05/30/2022'];
     dateLabels = [
         {
             date: 'Tue',
@@ -13,7 +13,6 @@ export default class CalendarLabels extends LightningElement {
         },
         {
             date: 25,
-            label: '',
             variant: 'error',
             iconName: 'standard:campaign',
             iconVariant: 'inverse'

--- a/src/modules/base/calendar/__tests__/calendar.test.js
+++ b/src/modules/base/calendar/__tests__/calendar.test.js
@@ -80,7 +80,7 @@ describe('Calendar', () => {
 
         return Promise.resolve().then(() => {
             const day26Label = element.shadowRoot.querySelector(
-                '[data-cell-day="1653537600000"] .avonni-calendar__chip-label'
+                '[data-cell-day="1653537600000"] [data-element-id="date-label"]'
             );
             expect(day26Label).toBeTruthy();
         });

--- a/src/modules/base/calendar/__tests__/calendar.test.js
+++ b/src/modules/base/calendar/__tests__/calendar.test.js
@@ -55,6 +55,7 @@ describe('Calendar', () => {
             is: Calendar
         });
 
+        expect(element.dateLabels).toMatchObject([]);
         expect(element.disabled).toBeFalsy();
         expect(element.disabledDates).toMatchObject([]);
         expect(element.markedDates).toMatchObject([]);
@@ -66,6 +67,24 @@ describe('Calendar', () => {
     });
 
     /* ----- ATTRIBUTES ----- */
+
+    // dateLabels
+    it('Calendar date labels', () => {
+        element.value = '05/14/2022';
+        element.dateLabels = [
+            {
+                date: new Date('05/26/2022'),
+                label: '26 may'
+            }
+        ];
+
+        return Promise.resolve().then(() => {
+            const day26Label = element.shadowRoot.querySelector(
+                '[data-cell-day="1653537600000"] .avonni-calendar__chip-label'
+            );
+            expect(day26Label).toBeTruthy();
+        });
+    });
 
     // disabled
     it('Calendar disabled', () => {
@@ -252,7 +271,7 @@ describe('Calendar', () => {
         });
     });
 
-    it('Calendar values selection-mode: interval startDate < newDate', () => {
+    it('Calendar values selection-mode: interval newDate < startDate', () => {
         element.value = '05/15/2021';
         element.min = new Date('05/01/2021');
         element.max = new Date('05/31/2021');
@@ -262,11 +281,14 @@ describe('Calendar', () => {
                 'span[data-date="14"]'
             );
             day14.click();
-            expect(element.value).toMatchObject([new Date('05/14/2021')]);
+            expect(element.value).toMatchObject([
+                new Date('05/14/2021'),
+                new Date('05/15/2021')
+            ]);
         });
     });
 
-    it('Calendar values selection-mode: interval startDate > newDate', () => {
+    it('Calendar values selection-mode: interval newDate > startDate', () => {
         element.value = '05/15/2021';
         element.min = new Date('05/01/2021');
         element.max = new Date('05/31/2021');
@@ -283,7 +305,7 @@ describe('Calendar', () => {
         });
     });
 
-    it('Calendar values selection-mode: interval endDate < newDate', () => {
+    it('Calendar values selection-mode: interval newDate < endDate', () => {
         element.value = ['05/15/2021', '05/16/2021'];
         element.min = new Date('05/01/2021');
         element.max = new Date('05/31/2021');
@@ -300,7 +322,7 @@ describe('Calendar', () => {
         });
     });
 
-    it('Calendar values selection-mode: interval endDate > newDate < startDate', () => {
+    it('Calendar values selection-mode: interval newDate < startDate < endDate', () => {
         element.value = ['05/15/2021', '05/16/2021'];
         element.min = new Date('05/01/2021');
         element.max = new Date('05/31/2021');
@@ -310,7 +332,10 @@ describe('Calendar', () => {
                 'span[data-date="14"]'
             );
             day14.click();
-            expect(element.value).toMatchObject([new Date('05/14/2021')]);
+            expect(element.value).toMatchObject([
+                new Date('05/14/2021'),
+                new Date('05/16/2021')
+            ]);
         });
     });
 

--- a/src/modules/base/calendar/calendar.css
+++ b/src/modules/base/calendar/calendar.css
@@ -30,8 +30,53 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 :host {
-    --avonni-calendar-cell-sizing-width: 60px;
-    --avonni-calendar-cell-sizing-height: 60px;
+    /* internal styling hooks - not documented */
+    --avonni-calendar-cell-sizing-width: 30px;
+    --avonni-calendar-cell-sizing-height: 30px;
+    --avonni-calendar-cell-labeled-sizing-width: 70px;
+    --avonni-calendar-cell-labeled-sizing-height: 60px;
+}
+
+td {
+    -moz-user-select: none;
+    -khtml-user-select: none;
+    -webkit-user-select: none;
+    border-width: 1px;
+    position: relative;
+    vertical-align: top;
+    width: var(--avonni-calendar-cell-sizing-width);
+    min-width: var(--avonni-calendar-cell-sizing-width);
+    max-width: var(--avonni-calendar-cell-sizing-width);
+    height: var(--avonni-calendar-cell-sizing-height);
+    min-height: var(--avonni-calendar-cell-sizing-height);
+    max-height: var(--avonni-calendar-cell-sizing-height);
+}
+
+.avonni-calendar__date-with-labels td {
+    width: var(
+        --avonni-calendar-cell-labeled-sizing-width,
+        var(--avonni-calendar-cell-sizing-width)
+    );
+    min-width: var(
+        --avonni-calendar-cell-labeled-sizing-width,
+        var(--avonni-calendar-cell-sizing-width)
+    );
+    max-width: var(
+        --avonni-calendar-cell-labeled-sizing-width,
+        var(--avonni-calendar-cell-sizing-width)
+    );
+    height: var(
+        --avonni-calendar-cell-labeled-sizing-height,
+        var(--avonni-calendar-cell-sizing-height)
+    );
+    min-height: var(
+        --avonni-calendar-cell-labeled-sizing-height,
+        var(--avonni-calendar-cell-sizing-height)
+    );
+    max-height: var(
+        --avonni-calendar-cell-labeled-sizing-height,
+        var(--avonni-calendar-cell-sizing-height)
+    );
 }
 
 .avonni-calendar__container {
@@ -116,11 +161,11 @@ th {
     color: var(--avonni-calendar-selected-date-text-color, #ffffff);
 }
 
-.slds-datepicker
+.slds-datepicker__month
     td.slds-is-selected-multi
     + .slds-is-selected-multi
     > .slds-day:before,
-.slds-datepicker
+.slds-datepicker__month
     td.slds-is-selected-multi
     + .slds-is-selected-multi
     > .avonni-calendar__disabled-cell:before {
@@ -128,9 +173,21 @@ th {
     position: absolute;
     height: 100%;
     width: var(--avonni-calendar-cell-sizing-width);
-    transform: translateX(calc(-50%));
+    transform: translateX(calc(- (width/2)));
     z-index: -1;
     background: var(--avonni-calendar-selected-date-color-background, #0176d3);
+}
+
+.slds-datepicker__month.avonni-calendar__date-with-labels
+    td.slds-is-selected-multi
+    + .slds-is-selected-multi
+    > .slds-day:before,
+.slds-datepicker__month.avonni-calendar__date-with-labels
+    td.slds-is-selected-multi
+    + .slds-is-selected-multi
+    > .avonni-calendar__disabled-cell:before {
+    width: var(--avonni-calendar-cell-labeled-sizing-width);
+    transform: translateX(-50%);
 }
 
 div:focus {
@@ -142,7 +199,6 @@ div:focus {
         --avonni-calendar-multi-selected-color-border-hover,
         #d3d3d39a
     );
-    border-right-width: 1px;
     border-right-style: var(
         --avonni-calendar-multi-selected-styling-border-hover,
         dashed
@@ -154,14 +210,20 @@ div:focus {
         --avonni-calendar-multi-selected-color-border-hover,
         #d3d3d39a
     );
-    border-left-width: 1px;
     border-left-style: var(
         --avonni-calendar-multi-selected-styling-border-hover,
         dashed
     );
 }
 
-.avonni-calendar__cell_bordered-top_bottom {
+.avonni-calendar__cell_bordered-top_bottom:after {
+    content: '';
+    position: absolute;
+    pointer-events: none;
+    top: 0;
+    left: 0;
+    height: calc(100% + 1px);
+    width: 100%;
     border-bottom-color: var(
         --avonni-calendar-multi-selected-color-border-hover,
         #d3d3d39a
@@ -206,25 +268,15 @@ div:focus {
     background-color: var(--avonni-calendar-color-background, transparent);
 }
 
-.avonni-calendar__label {
-    --avonni-chip-radius-border: 30px;
+.avonni-calendar__chip-label {
+    /* --avonni-chip-radius-border: 2px; */
     --avonni-chip-label-font-size: 8px;
     --avonni-chip-spacing-block-start: 2px;
     --avonni-chip-spacing-block-end: 2px;
-    --avonni-chip-spacing-inline-start: 2px;
+    --avonni-chip-spacing-inline-start: 3px;
     --avonni-chip-spacing-inline-end: 2px;
-    --avonni-chip-sizing-width: 100%;
+    /* --avonni-chip-sizing-width: 100%; */
+    --avonni-chip-sizing-max-width: 100%;
+    margin: 0 auto;
     pointer-events: none;
-}
-
-td {
-    border: 1px solid transparent;
-    vertical-align: top;
-    /* outline: 0.4px solid rgba(211, 211, 211, 0.438); */
-    width: var(--avonni-calendar-cell-sizing-width);
-    min-width: var(--avonni-calendar-cell-sizing-width);
-    max-width: var(--avonni-calendar-cell-sizing-width);
-    height: var(--avonni-calendar-cell-sizing-height);
-    min-height: var(--avonni-calendar-cell-sizing-height);
-    max-height: var(--avonni-calendar-cell-sizing-height);
 }

--- a/src/modules/base/calendar/calendar.css
+++ b/src/modules/base/calendar/calendar.css
@@ -45,6 +45,7 @@ td {
     -moz-user-select: none;
     -khtml-user-select: none;
     -webkit-user-select: none;
+    user-select: none;
     position: relative;
     vertical-align: top;
     width: var(--avonni-calendar-cell-sizing-width);
@@ -57,10 +58,8 @@ td {
 
 .avonni-calendar__date-with-labels td {
     width: var(--avonni-calendar-cell-labeled-sizing-width);
-    min-width: var(--avonni-calendar-cell-labeled-sizing-width);
     max-width: var(--avonni-calendar-cell-labeled-sizing-width);
     height: var(--avonni-calendar-cell-labeled-sizing-height);
-    min-height: var(--avonni-calendar-cell-labeled-sizing-height);
     max-height: var(--avonni-calendar-cell-labeled-sizing-height);
 }
 
@@ -83,14 +82,14 @@ th {
     color: #adadad;
 }
 
-.slds-datepicker td > span[data-element-id='span-day-label'] {
+.slds-datepicker td > span.avonni-calendar__chip-label {
     width: var(--lwc-squareIconMediumBoundary, 2rem);
     height: var(--lwc-squareIconMediumBoundary, 2rem);
     display: block;
     position: relative;
     min-width: var(--lwc-squareIconMediumBoundary, 2rem);
     line-height: var(--lwc-squareIconMediumBoundary, 2rem);
-    border-radius: var(--lwc-borderRadiusCircle, 10rem);
+    border-radius: var(--lwc-borderRadiusCircle, 50%);
     margin: auto;
 }
 
@@ -199,7 +198,7 @@ th {
     pointer-events: none;
     top: 0;
     left: 0;
-    height: calc(100% + 1px);
+    height: 100%;
     width: 100%;
     border-width: 1px;
 }
@@ -227,6 +226,7 @@ th {
 }
 
 .avonni-calendar__cell_bordered-top_bottom:after {
+    height: calc(100% + 1px);
     border-bottom-color: var(
         --avonni-calendar-multi-selected-color-border-hover,
         #d3d3d39a

--- a/src/modules/base/calendar/calendar.css
+++ b/src/modules/base/calendar/calendar.css
@@ -37,11 +37,14 @@
     --avonni-calendar-cell-labeled-sizing-height: 60px;
 }
 
+div:focus {
+    outline: none;
+}
+
 td {
     -moz-user-select: none;
     -khtml-user-select: none;
     -webkit-user-select: none;
-    border-width: 1px;
     position: relative;
     vertical-align: top;
     width: var(--avonni-calendar-cell-sizing-width);
@@ -53,30 +56,12 @@ td {
 }
 
 .avonni-calendar__date-with-labels td {
-    width: var(
-        --avonni-calendar-cell-labeled-sizing-width,
-        var(--avonni-calendar-cell-sizing-width)
-    );
-    min-width: var(
-        --avonni-calendar-cell-labeled-sizing-width,
-        var(--avonni-calendar-cell-sizing-width)
-    );
-    max-width: var(
-        --avonni-calendar-cell-labeled-sizing-width,
-        var(--avonni-calendar-cell-sizing-width)
-    );
-    height: var(
-        --avonni-calendar-cell-labeled-sizing-height,
-        var(--avonni-calendar-cell-sizing-height)
-    );
-    min-height: var(
-        --avonni-calendar-cell-labeled-sizing-height,
-        var(--avonni-calendar-cell-sizing-height)
-    );
-    max-height: var(
-        --avonni-calendar-cell-labeled-sizing-height,
-        var(--avonni-calendar-cell-sizing-height)
-    );
+    width: var(--avonni-calendar-cell-labeled-sizing-width);
+    min-width: var(--avonni-calendar-cell-labeled-sizing-width);
+    max-width: var(--avonni-calendar-cell-labeled-sizing-width);
+    height: var(--avonni-calendar-cell-labeled-sizing-height);
+    min-height: var(--avonni-calendar-cell-labeled-sizing-height);
+    max-height: var(--avonni-calendar-cell-labeled-sizing-height);
 }
 
 .avonni-calendar__container {
@@ -98,7 +83,7 @@ th {
     color: #adadad;
 }
 
-.slds-datepicker td > span {
+.slds-datepicker td > span[data-element-id='span-day-label'] {
     width: var(--lwc-squareIconMediumBoundary, 2rem);
     height: var(--lwc-squareIconMediumBoundary, 2rem);
     display: block;
@@ -161,6 +146,7 @@ th {
     color: var(--avonni-calendar-selected-date-text-color, #ffffff);
 }
 
+/* Interval selection */
 .slds-datepicker__month
     td.slds-is-selected-multi
     + .slds-is-selected-multi
@@ -173,7 +159,7 @@ th {
     position: absolute;
     height: 100%;
     width: var(--avonni-calendar-cell-sizing-width);
-    transform: translateX(calc(- (width/2)));
+    transform: translateX(calc(-var(--avonni-calendar-cell-sizing-width) / 2));
     z-index: -1;
     background: var(--avonni-calendar-selected-date-color-background, #0176d3);
 }
@@ -187,14 +173,38 @@ th {
     + .slds-is-selected-multi
     > .avonni-calendar__disabled-cell:before {
     width: var(--avonni-calendar-cell-labeled-sizing-width);
-    transform: translateX(-50%);
+    transform: translateX(calc(-50% + -2px));
 }
 
-div:focus {
-    outline: none;
+.slds-datepicker__month
+    td.slds-is-selected-multi
+    + .slds-is-selected-multi
+    > .avonni-calendar__disabled-cell:before {
+    transform: translateX(-85%);
 }
 
-.avonni-calendar__cell_bordered-right {
+.slds-datepicker__month.avonni-calendar__date-with-labels
+    td.slds-is-selected-multi
+    + .slds-is-selected-multi
+    > .avonni-calendar__disabled-cell:before {
+    transform: translateX(-92%);
+}
+
+/* Borders around hovered interval */
+.avonni-calendar__cell_bordered-right:after,
+.avonni-calendar__cell_bordered-left:after,
+.avonni-calendar__cell_bordered-top_bottom:after {
+    content: '';
+    position: absolute;
+    pointer-events: none;
+    top: 0;
+    left: 0;
+    height: calc(100% + 1px);
+    width: 100%;
+    border-width: 1px;
+}
+
+.avonni-calendar__cell_bordered-right:after {
     border-right-color: var(
         --avonni-calendar-multi-selected-color-border-hover,
         #d3d3d39a
@@ -205,7 +215,7 @@ div:focus {
     );
 }
 
-.avonni-calendar__cell_bordered-left {
+.avonni-calendar__cell_bordered-left:after {
     border-left-color: var(
         --avonni-calendar-multi-selected-color-border-hover,
         #d3d3d39a
@@ -217,18 +227,10 @@ div:focus {
 }
 
 .avonni-calendar__cell_bordered-top_bottom:after {
-    content: '';
-    position: absolute;
-    pointer-events: none;
-    top: 0;
-    left: 0;
-    height: calc(100% + 1px);
-    width: 100%;
     border-bottom-color: var(
         --avonni-calendar-multi-selected-color-border-hover,
         #d3d3d39a
     );
-    border-bottom-width: 1px;
     border-bottom-style: var(
         --avonni-calendar-multi-selected-styling-border-hover,
         dashed
@@ -237,13 +239,13 @@ div:focus {
         --avonni-calendar-multi-selected-color-border-hover,
         #d3d3d39a
     );
-    border-top-width: 1px;
     border-top-style: var(
         --avonni-calendar-multi-selected-styling-border-hover,
         dashed
     );
 }
 
+/* Markers */
 .avonni-calendar__marked-cells {
     width: 5px;
     height: 5px;
@@ -268,6 +270,7 @@ div:focus {
     background-color: var(--avonni-calendar-color-background, transparent);
 }
 
+/* Chip label */
 .avonni-calendar__chip-label {
     --avonni-chip-label-font-size: 8px;
     --avonni-chip-spacing-block-start: 2px;
@@ -277,7 +280,6 @@ div:focus {
     --avonni-chip-sizing-max-width: 100%;
     --avonni-chip-sizing-height: 16px;
     margin: 0 auto;
-    pointer-events: none;
 }
 .avonni-calendar__chip-icon-only {
     position: relative;
@@ -290,5 +292,6 @@ div:focus {
 }
 
 .avonni-calendar__chip-icon-only .avonni-calendar-chip-icon {
+    /* necessary for icon-only labels, otherwise they break */
     position: absolute;
 }

--- a/src/modules/base/calendar/calendar.css
+++ b/src/modules/base/calendar/calendar.css
@@ -29,6 +29,10 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
+:host {
+    --avonni-calendar-cell-sizing-width: 60px;
+    --avonni-calendar-cell-sizing-height: 60px;
+}
 
 .avonni-calendar__container {
     width: fit-content;
@@ -56,7 +60,7 @@ th {
     position: relative;
     min-width: var(--lwc-squareIconMediumBoundary, 2rem);
     line-height: var(--lwc-squareIconMediumBoundary, 2rem);
-    border-radius: var(--lwc-borderRadiusCircle, 50%);
+    border-radius: var(--lwc-borderRadiusCircle, 10rem);
     margin: auto;
 }
 
@@ -122,13 +126,9 @@ th {
     > .avonni-calendar__disabled-cell:before {
     content: '';
     position: absolute;
-    top: 0;
-    left: -50%;
-    /* right: 0; */
     height: 100%;
-    width: 70px;
-    /* width: 2.5rem; */
-    transform: translateX(-50%);
+    width: var(--avonni-calendar-cell-sizing-width);
+    transform: translateX(calc(-50%));
     z-index: -1;
     background: var(--avonni-calendar-selected-date-color-background, #0176d3);
 }
@@ -207,7 +207,7 @@ div:focus {
 }
 
 .avonni-calendar__label {
-    --avonni-chip-radius-border: 2px;
+    --avonni-chip-radius-border: 30px;
     --avonni-chip-label-font-size: 8px;
     --avonni-chip-spacing-block-start: 2px;
     --avonni-chip-spacing-block-end: 2px;
@@ -218,8 +218,13 @@ div:focus {
 }
 
 td {
-    outline: 0.4px solid rgba(211, 211, 211, 0.438);
-    width: 70px;
-    max-width: 70px;
-    height: 50px;
+    border: 1px solid transparent;
+    vertical-align: top;
+    /* outline: 0.4px solid rgba(211, 211, 211, 0.438); */
+    width: var(--avonni-calendar-cell-sizing-width);
+    min-width: var(--avonni-calendar-cell-sizing-width);
+    max-width: var(--avonni-calendar-cell-sizing-width);
+    height: var(--avonni-calendar-cell-sizing-height);
+    min-height: var(--avonni-calendar-cell-sizing-height);
+    max-height: var(--avonni-calendar-cell-sizing-height);
 }

--- a/src/modules/base/calendar/calendar.css
+++ b/src/modules/base/calendar/calendar.css
@@ -124,9 +124,11 @@ th {
     position: absolute;
     top: 0;
     left: -50%;
+    /* right: 0; */
     height: 100%;
-    width: 2.5rem;
-    transform: translateX(-0.5rem);
+    width: 70px;
+    /* width: 2.5rem; */
+    transform: translateX(-50%);
     z-index: -1;
     background: var(--avonni-calendar-selected-date-color-background, #0176d3);
 }
@@ -202,4 +204,22 @@ div:focus {
 
 .avonni-calendar__background_color {
     background-color: var(--avonni-calendar-color-background, transparent);
+}
+
+.avonni-calendar__label {
+    --avonni-chip-radius-border: 2px;
+    --avonni-chip-label-font-size: 8px;
+    --avonni-chip-spacing-block-start: 2px;
+    --avonni-chip-spacing-block-end: 2px;
+    --avonni-chip-spacing-inline-start: 2px;
+    --avonni-chip-spacing-inline-end: 2px;
+    --avonni-chip-sizing-width: 100%;
+    pointer-events: none;
+}
+
+td {
+    outline: 0.4px solid rgba(211, 211, 211, 0.438);
+    width: 70px;
+    max-width: 70px;
+    height: 50px;
 }

--- a/src/modules/base/calendar/calendar.css
+++ b/src/modules/base/calendar/calendar.css
@@ -37,6 +37,10 @@
     --avonni-calendar-cell-labeled-sizing-height: 60px;
 }
 
+.primitive-icon-calendar {
+    max-height: 100%;
+}
+
 td {
     -moz-user-select: none;
     -khtml-user-select: none;
@@ -277,6 +281,7 @@ div:focus {
     --avonni-chip-spacing-inline-end: 2px;
     /* --avonni-chip-sizing-width: 100%; */
     --avonni-chip-sizing-max-width: 100%;
+    --avonni-ship-sizing-height: 16px;
     margin: 0 auto;
     pointer-events: none;
 }

--- a/src/modules/base/calendar/calendar.css
+++ b/src/modules/base/calendar/calendar.css
@@ -31,14 +31,10 @@
  */
 :host {
     /* internal styling hooks - not documented */
-    --avonni-calendar-cell-sizing-width: 30px;
-    --avonni-calendar-cell-sizing-height: 30px;
+    --avonni-calendar-cell-sizing-width: 40px;
+    --avonni-calendar-cell-sizing-height: 40px;
     --avonni-calendar-cell-labeled-sizing-width: 70px;
     --avonni-calendar-cell-labeled-sizing-height: 60px;
-}
-
-.primitive-icon-calendar {
-    max-height: 100%;
 }
 
 td {
@@ -273,15 +269,26 @@ div:focus {
 }
 
 .avonni-calendar__chip-label {
-    /* --avonni-chip-radius-border: 2px; */
     --avonni-chip-label-font-size: 8px;
     --avonni-chip-spacing-block-start: 2px;
     --avonni-chip-spacing-block-end: 2px;
     --avonni-chip-spacing-inline-start: 3px;
     --avonni-chip-spacing-inline-end: 2px;
-    /* --avonni-chip-sizing-width: 100%; */
     --avonni-chip-sizing-max-width: 100%;
-    --avonni-ship-sizing-height: 16px;
+    --avonni-chip-sizing-height: 16px;
     margin: 0 auto;
     pointer-events: none;
+}
+.avonni-calendar__chip-icon-only {
+    position: relative;
+    top: -3px;
+    --avonni-chip-spacing-block-start: 0px;
+    --avonni-chip-spacing-block-end: 0px;
+    --avonni-chip-spacing-inline-start: 0px;
+    --avonni-chip-spacing-inline-end: 0px;
+    --avonni-chip-sizing-width: 16px;
+}
+
+.avonni-calendar__chip-icon-only .avonni-calendar-chip-icon {
+    position: absolute;
 }

--- a/src/modules/base/calendar/calendar.html
+++ b/src/modules/base/calendar/calendar.html
@@ -175,7 +175,7 @@
                                         <c-chip
                                             if:true={day.labeled}
                                             class="avonni-calendar__label"
-                                            label={day.chipLabel}
+                                            label="chip label long text"
                                         ></c-chip>
                                     </td>
                                 </template>

--- a/src/modules/base/calendar/calendar.html
+++ b/src/modules/base/calendar/calendar.html
@@ -176,9 +176,10 @@
                                             if:true={day.labeled}
                                             variant={day.chip.variant}
                                             class="avonni-calendar__chip-label"
-                                            label={day.chip.label}
-                                            outline="true"
+                                            label={day.chip.outline}
+                                            outline={day.chip.outline}
                                         >
+                                            <!-- outline={day.chip.outline} -->
                                             <c-primitive-icon
                                                 if:true={day.chip.showLeft}
                                                 slot="left"

--- a/src/modules/base/calendar/calendar.html
+++ b/src/modules/base/calendar/calendar.html
@@ -174,27 +174,33 @@
                                         </div>
                                         <c-chip
                                             if:true={day.labeled}
-                                            variant={day.chip.variant}
                                             class={day.chip.classes}
                                             label={day.chip.label}
+                                            variant={day.chip.variant}
                                             outline={day.chip.outline}
+                                            data-day={day.fullDate}
                                         >
                                             <c-primitive-icon
+                                                if:true={day.chip.showLeft}
                                                 class="
                                                     avonni-calendar-chip-icon
                                                 "
-                                                if:true={day.chip.showLeft}
                                                 slot="left"
                                                 size="xx-small"
                                                 variant={day.chip.iconVariant}
                                                 icon-name={day.chip.iconName}
+                                                data-day={day.fullDate}
                                             ></c-primitive-icon>
                                             <c-primitive-icon
                                                 if:true={day.chip.showRight}
+                                                class="
+                                                    avonni-calendar-chip-icon
+                                                "
                                                 slot="right"
                                                 size="xx-small"
                                                 variant={day.chip.iconVariant}
                                                 icon-name={day.chip.iconName}
+                                                data-day={day.fullDate}
                                             ></c-primitive-icon>
                                         </c-chip>
                                     </td>

--- a/src/modules/base/calendar/calendar.html
+++ b/src/modules/base/calendar/calendar.html
@@ -175,7 +175,7 @@
                                         <c-chip
                                             if:true={day.labeled}
                                             class="avonni-calendar__label"
-                                            label="chip label long text"
+                                            label={day.chipLabel}
                                         ></c-chip>
                                     </td>
                                 </template>

--- a/src/modules/base/calendar/calendar.html
+++ b/src/modules/base/calendar/calendar.html
@@ -104,7 +104,7 @@
                 <table
                     aria-labelledby="month"
                     aria-multiselectable="true"
-                    class="slds-datepicker__month"
+                    class={tableClasses}
                     role="grid"
                 >
                     <thead>
@@ -174,9 +174,26 @@
                                         </div>
                                         <c-chip
                                             if:true={day.labeled}
-                                            class="avonni-calendar__label"
-                                            label={day.chipLabel}
-                                        ></c-chip>
+                                            variant={day.chip.variant}
+                                            class="avonni-calendar__chip-label"
+                                            label={day.chip.label}
+                                            outline="true"
+                                        >
+                                            <c-primitive-icon
+                                                if:true={day.chip.showLeft}
+                                                slot="left"
+                                                size="xx-small"
+                                                variant={day.chip.iconVariant}
+                                                icon-name={day.chip.iconName}
+                                            ></c-primitive-icon>
+                                            <c-primitive-icon
+                                                if:true={day.chip.showRight}
+                                                slot="right"
+                                                size="xx-small"
+                                                variant={day.chip.iconVariant}
+                                                icon-name={day.chip.iconName}
+                                            ></c-primitive-icon>
+                                        </c-chip>
                                     </td>
                                 </template>
                             </tr>

--- a/src/modules/base/calendar/calendar.html
+++ b/src/modules/base/calendar/calendar.html
@@ -173,15 +173,16 @@
                                             </div>
                                         </div>
                                         <c-chip
-                                            if:true={day.chip.label}
+                                            if:true={day.labeled}
                                             variant={day.chip.variant}
-                                            class="avonni-calendar__chip-label"
+                                            class={day.chip.classes}
                                             label={day.chip.label}
                                             outline={day.chip.outline}
                                         >
-                                            <!-- outline={day.chip.outline} -->
                                             <c-primitive-icon
-                                                class="primitive-icon-calendar"
+                                                class="
+                                                    avonni-calendar-chip-icon
+                                                "
                                                 if:true={day.chip.showLeft}
                                                 slot="left"
                                                 size="xx-small"

--- a/src/modules/base/calendar/calendar.html
+++ b/src/modules/base/calendar/calendar.html
@@ -172,6 +172,11 @@
                                                 </template>
                                             </div>
                                         </div>
+                                        <c-chip
+                                            if:true={day.labeled}
+                                            class="avonni-calendar__label"
+                                            label={day.chipLabel}
+                                        ></c-chip>
                                     </td>
                                 </template>
                             </tr>

--- a/src/modules/base/calendar/calendar.html
+++ b/src/modules/base/calendar/calendar.html
@@ -173,14 +173,15 @@
                                             </div>
                                         </div>
                                         <c-chip
-                                            if:true={day.labeled}
+                                            if:true={day.chip.label}
                                             variant={day.chip.variant}
                                             class="avonni-calendar__chip-label"
-                                            label={day.chip.outline}
+                                            label={day.chip.label}
                                             outline={day.chip.outline}
                                         >
                                             <!-- outline={day.chip.outline} -->
                                             <c-primitive-icon
+                                                class="primitive-icon-calendar"
                                                 if:true={day.chip.showLeft}
                                                 slot="left"
                                                 size="xx-small"

--- a/src/modules/base/calendar/calendar.html
+++ b/src/modules/base/calendar/calendar.html
@@ -177,6 +177,7 @@
                                             class={day.chip.classes}
                                             label={day.chip.label}
                                             variant={day.chip.variant}
+                                            data-element-id="date-label"
                                             outline={day.chip.outline}
                                             data-day={day.fullDate}
                                         >

--- a/src/modules/base/calendar/calendar.js
+++ b/src/modules/base/calendar/calendar.js
@@ -36,8 +36,7 @@ import {
     normalizeString,
     normalizeArray
 } from 'c/utilsPrivate';
-import { generateUUID } from 'c/utils';
-import { classSet } from '../utils/classSet';
+import { generateUUID, classSet } from 'c/utils';
 
 const DAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 const MONTHS = [
@@ -68,6 +67,11 @@ const SELECTION_MODES = {
     default: 'single'
 };
 
+const LABEL_ICON_POSITIONS = {
+    valid: ['left', 'right'],
+    default: 'left'
+};
+
 /**
  * @class
  * @name Calendar
@@ -76,6 +80,7 @@ const SELECTION_MODES = {
  * @public
  */
 export default class Calendar extends LightningElement {
+    _dateLabels = [];
     _disabled = false;
     _disabledDates = [];
     _markedDates = [];
@@ -83,7 +88,6 @@ export default class Calendar extends LightningElement {
     _min = DEFAULT_MIN;
     _selectionMode = SELECTION_MODES.default;
     _value = [];
-    _dateLabels = [];
     _weekNumber = false;
     date = DEFAULT_DATE;
     year;
@@ -98,7 +102,7 @@ export default class Calendar extends LightningElement {
     }
 
     /**
-     * Array of date labels. The dates should be a Date object, a timestamp, or an ISO8601 formatted string. The labels are strings
+     * Array of date labels objects. Each object must contain a date and either a label or iconName at a minimum.
      *
      * @public
      * @type {object[]}
@@ -391,7 +395,7 @@ export default class Calendar extends LightningElement {
      * @returns string
      */
     get tableClasses() {
-        let isLabeled = this._dateLabels.length > 0;
+        const isLabeled = this._dateLabels.length > 0;
         return classSet('slds-datepicker__month')
             .add({ 'avonni-calendar__date-with-labels': isLabeled })
             .toString();
@@ -553,35 +557,33 @@ export default class Calendar extends LightningElement {
                     labelIndex = this.findArrayPosition(date, this._dateLabels);
                     if (this.isInArray(date, this.labeledDatesArray)) {
                         labeled = true;
+                        const label = this._dateLabels[labelIndex];
+                        iconPosition = normalizeString(label.iconPosition, {
+                            fallbackValue: LABEL_ICON_POSITIONS.default,
+                            validValues: LABEL_ICON_POSITIONS.valid
+                        });
+                        if (
+                            iconPosition === 'left' &&
+                            label.iconName?.length > 0
+                        ) {
+                            showLeft = true;
+                        }
+                        if (
+                            iconPosition === 'right' &&
+                            label.iconName?.length > 0
+                        ) {
+                            showRight = true;
+                        }
+                        let iconOnlyLabel =
+                            (label.iconName?.length > 0 &&
+                                (label.label?.length < 1 || !label.label)) ||
+                            false;
+                        labelClasses = classSet('avonni-calendar__chip-label')
+                            .add({
+                                'avonni-calendar__chip-icon-only': iconOnlyLabel
+                            })
+                            .toString();
                     }
-                }
-                if (labeled) {
-                    if (this._dateLabels[labelIndex].iconPosition?.length > 0) {
-                        iconPosition =
-                            this._dateLabels[labelIndex].iconPosition;
-                    }
-                    if (
-                        iconPosition === 'left' &&
-                        this._dateLabels[labelIndex].iconName?.length > 0
-                    ) {
-                        showLeft = true;
-                    }
-                    if (
-                        iconPosition === 'right' &&
-                        this._dateLabels[labelIndex].iconName?.length > 0
-                    ) {
-                        showRight = true;
-                    }
-                    let iconOnlyLabel =
-                        (this._dateLabels[labelIndex].iconName?.length > 0 &&
-                            (this._dateLabels[labelIndex].label?.length < 1 ||
-                                !this._dateLabels[labelIndex].label)) ||
-                        false;
-                    labelClasses = classSet('avonni-calendar__chip-label')
-                        .add({
-                            'avonni-calendar__chip-icon-only': iconOnlyLabel
-                        })
-                        .toString();
                 }
 
                 // interval

--- a/src/modules/base/calendar/calendar.js
+++ b/src/modules/base/calendar/calendar.js
@@ -109,6 +109,9 @@ export default class Calendar extends LightningElement {
     }
 
     set dateLabels(value) {
+        if (!value) {
+            return;
+        }
         this._dateLabels = value.map((x) => {
             const labelDate =
                 new Date(x.date).setHours(0, 0, 0, 0) !== NULL_DATE &&
@@ -542,7 +545,7 @@ export default class Calendar extends LightningElement {
                 // chip label
                 let labelIndex;
                 let labeled = false;
-                let iconPosition;
+                let iconPosition = 'left';
                 let showLeft = false;
                 let showRight = false;
                 let labelClasses;
@@ -553,10 +556,10 @@ export default class Calendar extends LightningElement {
                     }
                 }
                 if (labeled) {
-                    iconPosition =
-                        labelIndex > -1
-                            ? this._dateLabels[labelIndex].iconPosition
-                            : 'left';
+                    if (this._dateLabels[labelIndex].iconPosition?.length > 0) {
+                        iconPosition =
+                            this._dateLabels[labelIndex].iconPosition;
+                    }
                     if (
                         iconPosition === 'left' &&
                         this._dateLabels[labelIndex].iconName?.length > 0
@@ -656,6 +659,8 @@ export default class Calendar extends LightningElement {
     findArrayPosition(day, array) {
         let index;
 
+        // The dates are prioritize from last to first from the array.
+        // We might wnat to fix this in the future.
         array
             .map((x) => x.date)
             .forEach((x, _index) => {
@@ -924,12 +929,11 @@ export default class Calendar extends LightningElement {
      */
     handleMouseOver(event) {
         const day = event.target.getAttribute('data-day');
-        // const day = 1621483200000
         const dayCell = this.template.querySelector(`[data-day="${day}"]`);
         const timeArray = this._value
             .map((x) => x.getTime())
             .sort((a, b) => a - b);
-        if (this._selectionMode === 'interval' && day !== '') {
+        if (this._selectionMode === 'interval' && !!day) {
             if (timeArray.length === 1) {
                 if (day > timeArray[0]) {
                     dayCell.classList.add(

--- a/src/modules/base/calendar/calendar.js
+++ b/src/modules/base/calendar/calendar.js
@@ -110,11 +110,6 @@ export default class Calendar extends LightningElement {
 
     set dateLabels(value) {
         this._dateLabels = value.map((x) => {
-            console.log(
-                new Date(x.date).setHours(0, 0, 0, 0),
-                this.formattedWithTimezoneOffset(new Date(x.date)),
-                x.date
-            );
             const labelDate =
                 new Date(x.date).setHours(0, 0, 0, 0) !== NULL_DATE &&
                 !isNaN(Date.parse(x.date))
@@ -122,7 +117,6 @@ export default class Calendar extends LightningElement {
                     : x.date;
             return { date: labelDate, ...x };
         });
-        console.log(this._dateLabels);
     }
 
     /**
@@ -183,11 +177,6 @@ export default class Calendar extends LightningElement {
 
     set markedDates(value) {
         this._markedDates = value.map((x) => {
-            console.log(
-                new Date(x.date).setHours(0, 0, 0, 0),
-                this.formattedWithTimezoneOffset(new Date(x.date)),
-                x.date
-            );
             const isDate =
                 new Date(x.date).setHours(0, 0, 0, 0) !== NULL_DATE &&
                 !isNaN(Date.parse(x.date))
@@ -560,19 +549,29 @@ export default class Calendar extends LightningElement {
                     false;
                 let iconPosition;
                 let chipOuline;
-                let showLeft;
-                let showRight;
+                let showLeft = false;
+                let showRight = false;
                 if (labeled) {
                     iconPosition =
                         labelIndex > -1
                             ? this._dateLabels[labelIndex].iconPosition
                             : 'left';
                     chipOuline =
-                        this._dateLabels[labelIndex].outline === 'true'
-                            ? 'true'
-                            : 'false';
-                    showLeft = iconPosition === 'left' ? true : false;
-                    showRight = iconPosition === 'right' ? true : false;
+                        this._dateLabels[labelIndex].outline === true
+                            ? true
+                            : false;
+                    if (
+                        iconPosition === 'left' &&
+                        this._dateLabels[labelIndex].iconName?.length > 0
+                    ) {
+                        showLeft = true;
+                    }
+                    if (
+                        iconPosition === 'right' &&
+                        this._dateLabels[labelIndex].iconName?.length > 0
+                    ) {
+                        showRight = true;
+                    }
                 }
 
                 // interval
@@ -614,7 +613,6 @@ export default class Calendar extends LightningElement {
                     markedDate = true;
                 }
 
-                // console.log(labeled)
                 weekData.push({
                     label: label,
                     class: dateClass,
@@ -628,8 +626,8 @@ export default class Calendar extends LightningElement {
                     chip: {
                         showLeft: showLeft,
                         showRight: showRight,
-                        outline: chipOuline,
-                        ...this._dateLabels[labelIndex]
+                        ...this._dateLabels[labelIndex],
+                        outline: chipOuline
                     }
                 });
 
@@ -649,24 +647,23 @@ export default class Calendar extends LightningElement {
      * @returns index
      */
     findArrayPosition(day, array) {
-        let datesArray = array.map((x) => x.date);
-        let time = day.getTime();
-        let weekDay = day.getDay();
-        let monthDay = day.getDate();
         let index;
 
-        if (this.fullDatesFromArray(datesArray).indexOf(time) > -1) {
-            index = this.fullDatesFromArray(datesArray).indexOf(time);
-            console.log('this is a full date', index);
-        }
-        if (this.weekDaysFromArray(datesArray).indexOf(weekDay) > -1) {
-            index = this.weekDaysFromArray(datesArray).indexOf(weekDay);
-            console.log('this is a weekday', index);
-        }
-        if (this.monthDaysFromArray(datesArray).indexOf(monthDay) > -1) {
-            index = this.monthDaysFromArray(datesArray).indexOf(monthDay);
-            console.log('this is a month day', index);
-        }
+        array
+            .map((x) => x.date)
+            .forEach((x, _index) => {
+                if (DAYS.includes(x)) {
+                    index = _index;
+                }
+
+                if (x === day.getDate()) {
+                    index = _index;
+                }
+
+                if (typeof x === 'object' && x.getTime() === day.getTime()) {
+                    index = _index;
+                }
+            });
 
         return index;
     }

--- a/src/modules/base/calendar/calendar.js
+++ b/src/modules/base/calendar/calendar.js
@@ -109,7 +109,8 @@ export default class Calendar extends LightningElement {
 
     set dateLabels(value) {
         this._dateLabels = value.map((x) => {
-            console.log(x.date);
+            console.log(new Date(x.date));
+            // console.log(new Date().setDate(x.date))
             const labelDate =
                 new Date(x.date).setHours(0, 0, 0, 0) !== NULL_DATE &&
                 !isNaN(Date.parse(x.date))
@@ -117,7 +118,6 @@ export default class Calendar extends LightningElement {
                     : x.date;
             return { date: labelDate, label: x.label };
         });
-        console.log(this._dateLabels);
     }
 
     /**
@@ -529,11 +529,13 @@ export default class Calendar extends LightningElement {
                     currentDate = true;
                 }
 
+                // chip label
                 // if (labeled) {
-                //     chipLabel = this._dateLabels.get(date)
+                //     this._dateLabels.keys(date).map(function(key){return date[key]})
+                //     console.log(this.formattedWithTimezoneOffset(new Date(date)))
+                //     // console.log(this.formattedWithTimezoneOffset(new Date(x.date)))
+                //     // chipLabel = this._dateLabels.get(date)
                 // }
-                // console.log(this.formattedWithTimezoneOffset(new Date(date)))
-                // console.log(this.formattedWithTimezoneOffset(new Date(x.date)))
 
                 // interval
                 this.endDateInInterval(this._value);

--- a/src/modules/base/calendar/calendar.js
+++ b/src/modules/base/calendar/calendar.js
@@ -110,7 +110,11 @@ export default class Calendar extends LightningElement {
 
     set dateLabels(value) {
         this._dateLabels = value.map((x) => {
-            // console.log(new Date().setDate(x.date))
+            console.log(
+                new Date(x.date).setHours(0, 0, 0, 0),
+                this.formattedWithTimezoneOffset(new Date(x.date)),
+                x.date
+            );
             const labelDate =
                 new Date(x.date).setHours(0, 0, 0, 0) !== NULL_DATE &&
                 !isNaN(Date.parse(x.date))
@@ -118,6 +122,7 @@ export default class Calendar extends LightningElement {
                     : x.date;
             return { date: labelDate, ...x };
         });
+        console.log(this._dateLabels);
     }
 
     /**
@@ -178,6 +183,11 @@ export default class Calendar extends LightningElement {
 
     set markedDates(value) {
         this._markedDates = value.map((x) => {
+            console.log(
+                new Date(x.date).setHours(0, 0, 0, 0),
+                this.formattedWithTimezoneOffset(new Date(x.date)),
+                x.date
+            );
             const isDate =
                 new Date(x.date).setHours(0, 0, 0, 0) !== NULL_DATE &&
                 !isNaN(Date.parse(x.date))
@@ -540,15 +550,27 @@ export default class Calendar extends LightningElement {
                 }
 
                 // chip label
-                const labeled =
-                    this.isInArray(date, this.labeledDatesArray) || false;
                 let labelIndex;
-                let iconPosition = 'left';
-                let showLeft = false;
-                let showRight = false;
-                if (labeled) {
+                if (this.isInArray(date, this.labeledDatesArray)) {
                     labelIndex = this.findArrayPosition(date, this._dateLabels);
-                    iconPosition = this._dateLabels[labelIndex].iconPosition;
+                }
+                let labeled =
+                    (this.isInArray(date, this.labeledDatesArray) &&
+                        labelIndex > -1) ||
+                    false;
+                let iconPosition;
+                let chipOuline;
+                let showLeft;
+                let showRight;
+                if (labeled) {
+                    iconPosition =
+                        labelIndex > -1
+                            ? this._dateLabels[labelIndex].iconPosition
+                            : 'left';
+                    chipOuline =
+                        this._dateLabels[labelIndex].outline === 'true'
+                            ? 'true'
+                            : 'false';
                     showLeft = iconPosition === 'left' ? true : false;
                     showRight = iconPosition === 'right' ? true : false;
                 }
@@ -606,6 +628,7 @@ export default class Calendar extends LightningElement {
                     chip: {
                         showLeft: showLeft,
                         showRight: showRight,
+                        outline: chipOuline,
                         ...this._dateLabels[labelIndex]
                     }
                 });
@@ -625,23 +648,24 @@ export default class Calendar extends LightningElement {
      * @param {object[]} array
      * @returns index
      */
-    findArrayPosition(date, array) {
+    findArrayPosition(day, array) {
+        let datesArray = array.map((x) => x.date);
+        let time = day.getTime();
+        let weekDay = day.getDay();
+        let monthDay = day.getDate();
         let index;
 
-        if (array.map((object) => object.date).indexOf(date.getDate()) > -1) {
-            index = this._dateLabels
-                .map((object) => object.date)
-                .indexOf(date.getDate());
+        if (this.fullDatesFromArray(datesArray).indexOf(time) > -1) {
+            index = this.fullDatesFromArray(datesArray).indexOf(time);
+            console.log('this is a full date', index);
         }
-        if (array.map((object) => object.date).indexOf(date.getDay()) > -1) {
-            index = this._dateLabels
-                .map((object) => object.date)
-                .indexOf(date.getDay());
+        if (this.weekDaysFromArray(datesArray).indexOf(weekDay) > -1) {
+            index = this.weekDaysFromArray(datesArray).indexOf(weekDay);
+            console.log('this is a weekday', index);
         }
-        if (array.map((object) => object.date).indexOf(date.getTime()) > -1) {
-            index = this._dateLabels
-                .map((object) => object.date)
-                .indexOf(date.getTime());
+        if (this.monthDaysFromArray(datesArray).indexOf(monthDay) > -1) {
+            index = this.monthDaysFromArray(datesArray).indexOf(monthDay);
+            console.log('this is a month day', index);
         }
 
         return index;

--- a/src/modules/base/calendar/calendar.js
+++ b/src/modules/base/calendar/calendar.js
@@ -109,7 +109,6 @@ export default class Calendar extends LightningElement {
 
     set dateLabels(value) {
         this._dateLabels = value.map((x) => {
-            console.log(new Date(x.date));
             // console.log(new Date().setDate(x.date))
             const labelDate =
                 new Date(x.date).setHours(0, 0, 0, 0) !== NULL_DATE &&
@@ -118,6 +117,7 @@ export default class Calendar extends LightningElement {
                     : x.date;
             return { date: labelDate, label: x.label };
         });
+        console.log(this._dateLabels);
     }
 
     /**
@@ -530,12 +530,38 @@ export default class Calendar extends LightningElement {
                 }
 
                 // chip label
-                // if (labeled) {
-                //     this._dateLabels.keys(date).map(function(key){return date[key]})
-                //     console.log(this.formattedWithTimezoneOffset(new Date(date)))
-                //     // console.log(this.formattedWithTimezoneOffset(new Date(x.date)))
-                //     // chipLabel = this._dateLabels.get(date)
-                // }
+                let chipLabel = '';
+                if (labeled) {
+                    let labelIndex;
+                    if (
+                        this._dateLabels
+                            .map((object) => object.date)
+                            .indexOf(date.getDate()) > -1
+                    ) {
+                        labelIndex = this._dateLabels
+                            .map((object) => object.date)
+                            .indexOf(date.getDate());
+                    }
+                    if (
+                        this._dateLabels
+                            .map((object) => object.date)
+                            .indexOf(date.getDay()) > -1
+                    ) {
+                        labelIndex = this._dateLabels
+                            .map((object) => object.date)
+                            .indexOf(date.getDay());
+                    }
+                    if (
+                        this._dateLabels
+                            .map((object) => object.date)
+                            .indexOf(date.getTime()) > -1
+                    ) {
+                        labelIndex = this._dateLabels
+                            .map((object) => object.date)
+                            .indexOf(date.getTime());
+                    }
+                    chipLabel = this._dateLabels[labelIndex].label;
+                }
 
                 // interval
                 this.endDateInInterval(this._value);
@@ -576,7 +602,6 @@ export default class Calendar extends LightningElement {
                     markedDate = true;
                 }
 
-                let chipLabel = label;
                 weekData.push({
                     label: label,
                     class: dateClass,

--- a/src/modules/base/calendar/calendar.js
+++ b/src/modules/base/calendar/calendar.js
@@ -82,6 +82,7 @@ export default class Calendar extends LightningElement {
     _min = DEFAULT_MIN;
     _selectionMode = SELECTION_MODES.default;
     _value = [];
+    _dateLabels = [];
     _weekNumber = false;
     date = DEFAULT_DATE;
     year;
@@ -93,6 +94,30 @@ export default class Calendar extends LightningElement {
 
     connectedCallback() {
         this.updateDateParameters();
+    }
+
+    /**
+     * Array of date labels. The dates should be a Date object, a timestamp, or an ISO8601 formatted string. The labels are strings
+     *
+     * @public
+     * @type {object[]}
+     */
+    @api
+    get dateLabels() {
+        return this._dateLabels;
+    }
+
+    set dateLabels(value) {
+        this._dateLabels = value.map((x) => {
+            console.log(x.date);
+            const labelDate =
+                new Date(x.date).setHours(0, 0, 0, 0) !== NULL_DATE &&
+                !isNaN(Date.parse(x.date))
+                    ? this.formattedWithTimezoneOffset(new Date(x.date))
+                    : x.date;
+            return { date: labelDate, label: x.label };
+        });
+        console.log(this._dateLabels);
     }
 
     /**
@@ -350,6 +375,15 @@ export default class Calendar extends LightningElement {
     }
 
     /**
+     * Generate array of dates from marked dates object.
+     */
+    get labeledDatesArray() {
+        return this.dateLabels.map((date) => {
+            return date.date;
+        });
+    }
+
+    /**
      * Create Dates array.
      *
      * @param {object[]} array
@@ -469,6 +503,7 @@ export default class Calendar extends LightningElement {
                 let disabled = this.isInArray(date, this.disabledDates);
                 const marked = this.isInArray(date, this.markedDatesArray);
                 const markedColors = this.isInArrayMarker(date);
+                const labeled = this.isInArray(date, this.labeledDatesArray);
                 let time = date.getTime();
                 let valueTime = this._value.length
                     ? this._value[0].getTime()
@@ -493,6 +528,12 @@ export default class Calendar extends LightningElement {
                     dateClass += ' slds-is-today';
                     currentDate = true;
                 }
+
+                // if (labeled) {
+                //     chipLabel = this._dateLabels.get(date)
+                // }
+                // console.log(this.formattedWithTimezoneOffset(new Date(date)))
+                // console.log(this.formattedWithTimezoneOffset(new Date(x.date)))
 
                 // interval
                 this.endDateInInterval(this._value);
@@ -533,6 +574,7 @@ export default class Calendar extends LightningElement {
                     markedDate = true;
                 }
 
+                let chipLabel = label;
                 weekData.push({
                     label: label,
                     class: dateClass,
@@ -541,7 +583,9 @@ export default class Calendar extends LightningElement {
                     currentDate: currentDate,
                     fullDate: fullDate,
                     marked: markedDate,
-                    markedColors: markedColors
+                    markedColors: markedColors,
+                    labeled: labeled,
+                    chipLabel: chipLabel
                 });
 
                 date.setDate(date.getDate() + 1);

--- a/src/modules/base/calendar/calendar.js
+++ b/src/modules/base/calendar/calendar.js
@@ -117,6 +117,7 @@ export default class Calendar extends LightningElement {
                     : x.date;
             return { date: labelDate, ...x };
         });
+        this.updateDateParameters();
     }
 
     /**
@@ -540,26 +541,22 @@ export default class Calendar extends LightningElement {
 
                 // chip label
                 let labelIndex;
-                if (this.isInArray(date, this.labeledDatesArray)) {
-                    labelIndex = this.findArrayPosition(date, this._dateLabels);
-                }
-                let labeled =
-                    (this.isInArray(date, this.labeledDatesArray) &&
-                        labelIndex > -1) ||
-                    false;
+                let labeled = false;
                 let iconPosition;
-                let chipOuline;
                 let showLeft = false;
                 let showRight = false;
+                let labelClasses;
+                if (this.isInArray(date, this.labeledDatesArray)) {
+                    labelIndex = this.findArrayPosition(date, this._dateLabels);
+                    if (this.isInArray(date, this.labeledDatesArray)) {
+                        labeled = true;
+                    }
+                }
                 if (labeled) {
                     iconPosition =
                         labelIndex > -1
                             ? this._dateLabels[labelIndex].iconPosition
                             : 'left';
-                    chipOuline =
-                        this._dateLabels[labelIndex].outline === true
-                            ? true
-                            : false;
                     if (
                         iconPosition === 'left' &&
                         this._dateLabels[labelIndex].iconName?.length > 0
@@ -572,6 +569,16 @@ export default class Calendar extends LightningElement {
                     ) {
                         showRight = true;
                     }
+                    let iconOnlyLabel =
+                        (this._dateLabels[labelIndex].iconName?.length > 0 &&
+                            (this._dateLabels[labelIndex].label?.length < 1 ||
+                                !this._dateLabels[labelIndex].label)) ||
+                        false;
+                    labelClasses = classSet('avonni-calendar__chip-label')
+                        .add({
+                            'avonni-calendar__chip-icon-only': iconOnlyLabel
+                        })
+                        .toString();
                 }
 
                 // interval
@@ -626,8 +633,8 @@ export default class Calendar extends LightningElement {
                     chip: {
                         showLeft: showLeft,
                         showRight: showRight,
-                        ...this._dateLabels[labelIndex],
-                        outline: chipOuline
+                        classes: labelClasses,
+                        ...this._dateLabels[labelIndex]
                     }
                 });
 

--- a/src/modules/base/chip/__docs__/chip.jsdoc.js
+++ b/src/modules/base/chip/__docs__/chip.jsdoc.js
@@ -259,7 +259,7 @@
  * @memberof stylingHooks
  * @name --avonni-chip-line-height
  * @default normal
- * @type line-height
+ * @type dimension
  */
 /**
  * @memberof stylingHooks

--- a/src/modules/base/chip/__docs__/chip.jsdoc.js
+++ b/src/modules/base/chip/__docs__/chip.jsdoc.js
@@ -261,3 +261,27 @@
  * @default normal
  * @type line-height
  */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-chip-spacing-block-start
+ * @default 0.25rem
+ * @type dimension
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-chip-spacing-block-start
+ * @default 0.25rem
+ * @type dimension
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-chip-spacing-inline-start
+ * @default 0.5rem
+ * @type dimension
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-chip-spacing-inline-start
+ * @default 0.5rem
+ * @type dimension
+ */

--- a/src/modules/base/chip/__docs__/chip.jsdoc.js
+++ b/src/modules/base/chip/__docs__/chip.jsdoc.js
@@ -269,7 +269,7 @@
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-chip-spacing-block-start
+ * @name --avonni-chip-spacing-block-end
  * @default 0.25rem
  * @type dimension
  */
@@ -281,7 +281,23 @@
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-chip-spacing-inline-start
+ * @name --avonni-chip-spacing-inline-end
+ * @default 0.5rem
+ * @type dimension
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-chip-sizing-width
+ * @type dimension
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-chip-sizing-max-width
+ * @type dimension
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-chip-sizing-height
  * @default 0.5rem
  * @type dimension
  */

--- a/src/modules/base/chip/chip.css
+++ b/src/modules/base/chip/chip.css
@@ -31,7 +31,10 @@
  */
 
 .avonni-chip {
-    padding: 0.25rem 0.5rem;
+    padding-top: var(--avonni-chip-spacing-block-start, 0.25rem);
+    padding-bottom: var(--avonni-chip-spacing-block-end, 0.25rem);
+    padding-left: var(--avonni-chip-spacing-inline-start, 0.5rem);
+    padding-right: var(--avonni-chip-spacing-inline-end, 0.5rem);
     border-width: var(--avonni-chip-sizing-border, 1px);
     border-style: var(--avonni-chip-styling-border, solid);
     border-radius: var(--avonni-chip-radius-border, 15rem);
@@ -45,6 +48,7 @@
     -webkit-box-align: center;
     -ms-flex-align: center;
     align-items: center;
+    width: var(--avonni-chip-sizing-width);
 }
 .avonni-chip_outline {
     background-color: #ffffff !important;

--- a/src/modules/base/chip/chip.css
+++ b/src/modules/base/chip/chip.css
@@ -49,6 +49,7 @@
     -ms-flex-align: center;
     align-items: center;
     width: var(--avonni-chip-sizing-width);
+    max-width: var(--avonni-chip-sizing-max-width);
 }
 .avonni-chip_outline {
     background-color: #ffffff !important;

--- a/src/modules/base/chip/chip.css
+++ b/src/modules/base/chip/chip.css
@@ -50,7 +50,7 @@
     align-items: center;
     width: var(--avonni-chip-sizing-width);
     max-width: var(--avonni-chip-sizing-max-width);
-    height: var(--avonni-ship-sizing-height);
+    height: var(--avonni-chip-sizing-height);
     overflow-y: hidden;
 }
 .avonni-chip_outline {

--- a/src/modules/base/chip/chip.css
+++ b/src/modules/base/chip/chip.css
@@ -50,6 +50,8 @@
     align-items: center;
     width: var(--avonni-chip-sizing-width);
     max-width: var(--avonni-chip-sizing-max-width);
+    height: var(--avonni-ship-sizing-height);
+    overflow-y: hidden;
 }
 .avonni-chip_outline {
     background-color: #ffffff !important;

--- a/src/modules/base/chip/chip.html
+++ b/src/modules/base/chip/chip.html
@@ -39,7 +39,7 @@
                 <slot name="left"></slot>
             </span>
         </template>
-        {label}
+        <span class="slds-truncate">{label}</span>
         <template if:true={showRight}>
             <span class="slds-badge__icon slds-badge__icon_right">
                 <slot name="right"></slot>

--- a/src/modules/base/list/__docs__/list.jsdoc.js
+++ b/src/modules/base/list/__docs__/list.jsdoc.js
@@ -59,8 +59,8 @@
 /**
  * @memberof stylingHooks
  * @name --avonni-list-header-line-height
- * @default 1.25
- * @type line-height
+ * @default 1.25rem
+ * @type dimension
  */
 /**
  * @memberof stylingHooks

--- a/src/modules/base/verticalVisualPicker/__docs__/verticalVisualPicker.jsdoc.js
+++ b/src/modules/base/verticalVisualPicker/__docs__/verticalVisualPicker.jsdoc.js
@@ -120,8 +120,8 @@
 /**
  * @memberof stylingHooks
  * @name --avonni-vertical-visual-picker-description-line-height
- * @default 1.25
- * @type line-height
+ * @default 1.25rem
+ * @type dimension
  */
 /**
  * @memberof stylingHooks

--- a/src/modules/base/visualPicker/__docs__/visualPicker.jsdoc.js
+++ b/src/modules/base/visualPicker/__docs__/visualPicker.jsdoc.js
@@ -142,8 +142,8 @@
 /**
  * @memberof stylingHooks
  * @name --avonni-visual-picker-item-description-line-height
- * @default 1.25
- * @type line-height
+ * @default 1.25rem
+ * @type dimension
  */
 /**
  * @memberof stylingHooks
@@ -220,8 +220,8 @@
 /**
  * @memberof stylingHooks
  * @name --avonni-visual-picker-description-line-height
- * @default 1.25
- * @type line-height
+ * @default 1.25rem
+ * @type dimension
  */
 /**
  * @memberof stylingHooks


### PR DESCRIPTION
**Calendar date labels and chip hooks**

https://avonnicreator.atlassian.net/wiki/spaces/ABC/pages/352976919/Calendar
Set dimensions for default and labeled calendar
Default: 40 x 40px
Labeled: w x h, 70 x 60px

Updated calendar interval selection behavior. 
In interval mode, when clicking a date before a selection, the selection extends to include that day instead of resetting the selection. 

Fix: Hover borders no longer cause dimension changes. 

https://avonnicreator.atlassian.net/wiki/spaces/ABC/pages/1424064563/Chip
Add hooks to chip
- [x] --avonni-chip-spacing-block-start
- [x] --avonni-chip-spacing-block-end
- [x] --avonni-chip-spacing-inline-start
- [x] --avonni-chip-spacing-inline-end
added truncated text when label larger than chip
max-width 100% added to chip