### PR TITLE
[fix] (ABC-536): Keep the combobox opened on the right level when new options are set

### DIFF
--- a/src/modules/base/calendar/__tests__/calendar.test.js
+++ b/src/modules/base/calendar/__tests__/calendar.test.js
@@ -449,7 +449,8 @@ describe('Calendar', () => {
 
             expect(handler).toHaveBeenCalled();
             const call = handler.mock.calls[0][0];
-            expect(call.detail.value).toBe('2021-05-07');
+            const normalizedDate = new Date('05/07/2021').toISOString();
+            expect(call.detail.value).toBe(normalizedDate);
             expect(call.bubbles).toBeFalsy();
             expect(call.composed).toBeFalsy();
             expect(call.cancelable).toBeFalsy();
@@ -474,7 +475,12 @@ describe('Calendar', () => {
 
             expect(handler).toHaveBeenCalled();
             const call = handler.mock.calls[0][0];
-            expect(call.detail.value).toEqual(['2021-05-09', '2021-05-07']);
+            const normalizedFirst = new Date('05/09/2021').toISOString();
+            const normalizedSecond = new Date('05/07/2021').toISOString();
+            expect(call.detail.value).toEqual([
+                normalizedFirst,
+                normalizedSecond
+            ]);
         });
     });
 
@@ -512,9 +518,11 @@ describe('Calendar', () => {
             );
             day11.click();
             expect(handler).toHaveBeenCalled();
+            const normalizedStart = new Date('05/09/2021').toISOString();
+            const normalizedEnd = new Date('05/11/2021').toISOString();
             expect(handler.mock.calls[0][0].detail.value).toEqual([
-                '2021-05-09',
-                '2021-05-11'
+                normalizedStart,
+                normalizedEnd
             ]);
         });
     });

--- a/src/modules/base/combobox/combobox.js
+++ b/src/modules/base/combobox/combobox.js
@@ -212,7 +212,7 @@ export default class Combobox extends LightningElement {
      * Action object. The back action is used to go back to the previous level, after clicking on an option that has nested options.
      *
      * @type {object}
-     * @default { iconName: 'utility:chevronright', label: Label of the parent option }
+     * @default { iconName: 'utility:chevronleft', label: Label of the parent option }
      * @public
      */
     @api

--- a/src/modules/base/primitiveCombobox/primitiveCombobox.js
+++ b/src/modules/base/primitiveCombobox/primitiveCombobox.js
@@ -409,6 +409,12 @@ export default class PrimitiveCombobox extends LightningElement {
 
         if (this._connected) {
             this.initValue();
+            this.visibleOptions = this.currentParent
+                ? this.currentParent.options
+                : this.options;
+            this.showLoader = this.currentParent
+                ? this.currentParent.isLoading
+                : this.isLoading;
         }
     }
 


### PR DESCRIPTION
### Combobox
**Fixes**
- If new options are set after a `levelchange` event, the combobox will stay open and display the updated options for the level picked.