### PR TITLE
[fix] (ABC-630): Normalize relationship graph primitives query selectors

### DIFF
--- a/src/modules/base/primitiveRelationshipGraphGroup/primitiveRelationshipGraphGroup.html
+++ b/src/modules/base/primitiveRelationshipGraphGroup/primitiveRelationshipGraphGroup.html
@@ -129,6 +129,7 @@
                         active-selection={item.activeSelection}
                         default-actions={itemActions}
                         variant={variant}
+                        data-element-id="avonni-primitive-relationship-graph-item"
                     ></c-primitive-relationship-graph-item>
                 </template>
             </template>

--- a/src/modules/base/primitiveRelationshipGraphGroup/primitiveRelationshipGraphGroup.js
+++ b/src/modules/base/primitiveRelationshipGraphGroup/primitiveRelationshipGraphGroup.js
@@ -106,7 +106,7 @@ export default class PrimitiveRelationshipGraphGroup extends LightningElement {
     @api
     get selectedItemComponent() {
         const items = this.template.querySelectorAll(
-            'c-primitive-relationship-graph-item'
+            '[data-element-id="avonni-primitive-relationship-graph-item"]'
         );
 
         let selectedItem;

--- a/src/modules/base/primitiveRelationshipGraphLevel/primitiveRelationshipGraphLevel.html
+++ b/src/modules/base/primitiveRelationshipGraphLevel/primitiveRelationshipGraphLevel.html
@@ -65,6 +65,7 @@
                         hide-items-count={hideItemsCount}
                         is-first-child={group.first}
                         class="slds-is-relative"
+                        data-element-id="avonni-primitive-relationship-graph-group"
                     ></c-primitive-relationship-graph-group>
                 </template>
             </div>
@@ -86,6 +87,7 @@
                 group-actions-position={groupActionsPosition}
                 item-actions={itemActions}
                 hide-items-count={hideItemsCount}
+                data-element-id="avonni-primitive-relationship-graph-level"
             ></c-primitive-relationship-graph-level>
         </div>
     </div>

--- a/src/modules/base/primitiveRelationshipGraphLevel/primitiveRelationshipGraphLevel.js
+++ b/src/modules/base/primitiveRelationshipGraphLevel/primitiveRelationshipGraphLevel.js
@@ -80,7 +80,7 @@ export default class PrimitiveRelationshipGraphLevel extends LightningElement {
         if (!currentLevel) return 0;
 
         const lastGroup = currentLevel.querySelector(
-            'c-primitive-relationship-graph-group:last-child'
+            '[data-element-id="avonni-primitive-relationship-graph-group"]:last-child'
         );
         if (!lastGroup) return 0;
 
@@ -102,7 +102,7 @@ export default class PrimitiveRelationshipGraphLevel extends LightningElement {
 
     get childLevel() {
         return this.template.querySelector(
-            'c-primitive-relationship-graph-level'
+            '[data-element-id="avonni-primitive-relationship-graph-level"]'
         );
     }
 
@@ -144,7 +144,7 @@ export default class PrimitiveRelationshipGraphLevel extends LightningElement {
 
     get selectedItemComponent() {
         const groups = this.template.querySelectorAll(
-            'c-primitive-relationship-graph-group'
+            '[data-element-id="avonni-primitive-relationship-graph-group"]'
         );
 
         let selectedItem;
@@ -157,7 +157,7 @@ export default class PrimitiveRelationshipGraphLevel extends LightningElement {
 
     get selectedGroupComponent() {
         const groups = this.template.querySelectorAll(
-            'c-primitive-relationship-graph-group'
+            '[data-element-id="avonni-primitive-relationship-graph-group"]'
         );
 
         let selectedGroup;

--- a/src/modules/base/relationshipGraph/__tests__/relationshipGraph.test.js
+++ b/src/modules/base/relationshipGraph/__tests__/relationshipGraph.test.js
@@ -866,7 +866,7 @@ describe('RelationshipGraph', () => {
             const actionsWrapper =
                 element.shadowRoot.querySelector('div:nth-of-type(2)');
             const actionButtons = element.shadowRoot.querySelectorAll('button');
-            const line = element.shadowRoot.querySelector('.line');
+            const line = element.shadowRoot.querySelector('[data-element-id="div-line"]');
 
             expect(level.variant).toBe('horizontal');
             expect(wrapper.classList).toContain('slds-grid');
@@ -908,7 +908,7 @@ describe('RelationshipGraph', () => {
             const actionsWrapper =
                 element.shadowRoot.querySelector('div:nth-of-type(2)');
             const actionButtons = element.shadowRoot.querySelectorAll('button');
-            const line = element.shadowRoot.querySelector('.line');
+            const line = element.shadowRoot.querySelector('[data-element-id="div-line"]');
 
             expect(level.variant).toBe('vertical');
             expect(wrapper.classList).not.toContain('slds-grid');

--- a/src/modules/base/relationshipGraph/relationshipGraph.html
+++ b/src/modules/base/relationshipGraph/relationshipGraph.html
@@ -75,7 +75,7 @@
     </div>
 
     <div class={wrapperClass}>
-        <div class={lineClass}></div>
+        <div class={lineClass} data-element-id="div-line"></div>
 
         <!-- Levels -->
         <c-primitive-relationship-graph-level
@@ -90,6 +90,7 @@
             group-actions-position={groupActionsPosition}
             item-actions={itemActions}
             hide-items-count={hideItemsCount}
+            data-element-id="avonni-primitive-relationship-graph-level"
         ></c-primitive-relationship-graph-level>
     </div>
 </template>

--- a/src/modules/base/relationshipGraph/relationshipGraph.js
+++ b/src/modules/base/relationshipGraph/relationshipGraph.js
@@ -297,7 +297,7 @@ export default class RelationshipGraph extends LightningElement {
      */
     get childLevel() {
         return this.template.querySelector(
-            'c-primitive-relationship-graph-level'
+            '[data-element-id="avonni-primitive-relationship-graph-level"]'
         );
     }
 
@@ -359,7 +359,7 @@ export default class RelationshipGraph extends LightningElement {
      * @type {string}
      */
     get lineClass() {
-        return classSet('line').add({
+        return classSet().add({
             line_vertical: this.variant === 'horizontal',
             'line_horizontal slds-m-bottom_large': this.variant === 'vertical'
         });
@@ -377,7 +377,7 @@ export default class RelationshipGraph extends LightningElement {
      * @type {string}
      */
     updateLine() {
-        const line = this.template.querySelector('.line');
+        const line = this.template.querySelector('[data-element-id="div-line"]');
         const currentLevel = this.childLevel;
 
         if (this.variant === 'vertical') {


### PR DESCRIPTION
This is a fix for the deployment on Salesforce. It should not be part of the release notes.