### PR TITLE
[fix] (ABC-580): Input Counter - Fix '-' and '+' alignment 

### DIFF
--- a/src/modules/base/inputCounter/inputCounter.css
+++ b/src/modules/base/inputCounter/inputCounter.css
@@ -31,18 +31,14 @@
  */
 .slds-input__button_decrement {
     position: absolute;
-    top: 50%;
-    -webkit-transform: translateY(-50%);
-    transform: translateY(-50%);
+    top: 1rem;
     left: 0.75rem;
     bottom: auto;
 }
 
 .slds-input__button_increment {
     position: absolute;
-    top: 50%;
-    -webkit-transform: translateY(-50%);
-    transform: translateY(-50%);
+    top: 1rem;
     right: 0.75rem;
     bottom: auto;
 }


### PR DESCRIPTION
### Fixes
Input Counter
- '-' and '+' now scale relative to top of input rather than height of element, which was bigger when a help message was shown