### PR TITLE
Add name to fields in pill container items

### DIFF
--- a/src/modules/base/pillContainer/__docs__/pillContainer.jsdoc.js
+++ b/src/modules/base/pillContainer/__docs__/pillContainer.jsdoc.js
@@ -21,6 +21,7 @@
  * @name items
  * @property {string} href Url of the page that the pill's link goes to.
  * @property {string} label Text to display in the pill.
+ * @property {string} name Name to identify the pill.
  * @property {object} avatar Avatar object. If present, the avatar is displayed to the left of the label.
  */
 


### PR DESCRIPTION
The labels are present already but the doc was missing. 
https://avonnicreator.atlassian.net/wiki/spaces/ABC/pages/2109734917/Pill+Container