### PR TITLE
[fix] (ABC-630): Normalize relationship graph query selectors

### DIFF
--- a/src/modules/base/relationshipGraph/__tests__/relationshipGraph.test.js
+++ b/src/modules/base/relationshipGraph/__tests__/relationshipGraph.test.js
@@ -866,7 +866,7 @@ describe('RelationshipGraph', () => {
             const actionsWrapper =
                 element.shadowRoot.querySelector('div:nth-of-type(2)');
             const actionButtons = element.shadowRoot.querySelectorAll('button');
-            const line = element.shadowRoot.querySelector('.line');
+            const line = element.shadowRoot.querySelector('[data-element-id="div-line"]');
 
             expect(level.variant).toBe('horizontal');
             expect(wrapper.classList).toContain('slds-grid');
@@ -908,7 +908,7 @@ describe('RelationshipGraph', () => {
             const actionsWrapper =
                 element.shadowRoot.querySelector('div:nth-of-type(2)');
             const actionButtons = element.shadowRoot.querySelectorAll('button');
-            const line = element.shadowRoot.querySelector('.line');
+            const line = element.shadowRoot.querySelector('[data-element-id="div-line"]');
 
             expect(level.variant).toBe('vertical');
             expect(wrapper.classList).not.toContain('slds-grid');

--- a/src/modules/base/relationshipGraph/relationshipGraph.html
+++ b/src/modules/base/relationshipGraph/relationshipGraph.html
@@ -75,7 +75,7 @@
     </div>
 
     <div class={wrapperClass}>
-        <div class={lineClass}></div>
+        <div class={lineClass} data-element-id="div-line"></div>
 
         <!-- Levels -->
         <c-primitive-relationship-graph-level
@@ -90,6 +90,7 @@
             group-actions-position={groupActionsPosition}
             item-actions={itemActions}
             hide-items-count={hideItemsCount}
+            data-element-id="avonni-primitive-relationship-graph-level"
         ></c-primitive-relationship-graph-level>
     </div>
 </template>

--- a/src/modules/base/relationshipGraph/relationshipGraph.js
+++ b/src/modules/base/relationshipGraph/relationshipGraph.js
@@ -297,7 +297,7 @@ export default class RelationshipGraph extends LightningElement {
      */
     get childLevel() {
         return this.template.querySelector(
-            'c-primitive-relationship-graph-level'
+            '[data-element-id="avonni-primitive-relationship-graph-level"]'
         );
     }
 
@@ -359,7 +359,7 @@ export default class RelationshipGraph extends LightningElement {
      * @type {string}
      */
     get lineClass() {
-        return classSet('line').add({
+        return classSet().add({
             line_vertical: this.variant === 'horizontal',
             'line_horizontal slds-m-bottom_large': this.variant === 'vertical'
         });
@@ -377,7 +377,7 @@ export default class RelationshipGraph extends LightningElement {
      * @type {string}
      */
     updateLine() {
-        const line = this.template.querySelector('.line');
+        const line = this.template.querySelector('[data-element-id="div-line"]');
         const currentLevel = this.childLevel;
 
         if (this.variant === 'vertical') {


### PR DESCRIPTION
This is a fix for the deployment on Salesforce. It should not be part of the release notes.
