### PR TITLE
[fix] (ABC-541): Fix vertical selected options in combobox

### DIFF
--- a/src/modules/base/combobox/combobox.html
+++ b/src/modules/base/combobox/combobox.html
@@ -117,7 +117,7 @@
                 actions={selectedOptionsActions}
                 alternative-text={selectedOptionsAriaLabel}
                 items={selectedOptions}
-                sortable={sortableSelectedOptions}
+                sortable={normalizedSelectedOptions}
                 data-element-id="avonni-pill-container"
                 onactionclick={handleRemovePill}
                 onreorder={handleReorderSelectedOptions}
@@ -132,7 +132,7 @@
                 actions={selectedOptionsActions}
                 alternative-text={selectedOptionsAriaLabel}
                 divider="around"
-                items={selectedOptions}
+                items={normalizedSelectedOptions}
                 sortable={sortableSelectedOptions}
                 data-element-id="avonni-list"
                 onactionclick={handleRemoveListItem}

--- a/src/modules/base/combobox/combobox.js
+++ b/src/modules/base/combobox/combobox.js
@@ -667,6 +667,15 @@ export default class Combobox extends LightningElement {
     }
 
     /**
+     * Selected options copied and converted to regular objects.
+     *
+     * @type {object[]}
+     */
+    get normalizedSelectedOptions() {
+        return deepCopy(this.selectedOptions);
+    }
+
+    /**
      * True if the selected options are visible and displayed as horizontal pills.
      *
      * @type {boolean}

--- a/src/modules/base/list/__docs__/list.jsdoc.js
+++ b/src/modules/base/list/__docs__/list.jsdoc.js
@@ -6,7 +6,9 @@
  * @property {string} href The URL of the page the link goes to.
  * @property {string[]} icons List of iconName display next to the label.
  * @property {string} imageSrc Image URL for the list item image. If present, the image is disaplyed to the left of the item.
- * @property {object} infos List of additional information to display. Fields:- label: string- href: string
+ * @property {object} infos List of additional information to display. Valid keys:
+ * - label: string
+ * - href: string
  * @property {string} label Required. Label of the item.
  */
 /**


### PR DESCRIPTION
### Fixes
**Combobox**
- Fixed `selected-options-direction` with vertical value.