### PR TITLE
[feat] (ABC-643): Add previousLevelPath to tree change event

### DIFF
--- a/src/modules/base/primitiveTreeItem/__tests__/primitiveTreeItem.test.js
+++ b/src/modules/base/primitiveTreeItem/__tests__/primitiveTreeItem.test.js
@@ -704,10 +704,10 @@ describe('Primitive Tree Item', () => {
         element.level = 3;
 
         return Promise.resolve().then(() => {
-            const item = element.shadowRoot.querySelector(
-                '.avonni-primitive-tree-item__item'
+            const wrapper = element.shadowRoot.querySelector(
+                '[data-element-id="div-wrapper"]'
             );
-            expect(item.style.cssText).toContain(
+            expect(wrapper.style.cssText).toContain(
                 '--avonni-tree-item-spacing-inline-left: 3rem;'
             );
         });

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.html
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.html
@@ -33,7 +33,7 @@
 -->
 
 <template>
-    <div class={wrapperClass}>
+    <div class={wrapperClass} data-element-id="div-wrapper">
         <div
             class="avonni-primitive-tree-item__item slds-is-relative slds-grid"
             data-element-id="div-item"

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
@@ -951,8 +951,11 @@ export default class PrimitiveTreeItem extends LightningElement {
      * Update the visual level offset of the item.
      */
     updateLevel() {
-        if (this.itemElement)
-            this.itemElement.style = `--avonni-tree-item-spacing-inline-left: ${this.level}rem;`;
+        const wrapper = this.template.querySelector(
+            '[data-element-id="div-wrapper"]'
+        );
+        if (wrapper)
+            wrapper.style = `--avonni-tree-item-spacing-inline-left: ${this.level}rem;`;
     }
 
     /**

--- a/src/modules/base/tree/__tests__/tree.test.js
+++ b/src/modules/base/tree/__tests__/tree.test.js
@@ -512,6 +512,9 @@ describe('Tree', () => {
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('expand');
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([2]);
+            expect(handler.mock.calls[0][0].detail.previousLevelPath).toEqual([
+                2
+            ]);
             expect(handler.mock.calls[0][0].detail.name).toBe('regular');
             expect(handler.mock.calls[0][0].detail.items[2]).toMatchObject(
                 item
@@ -556,6 +559,9 @@ describe('Tree', () => {
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('expand');
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([2]);
+            expect(handler.mock.calls[0][0].detail.previousLevelPath).toEqual([
+                2
+            ]);
             expect(handler.mock.calls[0][0].detail.name).toBe('regular');
             expect(handler.mock.calls[0][0].detail.items[2]).toMatchObject(
                 item
@@ -601,6 +607,9 @@ describe('Tree', () => {
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('add');
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([3]);
+            expect(handler.mock.calls[0][0].detail.previousLevelPath).toEqual([
+                3
+            ]);
             expect(handler.mock.calls[0][0].detail.name).toBe('simple');
             expect(handler.mock.calls[0][0].detail.items[3]).toMatchObject(
                 item
@@ -628,6 +637,9 @@ describe('Tree', () => {
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('add');
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([
+                ITEMS.length - 1
+            ]);
+            expect(handler.mock.calls[0][0].detail.previousLevelPath).toEqual([
                 ITEMS.length - 1
             ]);
             expect(handler.mock.calls[0][0].detail.name).toBeNull();
@@ -663,6 +675,9 @@ describe('Tree', () => {
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('delete');
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([3]);
+            expect(handler.mock.calls[0][0].detail.previousLevelPath).toEqual([
+                3
+            ]);
             expect(handler.mock.calls[0][0].detail.name).toBe('simple');
             expect(handler.mock.calls[0][0].detail.items).toHaveLength(3);
             expect(
@@ -693,6 +708,9 @@ describe('Tree', () => {
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('duplicate');
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([3]);
+            expect(handler.mock.calls[0][0].detail.previousLevelPath).toEqual([
+                3
+            ]);
             expect(handler.mock.calls[0][0].detail.name).not.toBe(
                 ITEMS[3].name
             );
@@ -747,6 +765,9 @@ describe('Tree', () => {
             expect(handler).toHaveBeenCalledTimes(1);
             expect(handler.mock.calls[0][0].detail.action).toBe('edit');
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([0]);
+            expect(handler.mock.calls[0][0].detail.previousLevelPath).toEqual([
+                0
+            ]);
             expect(handler.mock.calls[0][0].detail.name).toBe('new name');
             expect(handler.mock.calls[0][0].detail.items[0]).toMatchObject(
                 item
@@ -838,7 +859,10 @@ describe('Tree', () => {
             );
             expect(handler).toHaveBeenCalledTimes(2);
             expect(handler.mock.calls[1][0].detail.action).toBe('move');
-            expect(handler.mock.calls[1][0].detail.levelPath).toEqual([1]);
+            expect(handler.mock.calls[1][0].detail.previousLevelPath).toEqual([
+                1
+            ]);
+            expect(handler.mock.calls[1][0].detail.levelPath).toEqual([2]);
             expect(handler.mock.calls[1][0].detail.name).toBe(ITEMS[1].name);
             expect(
                 handler.mock.calls[1][0].detail.previousName
@@ -915,7 +939,10 @@ describe('Tree', () => {
             );
             expect(handler).toHaveBeenCalledTimes(2);
             expect(handler.mock.calls[1][0].detail.action).toBe('move');
-            expect(handler.mock.calls[1][0].detail.levelPath).toEqual([1]);
+            expect(handler.mock.calls[1][0].detail.previousLevelPath).toEqual([
+                1
+            ]);
+            expect(handler.mock.calls[1][0].detail.levelPath).toEqual([0]);
             expect(handler.mock.calls[1][0].detail.name).toBe(ITEMS[1].name);
             expect(
                 handler.mock.calls[1][0].detail.previousName
@@ -995,7 +1022,10 @@ describe('Tree', () => {
             );
             expect(handler).toHaveBeenCalledTimes(3);
             expect(handler.mock.calls[2][0].detail.action).toBe('move');
-            expect(handler.mock.calls[2][0].detail.levelPath).toEqual([1]);
+            expect(handler.mock.calls[2][0].detail.previousLevelPath).toEqual([
+                1
+            ]);
+            expect(handler.mock.calls[2][0].detail.levelPath).toEqual([1, 0]);
             expect(handler.mock.calls[2][0].detail.name).toBe(ITEMS[1].name);
             expect(
                 handler.mock.calls[2][0].detail.previousName
@@ -1095,7 +1125,8 @@ describe('Tree', () => {
             expect(handler).toHaveBeenCalledTimes(1);
             const detail = handler.mock.calls[0][0].detail;
             expect(detail.action).toBe('move');
-            expect(detail.levelPath).toEqual([3]);
+            expect(detail.levelPath).toEqual([2, 0, 3]);
+            expect(detail.previousLevelPath).toEqual([3]);
             expect(detail.name).toBe(ITEMS[3].name);
             expect(detail.previousName).toBeUndefined();
             expect(detail.items).toHaveLength(3);

--- a/src/modules/base/tree/tree.js
+++ b/src/modules/base/tree/tree.js
@@ -1326,9 +1326,15 @@ export default class Tree extends LightningElement {
      */
     dispatchChange({ key, name, action, previousName }) {
         // If no key is given, it's a new item at the root of the tree
-        const levelPath = this.treedata.getLevelPath(
+        let levelPath = this.treedata.getLevelPath(
             (key || this.items.length - 1).toString()
         );
+
+        const previousLevelPath = levelPath;
+        if (action === 'move') {
+            const newItem = this.treedata.getItemFromName(name);
+            levelPath = this.treedata.getLevelPath(newItem.key);
+        }
 
         /**
          * The event fired when a change is made to the tree.
@@ -1341,6 +1347,8 @@ export default class Tree extends LightningElement {
          * The levels start from 0. For example, if an item is the third child of its parent, and its parent is the second child of the tree root, the value would be: ``[1, 2]``.
          * @param {string} name Name of the specific item the change was made to.
          * @param {string} previousName For the ``duplicate`` action, name of the original item. For the ``edit`` action, if the name has changed, previous name of the item.
+         * @param {number[]} previousLevelPath Array of the levels of depth, of the previous position of the changed item.
+         * This value will differ from the levelPath only if the action is move.
          * @public
          */
         this.dispatchEvent(
@@ -1350,6 +1358,7 @@ export default class Tree extends LightningElement {
                     items: deepCopy(this.items),
                     levelPath,
                     name,
+                    previousLevelPath,
                     previousName
                 }
             })


### PR DESCRIPTION
### Features
**Tree**
- Added `previousLevelPath` to the `change` event, to identify the previous position of the item when the action is `move`.

### Fixes
**Tree**
- Fixed the indentation removal when an item was sorted.
