### PR TITLE
[feat] (ABC-457): Add normalizeObject and improve normalizeArray

### DIFF
--- a/src/modules/base/list/list.js
+++ b/src/modules/base/list/list.js
@@ -144,7 +144,7 @@ export default class List extends LightningElement {
     /**
      * Array of item objects.
      *
-     * @type {object}
+     * @type {object[]}
      * @public
      */
     @api
@@ -152,7 +152,7 @@ export default class List extends LightningElement {
         return this._items;
     }
     set items(proxy) {
-        this._items = normalizeArray(proxy);
+        this._items = normalizeArray(proxy, 'object');
         this.computedItems = JSON.parse(JSON.stringify(this._items));
         this.computedItems.forEach((item) => {
             item.infos = normalizeArray(item.infos);

--- a/src/modules/base/utilsPrivate/normalize.js
+++ b/src/modules/base/utilsPrivate/normalize.js
@@ -44,6 +44,13 @@ export function normalizeBoolean(value) {
     return typeof value === 'string' || !!value;
 }
 
+/**
+ * Normalize a given value into an array.
+ *
+ * @param {any} value Value that should be an array.
+ * @param {string} entryType Type of the array entries. Valid values inclue string, number, boolean and object. If given, only the entries of the correct type will be left in the array.
+ * @returns {any[]} Normalized array.
+ */
 export function normalizeArray(value, entryType) {
     if (Array.isArray(value)) {
         switch (entryType) {

--- a/src/modules/base/utilsPrivate/normalize.js
+++ b/src/modules/base/utilsPrivate/normalize.js
@@ -44,8 +44,31 @@ export function normalizeBoolean(value) {
     return typeof value === 'string' || !!value;
 }
 
-export function normalizeArray(value) {
+export function normalizeArray(value, entryType) {
     if (Array.isArray(value)) {
+        switch (entryType) {
+            case 'string':
+                return value.filter((entry) => normalizeString(entry));
+            case 'boolean':
+                return value.map((entry) => normalizeBoolean(entry));
+            case 'number': {
+                const numbers = [];
+                value.forEach((entry) => {
+                    const number = Number(entry);
+                    if (!isNaN(number)) {
+                        numbers.push(number);
+                    }
+                });
+                return numbers;
+            }
+            case 'object':
+                return value.filter((entry) => {
+                    const object = normalizeObject(entry);
+                    return Object.keys(object).length;
+                });
+            default:
+                break;
+        }
         return value;
     }
     return [];
@@ -63,4 +86,15 @@ export function normalizeAriaAttribute(value) {
         .filter((ariaValue) => !!ariaValue);
 
     return arias.length > 0 ? arias.join(' ') : null;
+}
+
+export function normalizeObject(value) {
+    if (
+        value &&
+        value.constructor === Object &&
+        Object.getPrototypeOf(value) === Object.prototype
+    ) {
+        return value;
+    }
+    return {};
 }

--- a/src/modules/base/utilsPrivate/utilsPrivate.js
+++ b/src/modules/base/utilsPrivate/utilsPrivate.js
@@ -41,7 +41,8 @@ export {
     normalizeBoolean,
     normalizeString,
     normalizeArray,
-    normalizeAriaAttribute
+    normalizeAriaAttribute,
+    normalizeObject
 } from './normalize';
 export {
     generateColors,


### PR DESCRIPTION
_This pull request should not be reflected in the release notes, only utils have been changed._

- Added `normalizeObject` (only accepts direct prototypes of `Object` — not `Date`, `Array`, `null`, etc.).
- `normalizeArray` now accepts a second argument: the type of the array entries. Valid values are `string`, `number`, `boolean` and `object`.