### PR TITLE
[fix] (ABC-545): Prevent selected opt. removal when combobox is disabled

### DIFF
--- a/src/modules/base/combobox/combobox.html
+++ b/src/modules/base/combobox/combobox.html
@@ -116,8 +116,8 @@
             <c-pill-container
                 actions={selectedOptionsActions}
                 alternative-text={selectedOptionsAriaLabel}
-                items={selectedOptions}
-                sortable={normalizedSelectedOptions}
+                items={normalizedSelectedOptions}
+                sortable={sortableSelectedOptions}
                 data-element-id="avonni-pill-container"
                 onactionclick={handleRemovePill}
                 onreorder={handleReorderSelectedOptions}

--- a/src/modules/base/combobox/combobox.js
+++ b/src/modules/base/combobox/combobox.js
@@ -170,7 +170,6 @@ export default class Combobox extends LightningElement {
     _variant = VARIANTS.default;
 
     selectedOptions = [];
-    selectedOptionsActions = SELECTED_OPTIONS_ACTIONS;
     scopesValue;
 
     /*
@@ -435,9 +434,6 @@ export default class Combobox extends LightningElement {
     }
     set readOnly(value) {
         this._readOnly = normalizeBoolean(value);
-        this.selectedOptionsActions = this._readOnly
-            ? []
-            : SELECTED_OPTIONS_ACTIONS;
     }
 
     /**
@@ -673,6 +669,15 @@ export default class Combobox extends LightningElement {
      */
     get normalizedSelectedOptions() {
         return deepCopy(this.selectedOptions);
+    }
+
+    /**
+     * Array of actions displayed on the selected options pills. Return a unique remove action, or an empty array, if disabled or read-only.
+     *
+     * @type {object[]}
+     */
+    get selectedOptionsActions() {
+        return this.readOnly || this.disabled ? [] : SELECTED_OPTIONS_ACTIONS;
     }
 
     /**


### PR DESCRIPTION
### Fixes
**Combobox**
- Removed the "remove" action on selected options, when the combobox is disabled.