### PR TITLE
[fix] (ABC-648): Fix tree inline editing not saving last character

### DIFF
--- a/src/modules/base/primitiveTreeItem/__tests__/primitiveTreeItem.test.js
+++ b/src/modules/base/primitiveTreeItem/__tests__/primitiveTreeItem.test.js
@@ -1132,9 +1132,9 @@ describe('Primitive Tree Item', () => {
                     '[data-element-id="lightning-input-inline-label"]'
                 );
                 input.value = 'New label';
-                const keydown = new CustomEvent('keydown');
-                keydown.key = 'Enter';
-                input.dispatchEvent(keydown);
+                const keyup = new CustomEvent('keyup');
+                keyup.key = 'Enter';
+                input.dispatchEvent(keyup);
 
                 expect(element.label).toBe('New label');
                 expect(handler).toHaveBeenCalledTimes(1);

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.html
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.html
@@ -138,7 +138,7 @@
                         value={label}
                         data-element-id="lightning-input-inline-label"
                         onchange={stopPropagation}
-                        onkeydown={handleLabelInlineKeyDown}
+                        onkeyup={handleLabelInlineKeyUp}
                     ></lightning-input>
 
                     <lightning-button-icon

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
@@ -1172,7 +1172,7 @@ export default class PrimitiveTreeItem extends LightningElement {
      *
      * @param {Event} event
      */
-    handleLabelInlineKeyDown(event) {
+    handleLabelInlineKeyUp(event) {
         event.stopPropagation();
         this.draftValues.label = event.currentTarget.value;
 


### PR DESCRIPTION
### Fixes
**Tree**
- Fixed the inline editing: the last character entered is now saved when clicking on the check button.