### PR TITLE
[fix] (ABC-528): Dispatch string or array value in calendar change event

### DIFF
--- a/src/modules/base/calendar/__tests__/calendar.test.js
+++ b/src/modules/base/calendar/__tests__/calendar.test.js
@@ -443,20 +443,36 @@ describe('Calendar', () => {
         element.addEventListener('change', handler);
 
         return Promise.resolve().then(() => {
-            element.dispatchEvent(
-                new CustomEvent('change', {
-                    detail: {
-                        value: element.value
-                    }
-                })
-            );
+            const days = element.shadowRoot.querySelectorAll('[data-element-id="span-day-label"]');
+            const day7 = days[12];
+            day7.click();
+
             expect(handler).toHaveBeenCalled();
-            expect(handler.mock.calls[0][0].detail.value).toMatchObject([
-                new Date('05/09/2021')
-            ]);
-            expect(handler.mock.calls[0][0].bubbles).toBeFalsy();
-            expect(handler.mock.calls[0][0].composed).toBeFalsy();
-            expect(handler.mock.calls[0][0].cancelable).toBeFalsy();
+            const call = handler.mock.calls[0][0];
+            expect(call.detail.value).toBe('2021-05-07');
+            expect(call.bubbles).toBeFalsy();
+            expect(call.composed).toBeFalsy();
+            expect(call.cancelable).toBeFalsy();
+        });
+    });
+
+    it('Calendar event change selection-mode: multiple', () => {
+        element.value = '05/09/2021';
+        element.selectionMode = 'multiple';
+        element.min = new Date('05/01/2021');
+        element.max = new Date('05/31/2021');
+
+        const handler = jest.fn();
+        element.addEventListener('change', handler);
+
+        return Promise.resolve().then(() => {
+            const days = element.shadowRoot.querySelectorAll('[data-element-id="span-day-label"]');
+            const day7 = days[12];
+            day7.click();
+
+            expect(handler).toHaveBeenCalled();
+            const call = handler.mock.calls[0][0];
+            expect(call.detail.value).toEqual(['2021-05-09', '2021-05-07']);
         });
     });
 
@@ -476,9 +492,6 @@ describe('Calendar', () => {
             day9.click();
             expect(handler).toHaveBeenCalled();
             expect(handler.mock.calls[0][0].detail.value).toMatchObject([]);
-            expect(handler.mock.calls[0][0].bubbles).toBeFalsy();
-            expect(handler.mock.calls[0][0].composed).toBeFalsy();
-            expect(handler.mock.calls[0][0].cancelable).toBeFalsy();
         });
     });
 
@@ -497,13 +510,10 @@ describe('Calendar', () => {
             );
             day11.click();
             expect(handler).toHaveBeenCalled();
-            expect(handler.mock.calls[0][0].detail.value).toMatchObject([
-                new Date('05/09/2021'),
-                new Date('05/11/2021')
+            expect(handler.mock.calls[0][0].detail.value).toEqual([
+                '2021-05-09',
+                '2021-05-11'
             ]);
-            expect(handler.mock.calls[0][0].bubbles).toBeFalsy();
-            expect(handler.mock.calls[0][0].composed).toBeFalsy();
-            expect(handler.mock.calls[0][0].cancelable).toBeFalsy();
         });
     });
 });

--- a/src/modules/base/calendar/calendar.js
+++ b/src/modules/base/calendar/calendar.js
@@ -381,7 +381,7 @@ export default class Calendar extends LightningElement {
     }
 
     get normalizedValue() {
-        const stringDates = this.value.map((date) => {
+        const stringDates = this.value.map(date => {
             const stringDate = date.toISOString();
             return stringDate.match(/^\d{4}-\d{2}-\d{2}/)[0];
         });
@@ -891,7 +891,6 @@ export default class Calendar extends LightningElement {
                 }
             })
         );
-        console.log(this.normalizedValue);
     }
 
     /**

--- a/src/modules/base/calendar/calendar.js
+++ b/src/modules/base/calendar/calendar.js
@@ -251,10 +251,10 @@ export default class Calendar extends LightningElement {
     }
 
     /**
-     * The value of the date selected, which can be a Date object, timestamp, or an ISO8601 formatted string.
+     * The value of the selected date(s). Dates can be a Date object, timestamp, or an ISO8601 formatted string.
      *
      * @public
-     * @type {string}
+     * @type {string|string[]}
      */
     @api
     get value() {
@@ -378,6 +378,14 @@ export default class Calendar extends LightningElement {
         return this.markedDates.map((date) => {
             return date.date;
         });
+    }
+
+    get normalizedValue() {
+        const stringDates = this.value.map((date) => {
+            const stringDate = date.toISOString();
+            return stringDate.match(/^\d{4}-\d{2}-\d{2}/)[0];
+        });
+        return this.selectionMode === 'single' ? stringDates[0] : stringDates;
     }
 
     /**
@@ -837,6 +845,9 @@ export default class Calendar extends LightningElement {
      * @param {object} event
      */
     handlerSelectDate(event) {
+        // Prevent selecting week numbers
+        if (!event.currentTarget.dataset.day) return;
+
         let date = new Date(Number(event.target.dataset.day));
         const disabledDate = Array.from(event.target.classList).includes(
             'avonni-calendar__disabled-cell'
@@ -871,15 +882,16 @@ export default class Calendar extends LightningElement {
          * @event
          * @public
          * @name change
-         * @param {string} value Selected date.
+         * @param {string|string[]} value Selected date(s), as an ISO8601 formatted string. Returns a string if the selection mode is single. Returns an array of dates otherwise.
          */
         this.dispatchEvent(
             new CustomEvent('change', {
                 detail: {
-                    value: this._value
+                    value: this.normalizedValue
                 }
             })
         );
+        console.log(this.normalizedValue);
     }
 
     /**

--- a/src/modules/base/dateTimePicker/dateTimePicker.js
+++ b/src/modules/base/dateTimePicker/dateTimePicker.js
@@ -1188,9 +1188,14 @@ export default class DateTimePicker extends LightningElement {
      * Handles the onchange event of the lightning-input to change the date.
      */
     handleDateChange(event) {
-        const dateString = event.detail.value
-            .toString()
-            .match(/^(\d{4})-(\d{2})-(\d{2})$/);
+        const value = event.detail.value;
+        if (!value || typeof value !== 'string') {
+            // Prevent unselection of a date
+            event.currentTarget.value = this.firstWeekDayToString;
+            return;
+        }
+
+        const dateString = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
 
         if (dateString) {
             const year = dateString[1];

--- a/src/modules/base/inputDateRange/inputDateRange.js
+++ b/src/modules/base/inputDateRange/inputDateRange.js
@@ -684,32 +684,34 @@ export default class InputDateRange extends LightningElement {
      * Handles the change of start-date on c-calendar.
      */
     handleChangeStartDate(event) {
-        const date = event.detail.value;
+        const value = event.detail.value;
+        const normalizedValue = value instanceof Array ? value : [value];
+        const dates = normalizedValue.map((date) => new Date(date));
 
         // Handler if there is a start date and there is an end date.
         if (this.areBothDatePresent) {
-            if (date[1] > this._endDate) {
-                this._startDate = new Date(date[1]);
-            } else if (date[0] < this._startDate) {
-                this._startDate = new Date(date[0]);
+            if (dates[1] > this._endDate) {
+                this._startDate = new Date(dates[1]);
+            } else if (dates[0] < this._startDate) {
+                this._startDate = new Date(dates[0]);
                 // If user click on the same date.
-            } else if (date.length === 1) {
+            } else if (dates.length === 1) {
                 this._startDate = null;
             } else {
-                this._startDate = new Date(date[1]);
+                this._startDate = new Date(dates[1]);
             }
             // If there is no start date, but there is an end date.
         } else if (this.isOnlyEndDate) {
-            if (date[1] > this._endDate) {
-                this._startDate = new Date(date[1]);
-            } else if (date.length === 0) {
+            if (dates[1] > this._endDate) {
+                this._startDate = new Date(dates[1]);
+            } else if (dates.length === 0) {
                 this._startDate = this._endDate;
             } else {
-                this._startDate = new Date(date[0]);
+                this._startDate = new Date(dates[0]);
             }
             // If there is no start date and no end date.
         } else {
-            this._startDate = date[0] ? new Date(date[0]) : null;
+            this._startDate = dates[0] ? new Date(dates[0]) : null;
         }
 
         event.stopPropagation();
@@ -816,26 +818,28 @@ export default class InputDateRange extends LightningElement {
      * Handles the change of end-date on c-calendar.
      */
     handleChangeEndDate(event) {
-        const date = event.detail.value;
+        const value = event.detail.value;
+        const normalizedValue = value instanceof Array ? value : [value];
+        const dates = normalizedValue.map((date) => new Date(date));
 
         // Handler if there is an end date and there is no start date.
-        if (date.length === 1 && !this._startDate) {
-            this._endDate = new Date(date[0]);
+        if (dates.length === 1 && !this._startDate) {
+            this._endDate = new Date(dates[0]);
             // Handler if there is no end date, but there is a start date.
         } else if (this.isOnlyStartDate) {
-            if (date[1] > this._startDate) {
-                this._endDate = new Date(date[1]);
-            } else if (date.length === 0) {
+            if (dates[1] > this._startDate) {
+                this._endDate = new Date(dates[1]);
+            } else if (dates.length === 0) {
                 this._endDate = this._startDate;
             } else {
-                this._endDate = new Date(date[0]);
+                this._endDate = new Date(dates[0]);
             }
             // Handler if there is no end date and no start date or both date.
         } else {
-            if (date[1]) {
-                this._endDate = new Date(date[1]);
+            if (dates[1]) {
+                this._endDate = new Date(dates[1]);
             } else {
-                this._startDate = date[0] ? new Date(date[0]) : null;
+                this._startDate = dates[0] ? new Date(dates[0]) : null;
                 // For the case of clicking on the same date to delete it.
                 this._endDate = null;
             }
@@ -843,8 +847,8 @@ export default class InputDateRange extends LightningElement {
 
         // selecting 'end date' earlier than 'start date', make that the new 'end date', void 'start date', open start date picker
         if (this.areBothDatePresent) {
-            if (date[0] < this._startDate) {
-                this._endDate = date[0];
+            if (dates[0] < this._startDate) {
+                this._endDate = dates[0];
                 this._startDate = null;
             }
         }


### PR DESCRIPTION
### Fixes
**Calendar**
- The `change` event value is an ISO formatted string if the selection mode is `single`, or an array of ISO formatted strings otherwise.