### PR TITLE
[fix] (ABC-529): Do not allow dragging of the action menu in list

### DIFF
--- a/src/modules/base/list/list.html
+++ b/src/modules/base/list/list.html
@@ -219,7 +219,8 @@
                             icon-size="x-small"
                             data-element-id="lightning-button-menu"
                             data-item-index={index}
-                            ontouchstart={handleButtonMenuTouchStart}
+                            onmousedown={stopPropagation}
+                            ontouchstart={stopPropagation}
                             onselect={handleActionClick}
                         >
                             <template
@@ -240,7 +241,6 @@
                             <lightning-button
                                 if:true={firstAction.label}
                                 class="slds-m-right_none"
-                                ontouchstart={handleButtonMenuTouchStart}
                                 key={firstAction.name}
                                 value={firstAction.name}
                                 label={firstAction.label}
@@ -249,11 +249,11 @@
                                 data-item-index={index}
                                 data-element-id="lightning-button"
                                 onclick={handleActionClick}
+                                ontouchstart={stopPropagation}
                             ></lightning-button>
                             <lightning-button-icon
                                 if:false={firstAction.label}
                                 class="slds-m-right_none"
-                                ontouchstart={handleButtonMenuTouchStart}
                                 key={firstAction.name}
                                 value={firstAction.name}
                                 disabled={firstAction.disabled}
@@ -262,6 +262,7 @@
                                 data-item-index={index}
                                 data-element-id="lightning-button-icon"
                                 onclick={handleActionClick}
+                                ontouchstart={stopPropagation}
                             ></lightning-button-icon>
                         </template>
                     </div>

--- a/src/modules/base/list/list.js
+++ b/src/modules/base/list/list.js
@@ -721,15 +721,6 @@ export default class List extends LightningElement {
     }
 
     /**
-     * Stop the dragging process when touching the button menu.
-     *
-     * @param {Event} event
-     */
-    handleButtonMenuTouchStart(event) {
-        event.stopPropagation();
-    }
-
-    /**
      * Handles a click on an item action.
      *
      * @param {Event} event
@@ -789,5 +780,14 @@ export default class List extends LightningElement {
                 }
             })
         );
+    }
+
+    /**
+     * Stop the propagation of an event.
+     *
+     * @param {Event} event
+     */
+    stopPropagation(event) {
+        event.stopPropagation();
     }
 }


### PR DESCRIPTION
### Fixes
**List**
- In sortable lists with actions, prevented an item from being dragged when the user clicked and held an action menu item.