### PR TITLE
[fix](abc-645): Remove redundant slds avatar border

### DIFF
--- a/src/modules/base/avatarGroup/avatarGroup.css
+++ b/src/modules/base/avatarGroup/avatarGroup.css
@@ -39,6 +39,10 @@
     cursor: pointer;
 }
 
+.slds-avatar-grouped {
+    border: none;
+}
+
 .avonni-avatar-group_x-large {
     width: 4.5rem;
     height: 4.5rem;


### PR DESCRIPTION
Fix
- Removed doubled border around avatars in a group of two.
