### PR TITLE
[feat] (ABC-667): Refactor scheduler with new attributes structure

### DIFF
--- a/jest-mock/components/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
+++ b/jest-mock/components/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
@@ -11,6 +11,7 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
     @api timeSpan;
     @api visibleInterval;
     @api variant;
+    @api visibleWidth;
     @api zoomToFit;
 
     _start;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@avonni/base-components",
-    "version": "1.2.6",
+    "version": "1.3.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@avonni/base-components",
-            "version": "1.2.6",
+            "version": "1.3.1",
             "license": "MIT",
             "dependencies": {
                 "dompurify": "^2.2.6",

--- a/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrence.test.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrence.test.js
@@ -69,26 +69,26 @@ const TO = new Date(2021, 7, 30, 10);
 const RESOURCE_KEY = '3';
 const RESOURCES = [
     {
-        key: '1',
+        name: '1',
         height: 30,
         color: 'rgb(0, 0, 0)',
         data: {
             customField: 'Some useless string',
             overwrittenField: 'Another useless string',
             height: 30,
-            key: '1',
+            name: '1',
             color: 'rgb(0, 0, 0)'
         }
     },
     {
-        key: '3',
+        name: '3',
         height: 50,
         color: 'rgb(51, 51, 51)',
         data: {
             customField: 'Row field',
             overwrittenField: 'This will not show',
             height: 50,
-            key: '3',
+            name: '3',
             color: 'rgb(51, 51, 51)'
         }
     }

--- a/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
@@ -108,7 +108,6 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
     _disabled = false;
     _event;
     _from;
-    _keyFields = [];
     _labels = {};
     _occurrence = {};
     _readOnly = false;
@@ -825,7 +824,7 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
      */
     get resourceColor() {
         const resource = this.resources.find(
-            (computedResource) => computedResource.key === this.resourceKey
+            (res) => res.name === this.resourceKey
         );
         return resource && resource.color;
     }
@@ -973,7 +972,7 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
             const resources = this.resources;
             let y = 0;
             for (let j = 0; j < resources.length; j++) {
-                const resourceKey = resources[j].key;
+                const resourceKey = resources[j].name;
                 if (resourceKey === this.resourceKey) break;
 
                 y += resources[j].height;
@@ -982,7 +981,7 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
             this._y = y;
         } else if (!this.referenceLine && this.isVertical) {
             const resourceIndex = this.resources.findIndex((resource) => {
-                return resource.key === this.resourceKey;
+                return resource.name === this.resourceKey;
             });
             this._x = resourceIndex * cellWidth;
         }
@@ -1070,7 +1069,7 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
             element.style.width = `${this.cellWidth}px`;
         } else {
             const resource = this.resources.find(
-                (rw) => rw.key === this.resourceKey
+                (res) => res.name === this.resourceKey
             );
 
             if (resource) {
@@ -1119,7 +1118,7 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
 
         const labels = {};
         const resource = this.resources.find(
-            (res) => res.key === this.resourceKey
+            (res) => res.name === this.resourceKey
         );
 
         if (resource) {

--- a/src/modules/base/primitiveSchedulerHeaderGroup/__tests__/primitiveSchedulerHeaderGroup.test.js
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/__tests__/primitiveSchedulerHeaderGroup.test.js
@@ -90,6 +90,7 @@ describe('Primitive Scheduler Header Group', () => {
         expect(element.timeSpan).toMatchObject({ unit: 'day', span: 1 });
         expect(element.variant).toBe('horizontal');
         expect(element.visibleInterval).toBeUndefined();
+        expect(element.visibleWidth).toBe(0);
         expect(element.zoomToFit).toBeFalsy();
     });
 
@@ -689,7 +690,7 @@ describe('Primitive Scheduler Header Group', () => {
         });
     });
 
-    // zoom-to-fit
+    // visible-width and zoom-to-fit
     it('Scheduler header group: zoomToFit', () => {
         element.shadowRoot.host.getBoundingClientRect = jest.fn(() => {
             return { width: 120 };
@@ -706,6 +707,18 @@ describe('Primitive Scheduler Header Group', () => {
 
         expect(handler).toHaveBeenCalled();
         expect(handler.mock.calls[0][0].detail.cellSize).toBe(5);
+    });
+
+    it('Scheduler header group: visibleWidth and zoomToFit', () => {
+        element.visibleWidth = 1200;
+        const handler = jest.fn();
+        element.addEventListener('privatecellsizechange', handler);
+        element.start = new Date(2022, 4, 18);
+        element.zoomToFit = true;
+        jest.runAllTimers();
+
+        expect(handler).toHaveBeenCalled();
+        expect(handler.mock.calls[0][0].detail.cellSize).toBe(50);
     });
 
     /*

--- a/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
@@ -366,7 +366,11 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
         return this._visibleWidth;
     }
     set visibleWidth(value) {
-        this._visibleWidth = Number(value);
+        const width = parseInt(value, 10);
+        if (width === this._visibleWidth) {
+            return;
+        }
+        this._visibleWidth = width;
 
         if (this._connected) {
             this.computeCellSize();

--- a/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
@@ -609,7 +609,9 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
         if (!this.smallestHeader) {
             return;
         }
-        const totalWidth = this.visibleWidth;
+        const totalWidth =
+            this.visibleWidth ||
+            this.template.host.getBoundingClientRect().width;
         const totalNumberOfCells = this.smallestHeader.numberOfCells;
         let cellSize = 0;
 

--- a/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
@@ -92,6 +92,7 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
     _start = DEFAULT_START_DATE;
     _timeSpan = DEFAULT_TIME_SPAN;
     _variant = VARIANTS.default;
+    _visibleWidth = 0;
     _zoomToFit = false;
 
     _connected = false;
@@ -354,6 +355,24 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
         return Interval.fromDateTimes(start, end);
     }
 
+    /**
+     * Maximum visible width of the headers.
+     *
+     * @type {number}
+     * @public
+     */
+    @api
+    get visibleWidth() {
+        return this._visibleWidth;
+    }
+    set visibleWidth(value) {
+        this._visibleWidth = Number(value);
+
+        if (this._connected) {
+            this.computeCellSize();
+        }
+    }
+
     /*
      * ------------------------------------------------------------
      *  PRIVATE PROPERTIES
@@ -590,7 +609,7 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
         if (!this.smallestHeader) {
             return;
         }
-        const totalWidth = this.template.host.getBoundingClientRect().width;
+        const totalWidth = this.visibleWidth;
         const totalNumberOfCells = this.smallestHeader.numberOfCells;
         let cellSize = 0;
 

--- a/src/modules/base/scheduler/__docs__/data.js
+++ b/src/modules/base/scheduler/__docs__/data.js
@@ -35,13 +35,13 @@ const start = new Date(2021, 11, 13, 8);
 const columns = [
     {
         label: 'Staff',
-        fieldName: 'resourceAvatarSrc',
+        fieldName: 'avatarSrc',
         type: 'avatar',
         typeAttributes: {
             alternativeText: 'Avatar',
-            fallbackIconName: { fieldName: 'resourceAvatarFallbackIconName' },
-            initials: { fieldName: 'resourceAvatarInitials' },
-            primaryText: { fieldName: 'resourceName' }
+            fallbackIconName: { fieldName: 'avatarFallbackIconName' },
+            initials: { fieldName: 'avatarInitials' },
+            primaryText: { fieldName: 'name' }
         }
     },
     {
@@ -54,53 +54,48 @@ const columns = [
 const oneColumn = [
     {
         label: 'Employee',
-        fieldName: 'resourceName'
+        fieldName: 'name'
     }
 ];
 
 const resources = [
     {
-        id: '1',
-        resourceAvatarSrc:
+        avatarSrc:
             'https://www.lightningdesignsystem.com/assets/images/avatar2.jpg',
-        resourceAvatarFallbackIconName: 'standard:person_account',
-        resourceAvatarInitials: 'NG',
-        resourceName: 'Nina',
+        avatarFallbackIconName: 'standard:person_account',
+        avatarInitials: 'NG',
+        name: 'Nina',
         role: 'Lead developer',
         sharedField: `This shouldn't show up`
     },
     {
-        id: '2',
-        resourceAvatarSrc:
+        avatarSrc:
             'https://www.lightningdesignsystem.com/assets/images/avatar1.jpg',
-        resourceAvatarFallbackIconName: 'standard:person_account',
-        resourceAvatarInitials: 'DM',
-        resourceName: 'Dave',
+        avatarFallbackIconName: 'standard:person_account',
+        avatarInitials: 'DM',
+        name: 'Dave',
         role: 'UX Specialist',
         customRowField: 'Label coming from a custom field in the row'
     },
     {
-        id: '3',
-        resourceAvatarFallbackIconName: 'standard:person_account',
-        resourceAvatarInitials: 'JP',
-        resourceName: 'Jung',
+        avatarFallbackIconName: 'standard:person_account',
+        avatarInitials: 'JP',
+        name: 'Jung',
         role: 'Product Owner'
     },
     {
-        id: '4',
-        resourceAvatarFallbackIconName: 'standard:article',
-        resourceAvatarInitials: 'LM',
-        resourceName: 'Lily',
+        avatarFallbackIconName: 'standard:article',
+        avatarInitials: 'LM',
+        name: 'Lily',
         role: 'Graphic Designer',
         customField: "This comes from the row's custom field"
     },
     {
-        id: '5',
-        resourceAvatarSrc:
+        avatarSrc:
             'https://www.lightningdesignsystem.com/assets/images/avatar3.jpg',
-        resourceAvatarFallbackIconName: 'standard:person_account',
-        resourceAvatarInitials: 'RM',
-        resourceName: 'Reginald',
+        avatarFallbackIconName: 'standard:person_account',
+        avatarInitials: 'RM',
+        name: 'Reginald',
         role: 'Developer'
     }
 ];
@@ -109,7 +104,6 @@ const lotsOfRows = () => {
     const computedRows = [];
     for (let i = 1; i <= 20; i++) {
         computedRows.push({
-            id: i.toString(),
             name: `Employee #${i}`
         });
     }
@@ -141,9 +135,9 @@ const headers = [
 
 const lotsOfEvents = () => {
     const computedEvents = [];
-    const keyFields = [];
+    const resourceNames = [];
     for (let i = 1; i <= 20; i++) {
-        keyFields.push(i.toString());
+        resourceNames.push(i.toString());
     }
 
     let startTime = start.getTime();
@@ -151,19 +145,19 @@ const lotsOfEvents = () => {
 
     for (let i = 1; i <= 1000; i++) {
         // The event will be on one to three rows
-        const keyFieldsNumber = Math.floor(Math.random() * 3) + 1;
-        const eventKeyFields = [];
-        const computedKeyFields = [...keyFields];
-        for (let j = 0; j < keyFieldsNumber; j++) {
+        const resourceNamesNumber = Math.floor(Math.random() * 3) + 1;
+        const eventResourceNames = [];
+        const computedResourceNames = [...resourceNames];
+        for (let j = 0; j < resourceNamesNumber; j++) {
             const keyFieldIndex = Math.floor(
-                Math.random() * computedKeyFields.length
+                Math.random() * computedResourceNames.length
             );
-            eventKeyFields.push(computedKeyFields[keyFieldIndex]);
-            computedKeyFields.splice(keyFieldIndex, 1);
+            eventResourceNames.push(computedResourceNames[keyFieldIndex]);
+            computedResourceNames.splice(keyFieldIndex, 1);
         }
 
         computedEvents.push({
-            keyFields: eventKeyFields,
+            resourceNames: eventResourceNames,
             name: `event-${i}`,
             title: `Event ${i}`,
             from: startTime,
@@ -179,70 +173,70 @@ const lotsOfEvents = () => {
 
 const basicEvents = [
     {
-        keyFields: ['3', '4', '5'],
+        resourceNames: ['Jung', 'Lily', 'Reginald'],
         name: 'event-1',
         title: 'Event 1',
         from: 1639400400000,
         to: 1639407600000
     },
     {
-        keyFields: ['5', '3', '4'],
+        resourceNames: ['Reginald', 'Jung', 'Lily'],
         name: 'event-2',
         title: 'Event 2',
         from: 1639404000000,
         to: 1639411200000
     },
     {
-        keyFields: ['3', '4', '2'],
+        resourceNames: ['Jung', 'Lily', 'Dave'],
         name: 'event-3',
         title: 'Event 3',
         from: 1639407600000,
         to: 1639414800000
     },
     {
-        keyFields: ['1', '4'],
+        resourceNames: ['Nina', 'Lily'],
         name: 'event-4',
         title: 'Event 4',
         from: 1639411200000,
         to: 1639418400000
     },
     {
-        keyFields: ['2', '1'],
+        resourceNames: ['Dave', 'Nina'],
         name: 'event-5',
         title: 'Event 5',
         from: 1639414800000,
         to: 1639422000000
     },
     {
-        keyFields: ['1', '2', '3'],
+        resourceNames: ['Nina', 'Dave', 'Jung'],
         name: 'event-6',
         title: 'Event 6',
         from: 1639418400000,
         to: 1639425600000
     },
     {
-        keyFields: ['1'],
+        resourceNames: ['Nina'],
         name: 'event-7',
         title: 'Event 7',
         from: 1639422000000,
         to: 1639429200000
     },
     {
-        keyFields: ['3'],
+        resourceNames: ['Jung'],
         name: 'event-8',
         title: 'Event 8',
         from: 1639425600000,
         to: 1639432800000
     },
     {
-        keyFields: ['1'],
+        resourceNames: ['Nina'],
         name: 'event-9',
         title: 'Event 9',
         from: 1639429200000,
         to: 1639436400000
     },
     {
-        keyFields: ['2', '3', '4'],
+        resourceNames: ['Dave', 'Jung', 'Lily'],
         name: 'event-10',
         title: 'Event 10',
         from: 1639432800000,
@@ -251,70 +245,70 @@ const basicEvents = [
 ];
 const longEvents = [
     {
-        keyFields: ['3', '4', '5'],
+        resourceNames: ['Jung', 'Lily', 'Reginald'],
         name: 'event-1',
         title: 'Event 1',
         from: new Date(2021, 2, 1),
         to: new Date(2021, 3, 1)
     },
     {
-        keyFields: ['5', '3', '4'],
+        resourceNames: ['Reginald', 'Jung', 'Lily'],
         name: 'event-2',
         title: 'Event 2',
         from: new Date(2021, 1, 15),
         to: new Date(2021, 3, 30)
     },
     {
-        keyFields: ['3', '4', '2'],
+        resourceNames: ['Jung', 'Lily', 'Dave'],
         name: 'event-3',
         title: 'Event 3',
         from: new Date(2020, 11, 26),
         to: new Date(2021, 0, 31)
     },
     {
-        keyFields: ['1', '4'],
+        resourceNames: ['Nina', 'Lily'],
         name: 'event-4',
         title: 'Event 4',
         from: new Date(2021, 3, 12),
         to: new Date(2021, 4, 31)
     },
     {
-        keyFields: ['2', '1'],
+        resourceNames: ['Dave', 'Nina'],
         name: 'event-5',
         title: 'Event 5',
         from: new Date(2021, 7, 1),
         to: new Date(2021, 8, 31)
     },
     {
-        keyFields: ['1', '2', '3'],
+        resourceNames: ['Nina', 'Dave', 'Jung'],
         name: 'event-6',
         title: 'Event 6',
         from: new Date(2021, 5, 20),
         to: new Date(2021, 6, 31)
     },
     {
-        keyFields: ['1'],
+        resourceNames: ['Nina'],
         name: 'event-7',
         title: 'Event 7',
         from: new Date(2021, 6, 1),
         to: new Date(2021, 7, 31)
     },
     {
-        keyFields: ['3'],
+        resourceNames: ['Jung'],
         name: 'event-8',
         title: 'Event 8',
         from: new Date(2021, 9, 10),
         to: new Date(2021, 10, 31)
     },
     {
-        keyFields: ['1'],
+        resourceNames: ['Nina'],
         name: 'event-9',
         title: 'Event 9',
         from: new Date(2021, 9, 1),
         to: new Date(2022, 2, 3)
     },
     {
-        keyFields: ['2', '3', '4'],
+        resourceNames: ['Dave', 'Jung', 'Lily'],
         name: 'event-10',
         title: 'Event 10',
         from: new Date(2021, 10, 1),
@@ -324,14 +318,14 @@ const longEvents = [
 
 const events = [
     {
-        keyFields: ['3'],
+        resourceNames: ['Jung'],
         name: 'research',
         title: 'Research',
         from: new Date(2021, 11, 13, 9),
         to: new Date(2021, 11, 14, 12)
     },
     {
-        keyFields: ['1'],
+        resourceNames: ['Nina'],
         name: 'code-review',
         title: 'Code review',
         from: new Date(2021, 11, 13, 13),
@@ -339,77 +333,77 @@ const events = [
         recurrence: 'daily'
     },
     {
-        keyFields: ['3', '2'],
+        resourceNames: ['Jung', 'Dave'],
         name: 'seminar',
         title: 'Online seminar',
         from: new Date(2021, 11, 14, 8),
         to: new Date(2021, 11, 16)
     },
     {
-        keyFields: ['1', '3'],
+        resourceNames: ['Nina', 'Jung'],
         name: 'write-spec',
         title: 'Write specifications',
         from: new Date(2021, 11, 15),
         allDay: true
     },
     {
-        keyFields: ['2'],
+        resourceNames: ['Dave'],
         name: 'create-wireframe',
         title: 'Create wireframe',
         from: new Date(2021, 11, 13, 10, 15),
         to: new Date(2021, 11, 16, 12)
     },
     {
-        keyFields: ['4'],
+        resourceNames: ['Lily'],
         name: 'create-mockup',
         title: 'Create mockup',
         from: new Date(2021, 11, 20, 7),
         to: new Date(2021, 11, 22, 10, 30)
     },
     {
-        keyFields: ['2'],
+        resourceNames: ['Dave'],
         name: 'test-new-ui',
         title: 'Test new UI',
         from: new Date(2021, 11, 17, 15),
         to: new Date(2021, 11, 21)
     },
     {
-        keyFields: ['5'],
+        resourceNames: ['Reginald'],
         name: 'implement-feature',
         title: 'Implement feature',
         from: new Date(2021, 11, 13, 14),
         to: new Date(2021, 11, 15, 16)
     },
     {
-        keyFields: ['1'],
+        resourceNames: ['Nina'],
         name: 'push-to-prod',
         title: 'Push to production',
         from: new Date(2021, 11, 16, 11),
         to: new Date(2021, 11, 16, 12)
     },
     {
-        keyFields: ['1'],
+        resourceNames: ['Nina'],
         name: 'phone-meeting',
         title: 'Phone meeting',
         from: new Date(2021, 11, 21, 10),
         to: new Date(2021, 11, 21, 12)
     },
     {
-        keyFields: ['3'],
+        resourceNames: ['Jung'],
         name: 'update-documentation',
         title: 'Update documentation',
         from: new Date(2021, 11, 17, 11),
         to: new Date(2021, 11, 17, 18)
     },
     {
-        keyFields: ['3'],
+        resourceNames: ['Jung'],
         name: 'presentation',
         title: 'Presentation at the conference',
         from: new Date(2021, 11, 16, 11),
         to: new Date(2021, 11, 16, 18)
     },
     {
-        keyFields: ['2', '4'],
+        resourceNames: ['Dave', 'Lily'],
         name: 'ux-ui-team-meeting',
         title: 'UI/UX team meeting',
         from: new Date(2021, 11, 17, 11),
@@ -417,14 +411,14 @@ const events = [
         recurrence: 'weekly'
     },
     {
-        keyFields: ['1', '2', '3', '4', '5'],
+        resourceNames: ['Nina', 'Dave', 'Jung', 'Lily', 'Reginald'],
         name: 'office-party',
         title: 'Office party',
         from: new Date(2021, 11, 24, 12),
         to: new Date(2021, 11, 25)
     },
     {
-        keyFields: ['1', '5'],
+        resourceNames: ['Nina', 'Reginald'],
         name: 'standup',
         title: 'Stand-up meeting',
         from: new Date(2021, 11, 13, 9, 30),
@@ -438,7 +432,7 @@ const events = [
 
 const eventsWithLabels = [
     {
-        keyFields: ['3'],
+        resourceNames: ['Jung'],
         name: 'research',
         title: 'Research',
         from: new Date(2021, 11, 13, 9),
@@ -451,7 +445,7 @@ const eventsWithLabels = [
         }
     },
     {
-        keyFields: ['1'],
+        resourceNames: ['Nina'],
         name: 'code-review',
         title: 'Code review',
         from: new Date(2021, 11, 13, 13),
@@ -459,21 +453,21 @@ const eventsWithLabels = [
         recurrence: 'daily'
     },
     {
-        keyFields: ['3', '2'],
+        resourceNames: ['Jung', 'Dave'],
         name: 'seminar',
         title: 'Online seminar',
         from: new Date(2021, 11, 14, 8),
         to: new Date(2021, 11, 16)
     },
     {
-        keyFields: ['1', '3'],
+        resourceNames: ['Nina', 'Jung'],
         name: 'write-spec',
         title: 'Write specifications',
         from: new Date(2021, 11, 15),
         allDay: true
     },
     {
-        keyFields: ['2'],
+        resourceNames: ['Dave'],
         name: 'create-wireframe',
         title: 'Create wireframe',
         from: new Date(2021, 11, 13, 10, 15),
@@ -489,14 +483,14 @@ const eventsWithLabels = [
         }
     },
     {
-        keyFields: ['5'],
+        resourceNames: ['Reginald'],
         name: 'implement-feature',
         title: 'Implement feature',
         from: new Date(2021, 11, 13, 14),
         to: new Date(2021, 11, 15, 16)
     },
     {
-        keyFields: ['1', '5'],
+        resourceNames: ['Nina', 'Reginald'],
         name: 'standup',
         title: 'Stand-up meeting',
         from: new Date(2021, 11, 13, 9, 30),
@@ -510,7 +504,7 @@ const eventsWithLabels = [
 
 const eventsThemed = [
     {
-        keyFields: ['1', '5', '4'],
+        resourceNames: ['Nina', 'Reginald', 'Lily'],
         name: 'event-1',
         title: 'Theme hollow',
         from: 1639400400000,
@@ -518,7 +512,7 @@ const eventsThemed = [
         theme: 'hollow'
     },
     {
-        keyFields: ['4'],
+        resourceNames: ['Lily'],
         name: 'event-2',
         title: 'Theme line',
         from: 1639404000000,
@@ -526,7 +520,7 @@ const eventsThemed = [
         theme: 'line'
     },
     {
-        keyFields: ['5', '3'],
+        resourceNames: ['Reginald', 'Jung'],
         name: 'event-3',
         title: 'Custom color',
         from: 1639432800000,
@@ -534,7 +528,7 @@ const eventsThemed = [
         color: 'tomato'
     },
     {
-        keyFields: ['2', '4'],
+        resourceNames: ['Dave', 'Lily'],
         name: 'event-4',
         title: 'Theme transparent',
         from: 1639411200000,
@@ -542,7 +536,7 @@ const eventsThemed = [
         theme: 'transparent'
     },
     {
-        keyFields: ['2', '1'],
+        resourceNames: ['Dave', 'Nina'],
         name: 'event-5',
         title: 'Theme rounded',
         from: 1639414800000,
@@ -550,7 +544,7 @@ const eventsThemed = [
         theme: 'rounded'
     },
     {
-        keyFields: ['4', '1'],
+        resourceNames: ['Lily', 'Nina'],
         name: 'event-6',
         title: 'Default theme',
         from: 1639425600000,
@@ -560,7 +554,7 @@ const eventsThemed = [
 
 const disabledDatesTimes = [
     {
-        keyFields: ['1', '2', '3', '4', '5'],
+        resourceNames: ['Nina', 'Dave', 'Jung', 'Lily', 'Reginald'],
         title: 'Lunch',
         iconName: 'custom:custom51',
         from: new Date(2021, 0, 1, 12),
@@ -571,13 +565,13 @@ const disabledDatesTimes = [
         }
     },
     {
-        keyFields: ['4'],
+        resourceNames: ['Lily'],
         title: 'Vacation',
         from: new Date(2021, 11, 6),
         to: new Date(2021, 11, 20)
     },
     {
-        keyFields: ['3'],
+        resourceNames: ['Jung'],
         title: 'Day off',
         from: new Date(2021, 11, 23),
         allDay: true

--- a/src/modules/base/scheduler/__docs__/scheduler.jsdoc.js
+++ b/src/modules/base/scheduler/__docs__/scheduler.jsdoc.js
@@ -1,7 +1,7 @@
 /**
  * @typedef {Object} SchedulerAction
  * @name actions
- * @property {string} name Name of the action clicked.
+ * @property {string} name Name of the action clicked. Default action names are Standard.Scheduler.AddEvent, Standard.Scheduler.EditEvent and Standard.Scheduler.DeleteEvent.
  * @property {string} label Label of the action.
  * @property {string} iconName Name of the icon to display before the action label.
  * Names are written in the format 'standard:account' where 'standard' is the category, and 'account' is the specific icon to be displayed.
@@ -10,16 +10,16 @@
 /**
  * @typedef {Object} SchedulerHeader
  * @name headers
- * @property {string} unit The date/time unit of this header. Valid values include year, month, week, day, hour and minute.
- * @property {number} span The number of units in one column of this header. For example, if the unit is ‘hour’ and the span is '2', one column of this header will contain two hours.
- * @property {number} label The header label. See <a href="https://moment.github.io/luxon/#/formatting?id=table-of-tokens">Luxon’s documentation</a> for accepted format. If you want to insert text in the label, you need to escape it using single quote.
+ * @property {string} unit Required. The date/time unit of this header. Valid values include year, month, week, day, hour and minute.
+ * @property {number} span Required. The number of units in one column of this header. For example, if the unit is ‘hour’ and the span is '2', one column of this header will contain two hours.
+ * @property {number} label Required. The header label. See <a href="https://moment.github.io/luxon/#/formatting?id=table-of-tokens">Luxon’s documentation</a> for accepted format. If you want to insert text in the label, you need to escape it using single quote.
  * For example, the format of “Jan 14 day shift” would be “LLL dd 'day shift'".
  */
 
 /**
  * @typedef {Object} SchedulerEvent
  * @name events
- * @property {string[]} keyFields Required. Array of unique resource IDs. The event will be shown in the scheduler for each of these resources.
+ * @property {string[]} resourceNames Required. Array of unique resource names. The event will be shown in the scheduler for each of these resources.
  * @property {string} name Required. Unique name for the event. It will be returned by the <code>eventclick</code> and <code>actionclick</code> events.
  * @property {string} title Title of the event.
  * @property {(Date|number|string)} from Required. Start of the event. It can be a Date object, timestamp, or an ISO8601 formatted string.
@@ -41,7 +41,7 @@
 /**
  * @typedef {Object} SchedulerDisabledDatesTimes
  * @name disabledDates/times
- * @property {string[]} keyFields Required. Array of unique resource IDs. The disabled dates/times will be shown in the scheduler for each of these resources.
+ * @property {string[]} resourceNames Required. Array of unique resource names. The disabled dates/times will be shown in the scheduler for each of these resources.
  * @property {string} title Title of the disabled date/time.
  * @property {string} iconName The Lightning Design System name of the icon. Names are written in the format utility:user. The icon is appended to the left of the title.
  * @property {(Date|number|string)} from Required. Start of the disabled date/time. It can be a Date object, timestamp, or an ISO8601 formatted string.
@@ -75,6 +75,43 @@
  * @property {number} recurrenceCount Number of times the reference line will be repeated before the recurrence stops.
  * If a <code>recurrenceEndDate</code> is also given, the earliest ending date will be used.
  * @property {object} recurrenceAttributes Attributes specific to the recurrence type (see Recurrence attributes table).
+ */
+
+/**
+ * @typedef {object} SchedulerResource
+ * @name resources
+ * @property {string} avatarFallbackIconName The Lightning Design System name of the icon used as a fallback when the avatar image fails to load.
+ * Specify the name in the format 'utility:down' where 'utility' is the category, and 'down' is the specific icon to be displayed.
+ * @property {string} avatarInitials Initials to display in place of the avatar image, if it fails to load.
+ * If the record name contains two words, like first and last name, use the first capitalized letter of each. For records that only have a single word name, use the first two letters of that word using one capital and one lower case letter.
+ * @property {string} avatarSrc Image URL to use as the resource avatar.
+ * @property {string} label Label of the resource.
+ * @property {string} name Required. Unique name of the resource.
+ */
+
+/**
+ * @typedef {object} SchedulerTimeSpan
+ * @name timeSpans
+ * @property {object[]} customHeaders Array of header objects. If both present, it will overwrite the `headers`.
+ * @property {string} headers Name of the header preset, that will determine the precision of the timeline. Valid values include:
+ * * minuteAndHour
+ * * minuteHourAndDay
+ * * hourAndDay
+ * * hourDayAndWeek
+ * * dayAndWeek
+ * * dayAndMonth
+ * * dayLetterAndWeek
+ * * dayWeekAndMonth
+ * * weekAndMonth
+ * * weekMonthAndYear
+ * * monthAndYear
+ * * quartersAndYear
+ * * fiveYears
+ * Defaults to hourAndDay.
+ * @property {string} label Label of the time span.
+ * @property {string} name Required. Unique name of the time span.
+ * @property {number} span The number of unit the scheduler will show. Defaults to 1.
+ * @property {string} unit Unit of this time span. Valid values include minute, hour, day, week, month and year. Defaults to day.
  */
 
 /**

--- a/src/modules/base/scheduler/__docs__/scheduler.stories.js
+++ b/src/modules/base/scheduler/__docs__/scheduler.stories.js
@@ -49,212 +49,6 @@ import {
 export default {
     title: 'Example/Scheduler',
     argTypes: {
-        start: {
-            control: {
-                type: 'date'
-            },
-            description:
-                'Specifies the minimum date the calendar can show. It can be a Date object, timestamp, or an ISO8601 formatted string.',
-            table: {
-                type: { summary: 'object' },
-                defaultValue: { summary: 'Date()' },
-                category: 'Available dates'
-            }
-        },
-        headers: {
-            control: {
-                type: 'select'
-            },
-            options: [
-                'minuteAndHour',
-                'minuteHourAndDay',
-                'hourAndDay',
-                'hourDayAndWeek',
-                'dayAndWeek',
-                'dayLetterAndWeek',
-                'dayWeekAndMonth',
-                'weekAndMonth',
-                'weekMonthAndYear',
-                'monthAndYear',
-                'quartersAndYear',
-                'fiveYears'
-            ],
-            description:
-                'Name of the header preset to use. The headers are displayed in resources above the schedule, and used to create its columns. ',
-            table: {
-                type: { summary: 'string' },
-                defaultValue: { summary: 'hourAndDay' }
-            }
-        },
-        customHeaders: {
-            name: 'custom-headers',
-            control: {
-                type: 'object'
-            },
-            description:
-                'Array of date/time scheduler header objects. If present, it will overwrite the headers.',
-            table: {
-                type: { summary: 'object[]' }
-            }
-        },
-        columns: {
-            control: {
-                type: 'object'
-            },
-            description:
-                'Array of datatable column objects. The columns are displayed to the left of the schedule.',
-            table: {
-                type: { summary: 'object' }
-            }
-        },
-        resizeColumnDisabled: {
-            name: 'resize-column-disabled',
-            control: {
-                type: 'boolean'
-            },
-            description: 'If present, column resizing is disabled.',
-            table: {
-                type: { summary: 'boolean' },
-                defaultValue: { summary: 'false' }
-            }
-        },
-        collapseDisabled: {
-            name: 'collapse-disabled',
-            control: {
-                type: 'boolean'
-            },
-            description:
-                'If present, the schedule column is not collapsible or expandable.',
-            table: {
-                type: { summary: 'boolean' },
-                defaultValue: { summary: 'false' }
-            }
-        },
-        resources: {
-            control: {
-                type: 'object'
-            },
-            description:
-                'Array of datatable data objects. Each object represents a row of the scheduler.',
-            table: {
-                type: { summary: 'object' }
-            }
-        },
-        resourcesKeyField: {
-            name: 'resources-key-field',
-            control: {
-                type: 'text'
-            },
-            description:
-                'Name of a key of the row objects. This key needs to be present in all row objects. Its value needs to be unique to a row, as it will be used as the row identifier.',
-            table: {
-                type: { summary: 'string' }
-            }
-        },
-        timeSpan: {
-            name: 'time-span',
-            control: {
-                type: 'object'
-            },
-            description:
-                'Object used to set the duration of the scheduler. It has two keys: unit (valid values include minute, hour, day, month and year) and span (number).',
-            table: {
-                type: { summary: 'object' },
-                defaultValue: { summary: "{ unit: 'day', span: 1 }" }
-            }
-        },
-        hideToolbar: {
-            name: 'hide-toolbar',
-            control: {
-                type: 'boolean'
-            },
-            description: 'If present, the toolbar is hidden.',
-            table: {
-                type: { summary: 'boolean' },
-                defaultValue: { summary: 'false' },
-                category: 'Toolbar'
-            }
-        },
-        events: {
-            control: {
-                type: 'object'
-            },
-            description: 'Array of event objects.',
-            table: {
-                type: { summary: 'object' },
-                category: 'Events'
-            }
-        },
-        readOnly: {
-            name: 'read-only',
-            control: {
-                type: 'boolean'
-            },
-            description:
-                'If present, the scheduler is not editable. The events cannot be dragged and the default actions (edit, delete and add event) will be hidden from the context menus.',
-            table: {
-                type: { summary: 'boolean' },
-                defaultValue: { summary: 'false' }
-            }
-        },
-        isLoading: {
-            name: 'is-loading',
-            control: {
-                type: 'boolean'
-            },
-            description: 'If present, a loading spinner will be visible.',
-            table: {
-                type: { summary: 'boolean' },
-                defaultValue: { summary: 'false' }
-            }
-        },
-        loadingStateAlternativeText: {
-            name: 'loading-state-alternative-text',
-            control: {
-                type: 'text'
-            },
-            description: 'Alternative text of the loading spinner.',
-            table: {
-                type: { summary: 'string' },
-                defaultValue: { summary: 'Loading' }
-            }
-        },
-        recurrentEditModes: {
-            name: 'recurrent-edit-modes',
-            control: {
-                type: 'object'
-            },
-            description:
-                'Allowed edition modes for recurrent events. Available options are: - "all": All recurrent event occurrences will be updated when a change is made to one occurrence. - "one": Only the selected occurrence will be updated when a change is made.',
-            table: {
-                type: { summary: 'string[]' },
-                defaultValue: { summary: ['all', 'one'] },
-                category: 'Events'
-            }
-        },
-        referenceLines: {
-            name: 'reference-lines',
-            control: {
-                type: 'object'
-            },
-            description: 'Array of reference line objects.',
-            table: {
-                type: { summary: 'object[]' }
-            }
-        },
-        availableTimeFrames: {
-            name: 'available-time-frames',
-            control: {
-                type: 'object'
-            },
-            description:
-                'Array of available time frames. If present, the scheduler will only show the available time frames. Defaults to the full day being available. \nEach time frame string must follow the pattern ‘start-end’, with start and end being ISO8601 formatted time strings.',
-            table: {
-                type: { summary: 'object' },
-                defaultValue: { summary: "['00:00-23:59']" },
-                category: 'Available dates'
-            }
-        },
         availableDaysOfTheWeek: {
             name: 'available-days-of-the-week',
             control: {
@@ -283,96 +77,41 @@ export default {
                 category: 'Available dates'
             }
         },
-        dateFormat: {
-            name: 'date-format',
-            control: {
-                type: 'text'
-            },
-            description:
-                "The date format to use in the events' details popup and the labels. See Luxon’s documentation for accepted format. If you want to insert text in the label, you need to escape it using single quote.\n For example, the format of “Jan 14 day shift” would be “LLL dd 'day shift'\". ",
-            table: {
-                type: { summary: 'string' },
-                category: 'Events',
-                defaultValue: { summary: 'ff' }
-            }
-        },
-        disabledDatesTimes: {
-            name: 'disabled-dates-times',
+        availableTimeFrames: {
+            name: 'available-time-frames',
             control: {
                 type: 'object'
             },
-            description: 'Array of disabled date/time objects.',
+            description:
+                'Array of available time frames. If present, the scheduler will only show the available time frames. Defaults to the full day being available. \nEach time frame string must follow the pattern ‘start-end’, with start and end being ISO8601 formatted time strings.',
             table: {
                 type: { summary: 'object' },
+                defaultValue: { summary: "['00:00-23:59']" },
                 category: 'Available dates'
             }
         },
-        eventsLabels: {
-            name: 'events-labels',
+        collapseDisabled: {
+            name: 'collapse-disabled',
+            control: {
+                type: 'boolean'
+            },
+            description:
+                'If present, the schedule column is not collapsible or expandable.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' },
+                category: 'Panels and Toolbar'
+            }
+        },
+        columns: {
             control: {
                 type: 'object'
             },
             description:
-                'Labels of the events, by their position. Valid keys include: top, bottom, left, right, center. \nThe values can be the name of a row key, or the name of an event key. If the row and the event both have a key with the same name, the event value will be used.',
+                'Array of datatable column objects. The columns are displayed to the left of the schedule.',
             table: {
                 type: { summary: 'object' },
-                defaultValue: { summary: "{ center: { fieldName: 'title' } }" },
-                category: 'Events'
-            }
-        },
-        eventsTheme: {
-            name: 'events-theme',
-            control: {
-                type: 'select'
-            },
-            options: ['default', 'transparent', 'line', 'hollow', 'rounded'],
-            description:
-                'Theme of the events. Valid values include default, transparent, line, hollow and rounded.',
-            table: {
-                type: { summary: 'string' },
-                defaultValue: { summary: 'default' },
-                category: 'Events'
-            }
-        },
-        eventsPalette: {
-            name: 'events-palette',
-            control: {
-                type: 'select'
-            },
-            options: [
-                'aurora',
-                'bluegrass',
-                'dusk',
-                'fire',
-                'heat',
-                'lake',
-                'mineral',
-                'nightfall',
-                'ocean',
-                'pond',
-                'sunrise',
-                'water',
-                'watermelon',
-                'wildflowers'
-            ],
-            description:
-                'Default palette used for the event colors. Valid values include aurora, bluegrass, dusk, fire, heat, lake, mineral, nightfall, ocean, pond, sunrise, water, watermelon, wildflowers.',
-            table: {
-                type: { summary: 'string' },
-                defaultValue: { summary: 'aurora' },
-                category: 'Events'
-            }
-        },
-        customEventsPalette: {
-            name: 'custom-events-palette',
-            control: {
-                type: 'object'
-            },
-            description:
-                'Array of colors to use as a palette for the events. If present, it will overwrite the events-palette selected. \nThe color strings have to be valid CSS color values.',
-            table: {
-                type: { summary: 'object' },
-                category: 'Events'
+                category: 'Panels and Toolbar'
             }
         },
         contextMenuEventActions: {
@@ -406,6 +145,31 @@ export default {
                 }
             }
         },
+        customEventsPalette: {
+            name: 'custom-events-palette',
+            control: {
+                type: 'object'
+            },
+            description:
+                'Array of colors to use as a palette for the events. If present, it will overwrite the events-palette selected. \nThe color strings have to be valid CSS color values.',
+            table: {
+                type: { summary: 'object' },
+                category: 'Events'
+            }
+        },
+        dateFormat: {
+            name: 'date-format',
+            control: {
+                type: 'text'
+            },
+            description:
+                "The date format to use in the events' details popup and the labels. See Luxon’s documentation for accepted format. If you want to insert text in the label, you need to escape it using single quote.\n For example, the format of “Jan 14 day shift” would be “LLL dd 'day shift'\". ",
+            table: {
+                type: { summary: 'string' },
+                category: 'Events',
+                defaultValue: { summary: 'ff' }
+            }
+        },
         dialogLabels: {
             name: 'dialog-labels',
             control: {
@@ -435,24 +199,216 @@ export default {
                 category: 'Events'
             }
         },
-        toolbarTimeSpans: {
-            name: 'toolbar-time-spans',
+        disabledDatesTimes: {
+            name: 'disabled-dates-times',
+            control: {
+                type: 'object'
+            },
+            description: 'Array of disabled date/time objects.',
+            table: {
+                type: { summary: 'object' },
+                category: 'Available dates'
+            }
+        },
+        events: {
+            control: {
+                type: 'object'
+            },
+            description: 'Array of event objects.',
+            table: {
+                type: { summary: 'object' },
+                category: 'Events'
+            }
+        },
+        eventsLabels: {
+            name: 'events-labels',
             control: {
                 type: 'object'
             },
             description:
-                'Time spans, to display as buttons in the toolbar. On click on the button, the scheduler time span will be updated. Only three options can be visible, the others will be listed in a button menu.',
+                'Labels of the events. Valid keys include top, bottom, left, right and center. The value of each key should be a label object. \nTop, bottom, left and right labels are only supported for the timeline display with a horizontal variant.',
+            table: {
+                type: { summary: 'object' },
+                defaultValue: { summary: "{ center: { fieldName: 'title' } }" },
+                category: 'Events'
+            }
+        },
+        eventsPalette: {
+            name: 'events-palette',
+            control: {
+                type: 'select'
+            },
+            options: [
+                'aurora',
+                'bluegrass',
+                'dusk',
+                'fire',
+                'heat',
+                'lake',
+                'mineral',
+                'nightfall',
+                'ocean',
+                'pond',
+                'sunrise',
+                'water',
+                'watermelon',
+                'wildflowers'
+            ],
+            description:
+                'Default palette used for the event colors. Valid values include aurora, bluegrass, dusk, fire, heat, lake, mineral, nightfall, ocean, pond, sunrise, water, watermelon, wildflowers.',
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: 'aurora' },
+                category: 'Events'
+            }
+        },
+        eventsTheme: {
+            name: 'events-theme',
+            control: {
+                type: 'select'
+            },
+            options: ['default', 'transparent', 'line', 'hollow', 'rounded'],
+            description:
+                'Theme of the events. Valid values include default, transparent, line, hollow and rounded.',
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: 'default' },
+                category: 'Events'
+            }
+        },
+        hideToolbar: {
+            name: 'hide-toolbar',
+            control: {
+                type: 'boolean'
+            },
+            description: 'If present, the toolbar is hidden.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' },
+                category: 'Panels and Toolbar'
+            }
+        },
+        isLoading: {
+            name: 'is-loading',
+            control: {
+                type: 'boolean'
+            },
+            description: 'If present, a loading spinner will be visible.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' }
+            }
+        },
+        loadingStateAlternativeText: {
+            name: 'loading-state-alternative-text',
+            control: {
+                type: 'text'
+            },
+            description: 'Alternative text of the loading spinner.',
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: 'Loading' }
+            }
+        },
+        readOnly: {
+            name: 'read-only',
+            control: {
+                type: 'boolean'
+            },
+            description:
+                'If present, the scheduler is not editable. The events cannot be dragged and the default actions (edit, delete and add event) will be hidden from the context menus.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' }
+            }
+        },
+        recurrentEditModes: {
+            name: 'recurrent-edit-modes',
+            control: {
+                type: 'object'
+            },
+            description:
+                'Allowed edition modes for recurrent events. Available options are: - "all": All recurrent event occurrences will be updated when a change is made to one occurrence. - "one": Only the selected occurrence will be updated when a change is made.',
+            table: {
+                type: { summary: 'string[]' },
+                defaultValue: { summary: ['all', 'one'] },
+                category: 'Events'
+            }
+        },
+        referenceLines: {
+            name: 'reference-lines',
+            control: {
+                type: 'object'
+            },
+            description: 'Array of reference line objects.',
+            table: {
+                type: { summary: 'object[]' }
+            }
+        },
+        resizeColumnDisabled: {
+            name: 'resize-column-disabled',
+            control: {
+                type: 'boolean'
+            },
+            description: 'If present, column resizing is disabled.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' },
+                category: 'Panels and Toolbar'
+            }
+        },
+        resources: {
+            control: {
+                type: 'object'
+            },
+            description:
+                'Array of resource objects. The resources can be bound to events.',
+            table: {
+                type: { summary: 'object' }
+            }
+        },
+        selectedTimeSpan: {
+            name: 'selected-time-span',
+            control: {
+                type: 'text'
+            },
+            description:
+                'Unique name of the selected time span. The selected time span will determine the visible duration of the scheduler.',
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: 'Standard.Scheduler.DayTimeSpan' }
+            }
+        },
+        start: {
+            control: {
+                type: 'date'
+            },
+            description:
+                'Specifies the minimum date the calendar can show. It can be a Date object, timestamp, or an ISO8601 formatted string.',
+            table: {
+                type: { summary: 'object' },
+                defaultValue: { summary: 'Date()' },
+                category: 'Available dates'
+            }
+        },
+        timeSpans: {
+            name: 'time-spans',
+            control: {
+                type: 'object'
+            },
+            description:
+                'Array of time span objects. The time spans will be displayed in the toolbar. Only three options can be visible, the others will be listed in a button menu.',
             table: {
                 type: { summary: 'object[]' },
                 defaultValue: {
                     summary: `[
-                        { unit: 'day', span: 1, label: 'Day', headers: 'hourAndDay' },
-                        { unit: 'week', span: 1, label: 'Week', headers: 'hourAndDay' },
-                        { unit: 'month', span: 1, label: 'Month', headers: 'dayAndMonth' },
-                        { unit: 'year', span: 1, label: 'Year', headers: 'dayAndMonth' }
+                        { unit: 'day', span: 1, label: 'Day', headers: 'hourAndDay', name: 'Standard.Scheduler.DayTimeSpan' },
+                        { unit: 'week', span: 1, label: 'Week', headers: 'hourAndDay', name: 'Standard.Scheduler.WeekTimeSpan' },
+                        { unit: 'month', span: 1, label: 'Month', headers: 'dayAndMonth', name: 'Standard.Scheduler.MonthTimeSpan' },
+                        { unit: 'year', span: 1, label: 'Year', headers: 'dayAndMonth', name: 'Standard.Scheduler.YearTimeSpan' }
                     ]`
                 },
-                category: 'Toolbar'
+                category: 'Panels and Toolbar'
             }
         },
         variant: {
@@ -472,7 +428,8 @@ export default {
             control: {
                 type: 'boolean'
             },
-            description: 'If present, horizontal scrolling will be prevented.',
+            description:
+                'If present, horizontal scrolling will be prevented in the timeline view, and vertical scrolling will be prevented in the calendar view.',
             table: {
                 type: { summary: 'boolean' },
                 defaultValue: { summary: 'false' }
@@ -512,19 +469,43 @@ export default {
         },
         eventsPalette: 'aurora',
         eventsTheme: 'default',
-        headers: 'hourAndDay',
         hideToolbar: false,
         isLoading: false,
         loadingStateAlternativeText: 'Loading',
         recurrentEditModes: ['all', 'one'],
         readOnly: false,
         resizeColumnDisabled: false,
+        selectedTimeSpan: 'Standard.Scheduler.DayTimeSpan',
         start: new Date(),
-        timeSpan: { unit: 'day', span: 1 },
-        toolbarTimeSpans: [
-            { unit: 'day', span: 1, label: 'Day', headers: 'hourAndDay' },
-            { unit: 'week', span: 1, label: 'Week', headers: 'hourAndDay' },
-            { unit: 'month', span: 1, label: 'Month', headers: 'dayAndMonth' }
+        timeSpans: [
+            {
+                headers: 'hourAndDay',
+                label: 'Day',
+                name: 'Standard.Scheduler.DayTimeSpan',
+                span: 1,
+                unit: 'day'
+            },
+            {
+                headers: 'hourAndDay',
+                label: 'Week',
+                name: 'Standard.Scheduler.WeekTimeSpan',
+                span: 1,
+                unit: 'week'
+            },
+            {
+                headers: 'dayAndMonth',
+                label: 'Month',
+                name: 'Standard.Scheduler.MonthTimeSpan',
+                span: 1,
+                unit: 'month'
+            },
+            {
+                headers: 'dayAndMonth',
+                label: 'Year',
+                name: 'Standard.Scheduler.YearTimeSpan',
+                span: 1,
+                unit: 'year'
+            }
         ],
         variant: 'horizontal',
         zoomToFit: false
@@ -536,7 +517,6 @@ const Template = (args) => Scheduler(args);
 export const Base = Template.bind({});
 Base.args = {
     columns,
-    resourcesKeyField: 'id',
     resources,
     start,
     events: basicEvents
@@ -544,7 +524,6 @@ Base.args = {
 
 export const Vertical = Template.bind({});
 Vertical.args = {
-    resourcesKeyField: 'id',
     resources,
     start,
     availableTimeFrames: ['08:00-17:00'],
@@ -558,19 +537,32 @@ Vertical.args = {
 export const AvailableAndDisabledTimes = Template.bind({});
 AvailableAndDisabledTimes.args = {
     columns,
-    resourcesKeyField: 'id',
     resources,
-    customHeaders: headers,
-    timeSpan: {
-        unit: 'week',
-        span: 2
-    },
     start,
-    toolbarTimeSpans: [
-        { unit: 'day', span: 1, label: 'Day', headers: 'hourAndDay' },
-        { unit: 'week', span: 2, label: 'Sprint', headers: 'hourDayAndWeek' },
-        { unit: 'month', span: 1, label: 'Month', headers: 'dayAndMonth' }
+    timeSpans: [
+        {
+            unit: 'day',
+            span: 1,
+            label: 'Day',
+            headers: 'hourAndDay',
+            name: 'day'
+        },
+        {
+            unit: 'week',
+            span: 2,
+            label: 'Sprint',
+            name: 'sprint',
+            customHeaders: headers
+        },
+        {
+            unit: 'month',
+            span: 1,
+            label: 'Month',
+            headers: 'dayAndMonth',
+            name: 'month'
+        }
     ],
+    selectedTimeSpan: 'sprint',
     availableTimeFrames: ['08:00-17:00'],
     availableDaysOfTheWeek: [1, 2, 3, 4, 5],
     events,
@@ -581,12 +573,28 @@ AvailableAndDisabledTimes.args = {
 export const ReadOnly = Template.bind({});
 ReadOnly.args = {
     columns,
-    resourcesKeyField: 'id',
     resources,
-    timeSpan: {
-        unit: 'day',
-        span: 5
-    },
+    selectedTimeSpan: 'workWeek',
+    availableDaysOfTheWeek: [1, 2, 3, 4, 5],
+    timeSpans: [
+        {
+            name: 'day',
+            label: 'Day'
+        },
+        {
+            name: 'workWeek',
+            label: 'Work Week',
+            unit: 'day',
+            span: 5
+        },
+        {
+            name: 'trimester',
+            label: 'Trimester',
+            unit: 'month',
+            span: 3,
+            headers: 'monthAndYear'
+        }
+    ],
     start,
     events,
     eventsTheme: 'line',
@@ -605,17 +613,30 @@ export const ZoomToFit = Template.bind({});
 ZoomToFit.args = {
     zoomToFit: true,
     columns: oneColumn,
-    resourcesKeyField: 'id',
     resources,
-    timeSpan: {
-        unit: 'year',
-        span: 1
-    },
-    headers: 'monthAndYear',
-    toolbarTimeSpans: [
-        { unit: 'week', span: 1, label: 'Week', headers: 'dayAndWeek' },
-        { unit: 'month', span: 1, label: 'Month', headers: 'dayAndMonth' },
-        { unit: 'year', span: 1, label: 'Year', headers: 'monthAndYear' }
+    selectedTimeSpan: 'year',
+    timeSpans: [
+        {
+            unit: 'week',
+            span: 1,
+            label: 'Week',
+            headers: 'dayAndWeek',
+            name: 'week'
+        },
+        {
+            unit: 'month',
+            span: 1,
+            label: 'Month',
+            headers: 'dayAndMonth',
+            name: 'month'
+        },
+        {
+            unit: 'year',
+            span: 1,
+            label: 'Year',
+            headers: 'monthAndYear',
+            name: 'year'
+        }
     ],
     start: new Date(2021, 0, 1),
     events: longEvents,
@@ -625,15 +646,11 @@ ZoomToFit.args = {
 export const Labels = Template.bind({});
 Labels.args = {
     columns,
-    resourcesKeyField: 'id',
     resources,
     start,
     events: eventsWithLabels,
-    timeSpan: {
-        unit: 'day',
-        span: '2'
-    },
-    headers: 'minuteHourAndDay',
+    selectedTimeSpan: 'twoDays',
+    timeSpans: [{ span: 2, label: 'Two days', name: 'twoDays' }],
     eventsLabels: {
         left: {
             fieldName: 'from'
@@ -658,7 +675,6 @@ Labels.args = {
 export const ThemesAndColors = Template.bind({});
 ThemesAndColors.args = {
     columns,
-    resourcesKeyField: 'id',
     resources,
     start,
     events: eventsThemed,

--- a/src/modules/base/scheduler/__examples__/availableAndDisabledTimes/availableAndDisabledTimes.html
+++ b/src/modules/base/scheduler/__examples__/availableAndDisabledTimes/availableAndDisabledTimes.html
@@ -3,14 +3,12 @@
         available-days-of-the-week={availableDaysOfTheWeek}
         available-time-frames={availableTimeFrames}
         columns={columns}
-        custom-headers={headers}
         disabled-dates-times={disabledDatesTimes}
         events={events}
         reference-lines={referenceLines}
-        resources-key-field="id"
         resources={resources}
+        selected-time-span="sprint"
         start={start}
-        time-span={timeSpan}
-        toolbar-time-spans={toolbarTimeSpans}
+        time-spans={timeSpans}
     ></avonni-scheduler>
 </template>

--- a/src/modules/base/scheduler/__examples__/availableAndDisabledTimes/availableAndDisabledTimes.js
+++ b/src/modules/base/scheduler/__examples__/availableAndDisabledTimes/availableAndDisabledTimes.js
@@ -7,15 +7,13 @@ export default class SchedulerAvailableAndDisabledTimes extends LightningElement
     columns = [
         {
             label: 'Staff',
-            fieldName: 'resourceAvatarSrc',
+            fieldName: 'avatarSrc',
             type: 'avatar',
             typeAttributes: {
                 alternativeText: 'Avatar',
-                fallbackIconName: {
-                    fieldName: 'resourceAvatarFallbackIconName'
-                },
-                initials: { fieldName: 'resourceAvatarInitials' },
-                primaryText: { fieldName: 'resourceName' }
+                fallbackIconName: { fieldName: 'avatarFallbackIconName' },
+                initials: { fieldName: 'avatarInitials' },
+                primaryText: { fieldName: 'name' }
             }
         },
         {
@@ -25,32 +23,9 @@ export default class SchedulerAvailableAndDisabledTimes extends LightningElement
         }
     ];
 
-    customHeaders = [
-        {
-            unit: 'week',
-            span: 1,
-            label: "'Sprint' W"
-        },
-        {
-            unit: 'day',
-            span: 1,
-            label: 'ccc dd'
-        },
-        {
-            unit: 'hour',
-            span: 1,
-            label: 'h a'
-        },
-        {
-            unit: 'minute',
-            span: 15,
-            label: 'mm'
-        }
-    ];
-
     disabledDatesTimes = [
         {
-            keyFields: ['1', '2', '3', '4', '5'],
+            resourceNames: ['Nina', 'Dave', 'Jung', 'Lily', 'Reginald'],
             title: 'Lunch',
             iconName: 'custom:custom51',
             from: new Date(2021, 0, 1, 12),
@@ -61,13 +36,13 @@ export default class SchedulerAvailableAndDisabledTimes extends LightningElement
             }
         },
         {
-            keyFields: ['4'],
+            resourceNames: ['Lily'],
             title: 'Vacation',
             from: new Date(2021, 11, 6),
             to: new Date(2021, 11, 20)
         },
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             title: 'Day off',
             from: new Date(2021, 11, 23),
             allDay: true
@@ -76,14 +51,14 @@ export default class SchedulerAvailableAndDisabledTimes extends LightningElement
 
     events = [
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             name: 'research',
             title: 'Research',
             from: new Date(2021, 11, 13, 9),
             to: new Date(2021, 11, 14, 12)
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'code-review',
             title: 'Code review',
             from: new Date(2021, 11, 13, 13),
@@ -91,77 +66,77 @@ export default class SchedulerAvailableAndDisabledTimes extends LightningElement
             recurrence: 'daily'
         },
         {
-            keyFields: ['3', '2'],
+            resourceNames: ['Jung', 'Dave'],
             name: 'seminar',
             title: 'Online seminar',
             from: new Date(2021, 11, 14, 8),
             to: new Date(2021, 11, 16)
         },
         {
-            keyFields: ['1', '3'],
+            resourceNames: ['Nina', 'Jung'],
             name: 'write-spec',
             title: 'Write specifications',
             from: new Date(2021, 11, 15),
             allDay: true
         },
         {
-            keyFields: ['2'],
+            resourceNames: ['Dave'],
             name: 'create-wireframe',
             title: 'Create wireframe',
             from: new Date(2021, 11, 13, 10, 15),
             to: new Date(2021, 11, 16, 12)
         },
         {
-            keyFields: ['4'],
+            resourceNames: ['Lily'],
             name: 'create-mockup',
             title: 'Create mockup',
             from: new Date(2021, 11, 20, 7),
             to: new Date(2021, 11, 22, 10, 30)
         },
         {
-            keyFields: ['2'],
+            resourceNames: ['Dave'],
             name: 'test-new-ui',
             title: 'Test new UI',
             from: new Date(2021, 11, 17, 15),
             to: new Date(2021, 11, 21)
         },
         {
-            keyFields: ['5'],
+            resourceNames: ['Reginald'],
             name: 'implement-feature',
             title: 'Implement feature',
             from: new Date(2021, 11, 13, 14),
             to: new Date(2021, 11, 15, 16)
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'push-to-prod',
             title: 'Push to production',
             from: new Date(2021, 11, 16, 11),
             to: new Date(2021, 11, 16, 12)
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'phone-meeting',
             title: 'Phone meeting',
             from: new Date(2021, 11, 21, 10),
             to: new Date(2021, 11, 21, 12)
         },
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             name: 'update-documentation',
             title: 'Update documentation',
             from: new Date(2021, 11, 17, 11),
             to: new Date(2021, 11, 17, 18)
         },
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             name: 'presentation',
             title: 'Presentation at the conference',
             from: new Date(2021, 11, 16, 11),
             to: new Date(2021, 11, 16, 18)
         },
         {
-            keyFields: ['2', '4'],
+            resourceNames: ['Dave', 'Lily'],
             name: 'ux-ui-team-meeting',
             title: 'UI/UX team meeting',
             from: new Date(2021, 11, 17, 11),
@@ -169,14 +144,14 @@ export default class SchedulerAvailableAndDisabledTimes extends LightningElement
             recurrence: 'weekly'
         },
         {
-            keyFields: ['1', '2', '3', '4', '5'],
+            resourceNames: ['Nina', 'Dave', 'Jung', 'Lily', 'Reginald'],
             name: 'office-party',
             title: 'Office party',
             from: new Date(2021, 11, 24, 12),
             to: new Date(2021, 11, 25)
         },
         {
-            keyFields: ['1', '5'],
+            resourceNames: ['Nina', 'Reginald'],
             name: 'standup',
             title: 'Stand-up meeting',
             from: new Date(2021, 11, 13, 9, 30),
@@ -185,29 +160,6 @@ export default class SchedulerAvailableAndDisabledTimes extends LightningElement
             recurrenceAttributes: {
                 weekdays: [1, 3, 5]
             }
-        }
-    ];
-
-    headers = [
-        {
-            unit: 'week',
-            span: 1,
-            label: "'Sprint' W"
-        },
-        {
-            unit: 'day',
-            span: 1,
-            label: 'ccc dd'
-        },
-        {
-            unit: 'hour',
-            span: 1,
-            label: 'h a'
-        },
-        {
-            unit: 'minute',
-            span: 15,
-            label: 'mm'
         }
     ];
 
@@ -230,61 +182,90 @@ export default class SchedulerAvailableAndDisabledTimes extends LightningElement
 
     resources = [
         {
-            id: '1',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar2.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'NG',
-            resourceName: 'Nina',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'NG',
+            name: 'Nina',
             role: 'Lead developer',
             sharedField: `This shouldn't show up`
         },
         {
-            id: '2',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar1.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'DM',
-            resourceName: 'Dave',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'DM',
+            name: 'Dave',
             role: 'UX Specialist',
             customRowField: 'Label coming from a custom field in the row'
         },
         {
-            id: '3',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'JP',
-            resourceName: 'Jung',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'JP',
+            name: 'Jung',
             role: 'Product Owner'
         },
         {
-            id: '4',
-            resourceAvatarFallbackIconName: 'standard:article',
-            resourceAvatarInitials: 'LM',
-            resourceName: 'Lily',
+            avatarFallbackIconName: 'standard:article',
+            avatarInitials: 'LM',
+            name: 'Lily',
             role: 'Graphic Designer',
             customField: "This comes from the row's custom field"
         },
         {
-            id: '5',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar3.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'RM',
-            resourceName: 'Reginald',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'RM',
+            name: 'Reginald',
             role: 'Developer'
         }
     ];
 
     start = new Date(2021, 11, 13, 8);
 
-    timeSpan = {
-        unit: 'week',
-        span: 2
-    };
-
-    toolbarTimeSpans = [
-        { unit: 'day', span: 1, label: 'Day', headers: 'hourAndDay' },
-        { unit: 'week', span: 2, label: 'Sprint', headers: 'hourDayAndWeek' },
-        { unit: 'month', span: 1, label: 'Month', headers: 'dayAndMonth' }
+    timeSpans = [
+        {
+            unit: 'day',
+            span: 1,
+            label: 'Day',
+            headers: 'hourAndDay',
+            name: 'day'
+        },
+        {
+            unit: 'week',
+            span: 2,
+            label: 'Sprint',
+            name: 'sprint',
+            customHeaders: [
+                {
+                    unit: 'week',
+                    span: 1,
+                    label: "'Sprint' W"
+                },
+                {
+                    unit: 'day',
+                    span: 1,
+                    label: 'ccc dd'
+                },
+                {
+                    unit: 'hour',
+                    span: 1,
+                    label: 'h a'
+                },
+                {
+                    unit: 'minute',
+                    span: 15,
+                    label: 'mm'
+                }
+            ]
+        },
+        {
+            unit: 'month',
+            span: 1,
+            label: 'Month',
+            headers: 'dayAndMonth',
+            name: 'month'
+        }
     ];
 }

--- a/src/modules/base/scheduler/__examples__/base/base.html
+++ b/src/modules/base/scheduler/__examples__/base/base.html
@@ -1,7 +1,6 @@
 <template>
     <avonni-scheduler
         columns={columns}
-        resources-key-field="id"
         resources={resources}
         start={start}
         events={events}

--- a/src/modules/base/scheduler/__examples__/base/base.js
+++ b/src/modules/base/scheduler/__examples__/base/base.js
@@ -4,15 +4,13 @@ export default class SchedulerBase extends LightningElement {
     columns = [
         {
             label: 'Staff',
-            fieldName: 'resourceAvatarSrc',
+            fieldName: 'avatarSrc',
             type: 'avatar',
             typeAttributes: {
                 alternativeText: 'Avatar',
-                fallbackIconName: {
-                    fieldName: 'resourceAvatarFallbackIconName'
-                },
-                initials: { fieldName: 'resourceAvatarInitials' },
-                primaryText: { fieldName: 'resourceName' }
+                fallbackIconName: { fieldName: 'avatarFallbackIconName' },
+                initials: { fieldName: 'avatarInitials' },
+                primaryText: { fieldName: 'name' }
             }
         },
         {
@@ -24,70 +22,70 @@ export default class SchedulerBase extends LightningElement {
 
     events = [
         {
-            keyFields: ['3', '4', '5'],
+            resourceNames: ['Jung', 'Lily', 'Reginald'],
             name: 'event-1',
             title: 'Event 1',
             from: 1639400400000,
             to: 1639407600000
         },
         {
-            keyFields: ['5', '3', '4'],
+            resourceNames: ['Reginald', 'Jung', 'Lily'],
             name: 'event-2',
             title: 'Event 2',
             from: 1639404000000,
             to: 1639411200000
         },
         {
-            keyFields: ['3', '4', '2'],
+            resourceNames: ['Jung', 'Lily', 'Dave'],
             name: 'event-3',
             title: 'Event 3',
             from: 1639407600000,
             to: 1639414800000
         },
         {
-            keyFields: ['1', '4'],
+            resourceNames: ['Nina', 'Lily'],
             name: 'event-4',
             title: 'Event 4',
             from: 1639411200000,
             to: 1639418400000
         },
         {
-            keyFields: ['2', '1'],
+            resourceNames: ['Dave', 'Nina'],
             name: 'event-5',
             title: 'Event 5',
             from: 1639414800000,
             to: 1639422000000
         },
         {
-            keyFields: ['1', '2', '3'],
+            resourceNames: ['Nina', 'Dave', 'Jung'],
             name: 'event-6',
             title: 'Event 6',
             from: 1639418400000,
             to: 1639425600000
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'event-7',
             title: 'Event 7',
             from: 1639422000000,
             to: 1639429200000
         },
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             name: 'event-8',
             title: 'Event 8',
             from: 1639425600000,
             to: 1639432800000
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'event-9',
             title: 'Event 9',
             from: 1639429200000,
             to: 1639436400000
         },
         {
-            keyFields: ['2', '3', '4'],
+            resourceNames: ['Dave', 'Jung', 'Lily'],
             name: 'event-10',
             title: 'Event 10',
             from: 1639432800000,
@@ -97,47 +95,42 @@ export default class SchedulerBase extends LightningElement {
 
     resources = [
         {
-            id: '1',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar2.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'NG',
-            resourceName: 'Nina',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'NG',
+            name: 'Nina',
             role: 'Lead developer',
             sharedField: `This shouldn't show up`
         },
         {
-            id: '2',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar1.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'DM',
-            resourceName: 'Dave',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'DM',
+            name: 'Dave',
             role: 'UX Specialist',
             customRowField: 'Label coming from a custom field in the row'
         },
         {
-            id: '3',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'JP',
-            resourceName: 'Jung',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'JP',
+            name: 'Jung',
             role: 'Product Owner'
         },
         {
-            id: '4',
-            resourceAvatarFallbackIconName: 'standard:article',
-            resourceAvatarInitials: 'LM',
-            resourceName: 'Lily',
+            avatarFallbackIconName: 'standard:article',
+            avatarInitials: 'LM',
+            name: 'Lily',
             role: 'Graphic Designer',
             customField: "This comes from the row's custom field"
         },
         {
-            id: '5',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar3.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'RM',
-            resourceName: 'Reginald',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'RM',
+            name: 'Reginald',
             role: 'Developer'
         }
     ];

--- a/src/modules/base/scheduler/__examples__/labels/labels.html
+++ b/src/modules/base/scheduler/__examples__/labels/labels.html
@@ -4,10 +4,9 @@
         date-format="hh:mm"
         events={events}
         events-labels={eventsLabels}
-        headers="minuteHourAndDay"
-        resources-key-field="id"
         resources={resources}
+        selected-time-spans="twoDays"
         start={start}
-        time-span={timeSpan}
+        time-spans={timeSpans}
     ></avonni-scheduler>
 </template>

--- a/src/modules/base/scheduler/__examples__/labels/labels.js
+++ b/src/modules/base/scheduler/__examples__/labels/labels.js
@@ -4,15 +4,13 @@ export default class SchedulerLabels extends LightningElement {
     columns = [
         {
             label: 'Staff',
-            fieldName: 'resourceAvatarSrc',
+            fieldName: 'avatarSrc',
             type: 'avatar',
             typeAttributes: {
                 alternativeText: 'Avatar',
-                fallbackIconName: {
-                    fieldName: 'resourceAvatarFallbackIconName'
-                },
-                initials: { fieldName: 'resourceAvatarInitials' },
-                primaryText: { fieldName: 'resourceName' }
+                fallbackIconName: { fieldName: 'avatarFallbackIconName' },
+                initials: { fieldName: 'avatarInitials' },
+                primaryText: { fieldName: 'name' }
             }
         },
         {
@@ -24,7 +22,7 @@ export default class SchedulerLabels extends LightningElement {
 
     events = [
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             name: 'research',
             title: 'Research',
             from: new Date(2021, 11, 13, 9),
@@ -37,7 +35,7 @@ export default class SchedulerLabels extends LightningElement {
             }
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'code-review',
             title: 'Code review',
             from: new Date(2021, 11, 13, 13),
@@ -45,21 +43,21 @@ export default class SchedulerLabels extends LightningElement {
             recurrence: 'daily'
         },
         {
-            keyFields: ['3', '2'],
+            resourceNames: ['Jung', 'Dave'],
             name: 'seminar',
             title: 'Online seminar',
             from: new Date(2021, 11, 14, 8),
             to: new Date(2021, 11, 16)
         },
         {
-            keyFields: ['1', '3'],
+            resourceNames: ['Nina', 'Jung'],
             name: 'write-spec',
             title: 'Write specifications',
             from: new Date(2021, 11, 15),
             allDay: true
         },
         {
-            keyFields: ['2'],
+            resourceNames: ['Dave'],
             name: 'create-wireframe',
             title: 'Create wireframe',
             from: new Date(2021, 11, 13, 10, 15),
@@ -75,14 +73,14 @@ export default class SchedulerLabels extends LightningElement {
             }
         },
         {
-            keyFields: ['5'],
+            resourceNames: ['Reginald'],
             name: 'implement-feature',
             title: 'Implement feature',
             from: new Date(2021, 11, 13, 14),
             to: new Date(2021, 11, 15, 16)
         },
         {
-            keyFields: ['1', '5'],
+            resourceNames: ['Nina', 'Reginald'],
             name: 'standup',
             title: 'Stand-up meeting',
             from: new Date(2021, 11, 13, 9, 30),
@@ -115,55 +113,47 @@ export default class SchedulerLabels extends LightningElement {
 
     resources = [
         {
-            id: '1',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar2.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'NG',
-            resourceName: 'Nina',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'NG',
+            name: 'Nina',
             role: 'Lead developer',
             sharedField: `This shouldn't show up`
         },
         {
-            id: '2',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar1.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'DM',
-            resourceName: 'Dave',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'DM',
+            name: 'Dave',
             role: 'UX Specialist',
             customRowField: 'Label coming from a custom field in the row'
         },
         {
-            id: '3',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'JP',
-            resourceName: 'Jung',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'JP',
+            name: 'Jung',
             role: 'Product Owner'
         },
         {
-            id: '4',
-            resourceAvatarFallbackIconName: 'standard:article',
-            resourceAvatarInitials: 'LM',
-            resourceName: 'Lily',
+            avatarFallbackIconName: 'standard:article',
+            avatarInitials: 'LM',
+            name: 'Lily',
             role: 'Graphic Designer',
             customField: "This comes from the row's custom field"
         },
         {
-            id: '5',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar3.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'RM',
-            resourceName: 'Reginald',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'RM',
+            name: 'Reginald',
             role: 'Developer'
         }
     ];
 
     start = new Date(2021, 11, 13, 8);
 
-    timeSpan = {
-        unit: 'day',
-        span: 2
-    };
+    timeSpans = [{ span: 2, label: 'Two days', name: 'twoDays' }];
 }

--- a/src/modules/base/scheduler/__examples__/readOnly/readOnly.html
+++ b/src/modules/base/scheduler/__examples__/readOnly/readOnly.html
@@ -7,9 +7,9 @@
         events-theme="line"
         events-palette="dusk"
         read-only
-        resources-key-field="id"
         resources={resources}
+        selected-time-span="workWeek"
         start={start}
-        time-span={timeSpan}
+        time-spans={timeSpans}
     ></avonni-scheduler>
 </template>

--- a/src/modules/base/scheduler/__examples__/readOnly/readOnly.js
+++ b/src/modules/base/scheduler/__examples__/readOnly/readOnly.js
@@ -4,15 +4,13 @@ export default class SchedulerReadOnly extends LightningElement {
     columns = [
         {
             label: 'Staff',
-            fieldName: 'resourceAvatarSrc',
+            fieldName: 'avatarSrc',
             type: 'avatar',
             typeAttributes: {
                 alternativeText: 'Avatar',
-                fallbackIconName: {
-                    fieldName: 'resourceAvatarFallbackIconName'
-                },
-                initials: { fieldName: 'resourceAvatarInitials' },
-                primaryText: { fieldName: 'resourceName' }
+                fallbackIconName: { fieldName: 'avatarFallbackIconName' },
+                initials: { fieldName: 'avatarInitials' },
+                primaryText: { fieldName: 'name' }
             }
         },
         {
@@ -33,14 +31,14 @@ export default class SchedulerReadOnly extends LightningElement {
 
     events = [
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             name: 'research',
             title: 'Research',
             from: new Date(2021, 11, 13, 9),
             to: new Date(2021, 11, 14, 12)
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'code-review',
             title: 'Code review',
             from: new Date(2021, 11, 13, 13),
@@ -48,77 +46,77 @@ export default class SchedulerReadOnly extends LightningElement {
             recurrence: 'daily'
         },
         {
-            keyFields: ['3', '2'],
+            resourceNames: ['Jung', 'Dave'],
             name: 'seminar',
             title: 'Online seminar',
             from: new Date(2021, 11, 14, 8),
             to: new Date(2021, 11, 16)
         },
         {
-            keyFields: ['1', '3'],
+            resourceNames: ['Nina', 'Jung'],
             name: 'write-spec',
             title: 'Write specifications',
             from: new Date(2021, 11, 15),
             allDay: true
         },
         {
-            keyFields: ['2'],
+            resourceNames: ['Dave'],
             name: 'create-wireframe',
             title: 'Create wireframe',
             from: new Date(2021, 11, 13, 10, 15),
             to: new Date(2021, 11, 16, 12)
         },
         {
-            keyFields: ['4'],
+            resourceNames: ['Lily'],
             name: 'create-mockup',
             title: 'Create mockup',
             from: new Date(2021, 11, 20, 7),
             to: new Date(2021, 11, 22, 10, 30)
         },
         {
-            keyFields: ['2'],
+            resourceNames: ['Dave'],
             name: 'test-new-ui',
             title: 'Test new UI',
             from: new Date(2021, 11, 17, 15),
             to: new Date(2021, 11, 21)
         },
         {
-            keyFields: ['5'],
+            resourceNames: ['Reginald'],
             name: 'implement-feature',
             title: 'Implement feature',
             from: new Date(2021, 11, 13, 14),
             to: new Date(2021, 11, 15, 16)
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'push-to-prod',
             title: 'Push to production',
             from: new Date(2021, 11, 16, 11),
             to: new Date(2021, 11, 16, 12)
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'phone-meeting',
             title: 'Phone meeting',
             from: new Date(2021, 11, 21, 10),
             to: new Date(2021, 11, 21, 12)
         },
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             name: 'update-documentation',
             title: 'Update documentation',
             from: new Date(2021, 11, 17, 11),
             to: new Date(2021, 11, 17, 18)
         },
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             name: 'presentation',
             title: 'Presentation at the conference',
             from: new Date(2021, 11, 16, 11),
             to: new Date(2021, 11, 16, 18)
         },
         {
-            keyFields: ['2', '4'],
+            resourceNames: ['Dave', 'Lily'],
             name: 'ux-ui-team-meeting',
             title: 'UI/UX team meeting',
             from: new Date(2021, 11, 17, 11),
@@ -126,14 +124,14 @@ export default class SchedulerReadOnly extends LightningElement {
             recurrence: 'weekly'
         },
         {
-            keyFields: ['1', '2', '3', '4', '5'],
+            resourceNames: ['Nina', 'Dave', 'Jung', 'Lily', 'Reginald'],
             name: 'office-party',
             title: 'Office party',
             from: new Date(2021, 11, 24, 12),
             to: new Date(2021, 11, 25)
         },
         {
-            keyFields: ['1', '5'],
+            resourceNames: ['Nina', 'Reginald'],
             name: 'standup',
             title: 'Stand-up meeting',
             from: new Date(2021, 11, 13, 9, 30),
@@ -147,55 +145,65 @@ export default class SchedulerReadOnly extends LightningElement {
 
     resources = [
         {
-            id: '1',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar2.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'NG',
-            resourceName: 'Nina',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'NG',
+            name: 'Nina',
             role: 'Lead developer',
             sharedField: `This shouldn't show up`
         },
         {
-            id: '2',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar1.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'DM',
-            resourceName: 'Dave',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'DM',
+            name: 'Dave',
             role: 'UX Specialist',
             customRowField: 'Label coming from a custom field in the row'
         },
         {
-            id: '3',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'JP',
-            resourceName: 'Jung',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'JP',
+            name: 'Jung',
             role: 'Product Owner'
         },
         {
-            id: '4',
-            resourceAvatarFallbackIconName: 'standard:article',
-            resourceAvatarInitials: 'LM',
-            resourceName: 'Lily',
+            avatarFallbackIconName: 'standard:article',
+            avatarInitials: 'LM',
+            name: 'Lily',
             role: 'Graphic Designer',
             customField: "This comes from the row's custom field"
         },
         {
-            id: '5',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar3.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'RM',
-            resourceName: 'Reginald',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'RM',
+            name: 'Reginald',
             role: 'Developer'
         }
     ];
 
     start = new Date(2021, 11, 13, 8);
 
-    timeSpan = {
-        unit: 'day',
-        span: 5
-    };
+    timeSpans = [
+        {
+            name: 'day',
+            label: 'Day'
+        },
+        {
+            name: 'workWeek',
+            label: 'Work Week',
+            unit: 'day',
+            span: 5
+        },
+        {
+            name: 'trimester',
+            label: 'Trimester',
+            unit: 'month',
+            span: 3,
+            headers: 'monthAndYear'
+        }
+    ];
 }

--- a/src/modules/base/scheduler/__examples__/scheduler.js
+++ b/src/modules/base/scheduler/__examples__/scheduler.js
@@ -50,8 +50,6 @@ export const Scheduler = ({
     eventsLabels,
     eventsPalette,
     eventsTheme,
-    customHeaders,
-    headers,
     hideToolbar,
     isLoading,
     readOnly,
@@ -59,10 +57,9 @@ export const Scheduler = ({
     referenceLines,
     resizeColumnDisabled,
     resources,
-    resourcesKeyField,
+    selectedTimeSpan,
     start,
-    timeSpan,
-    toolbarTimeSpans,
+    timeSpans,
     variant,
     zoomToFit
 }) => {
@@ -82,8 +79,6 @@ export const Scheduler = ({
     element.eventsLabels = eventsLabels;
     element.eventsPalette = eventsPalette;
     element.eventsTheme = eventsTheme;
-    element.customHeaders = customHeaders;
-    element.headers = headers;
     element.hideToolbar = hideToolbar;
     element.isLoading = isLoading;
     element.readOnly = readOnly;
@@ -91,10 +86,9 @@ export const Scheduler = ({
     element.referenceLines = referenceLines;
     element.resizeColumnDisabled = resizeColumnDisabled;
     element.resources = resources;
-    element.resourcesKeyField = resourcesKeyField;
+    element.selectedTimeSpan = selectedTimeSpan;
     element.start = start;
-    element.timeSpan = timeSpan;
-    element.toolbarTimeSpans = toolbarTimeSpans;
+    element.timeSpans = timeSpans;
     element.variant = variant;
     element.zoomToFit = zoomToFit;
     return element;

--- a/src/modules/base/scheduler/__examples__/themesAndColors/themesAndColors.html
+++ b/src/modules/base/scheduler/__examples__/themesAndColors/themesAndColors.html
@@ -4,7 +4,6 @@
         events={events}
         events-palette="wildflowers"
         hide-toolbar
-        resources-key-field="id"
         resources={resources}
         start={start}
     ></avonni-scheduler>

--- a/src/modules/base/scheduler/__examples__/themesAndColors/themesAndColors.js
+++ b/src/modules/base/scheduler/__examples__/themesAndColors/themesAndColors.js
@@ -4,15 +4,13 @@ export default class SchedulerThemesAndColors extends LightningElement {
     columns = [
         {
             label: 'Staff',
-            fieldName: 'resourceAvatarSrc',
+            fieldName: 'avatarSrc',
             type: 'avatar',
             typeAttributes: {
                 alternativeText: 'Avatar',
-                fallbackIconName: {
-                    fieldName: 'resourceAvatarFallbackIconName'
-                },
-                initials: { fieldName: 'resourceAvatarInitials' },
-                primaryText: { fieldName: 'resourceName' }
+                fallbackIconName: { fieldName: 'avatarFallbackIconName' },
+                initials: { fieldName: 'avatarInitials' },
+                primaryText: { fieldName: 'name' }
             }
         },
         {
@@ -24,7 +22,7 @@ export default class SchedulerThemesAndColors extends LightningElement {
 
     events = [
         {
-            keyFields: ['1', '5', '4'],
+            resourceNames: ['Nina', 'Reginald', 'Lily'],
             name: 'event-1',
             title: 'Theme hollow',
             from: 1639400400000,
@@ -32,7 +30,7 @@ export default class SchedulerThemesAndColors extends LightningElement {
             theme: 'hollow'
         },
         {
-            keyFields: ['4'],
+            resourceNames: ['Lily'],
             name: 'event-2',
             title: 'Theme line',
             from: 1639404000000,
@@ -40,7 +38,7 @@ export default class SchedulerThemesAndColors extends LightningElement {
             theme: 'line'
         },
         {
-            keyFields: ['5', '3'],
+            resourceNames: ['Reginald', 'Jung'],
             name: 'event-3',
             title: 'Custom color',
             from: 1639432800000,
@@ -48,7 +46,7 @@ export default class SchedulerThemesAndColors extends LightningElement {
             color: 'tomato'
         },
         {
-            keyFields: ['2', '4'],
+            resourceNames: ['Dave', 'Lily'],
             name: 'event-4',
             title: 'Theme transparent',
             from: 1639411200000,
@@ -56,7 +54,7 @@ export default class SchedulerThemesAndColors extends LightningElement {
             theme: 'transparent'
         },
         {
-            keyFields: ['2', '1'],
+            resourceNames: ['Dave', 'Nina'],
             name: 'event-5',
             title: 'Theme rounded',
             from: 1639414800000,
@@ -64,7 +62,7 @@ export default class SchedulerThemesAndColors extends LightningElement {
             theme: 'rounded'
         },
         {
-            keyFields: ['4', '1'],
+            resourceNames: ['Lily', 'Nina'],
             name: 'event-6',
             title: 'Default theme',
             from: 1639425600000,
@@ -74,47 +72,42 @@ export default class SchedulerThemesAndColors extends LightningElement {
 
     resources = [
         {
-            id: '1',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar2.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'NG',
-            resourceName: 'Nina',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'NG',
+            name: 'Nina',
             role: 'Lead developer',
             sharedField: `This shouldn't show up`
         },
         {
-            id: '2',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar1.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'DM',
-            resourceName: 'Dave',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'DM',
+            name: 'Dave',
             role: 'UX Specialist',
             customRowField: 'Label coming from a custom field in the row'
         },
         {
-            id: '3',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'JP',
-            resourceName: 'Jung',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'JP',
+            name: 'Jung',
             role: 'Product Owner'
         },
         {
-            id: '4',
-            resourceAvatarFallbackIconName: 'standard:article',
-            resourceAvatarInitials: 'LM',
-            resourceName: 'Lily',
+            avatarFallbackIconName: 'standard:article',
+            avatarInitials: 'LM',
+            name: 'Lily',
             role: 'Graphic Designer',
             customField: "This comes from the row's custom field"
         },
         {
-            id: '5',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar3.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'RM',
-            resourceName: 'Reginald',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'RM',
+            name: 'Reginald',
             role: 'Developer'
         }
     ];

--- a/src/modules/base/scheduler/__examples__/vertical/vertical.html
+++ b/src/modules/base/scheduler/__examples__/vertical/vertical.html
@@ -5,7 +5,6 @@
         disabled-dates-times={disabledDatesTimes}
         events={events}
         reference-lines={referenceLines}
-        resources-key-field="id"
         resources={resources}
         start={start}
         variant="vertical"

--- a/src/modules/base/scheduler/__examples__/vertical/vertical.js
+++ b/src/modules/base/scheduler/__examples__/vertical/vertical.js
@@ -6,7 +6,7 @@ export default class SchedulerVertical extends LightningElement {
 
     disabledDatesTimes = [
         {
-            keyFields: ['1', '2', '3', '4', '5'],
+            resourceNames: ['Nina', 'Dave', 'Jung', 'Lily', 'Reginald'],
             title: 'Lunch',
             iconName: 'custom:custom51',
             from: new Date(2021, 0, 1, 12),
@@ -17,13 +17,13 @@ export default class SchedulerVertical extends LightningElement {
             }
         },
         {
-            keyFields: ['4'],
+            resourceNames: ['Lily'],
             title: 'Vacation',
             from: new Date(2021, 11, 6),
             to: new Date(2021, 11, 20)
         },
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             title: 'Day off',
             from: new Date(2021, 11, 23),
             allDay: true
@@ -32,14 +32,14 @@ export default class SchedulerVertical extends LightningElement {
 
     events = [
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             name: 'research',
             title: 'Research',
             from: new Date(2021, 11, 13, 9),
             to: new Date(2021, 11, 14, 12)
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'code-review',
             title: 'Code review',
             from: new Date(2021, 11, 13, 13),
@@ -47,77 +47,77 @@ export default class SchedulerVertical extends LightningElement {
             recurrence: 'daily'
         },
         {
-            keyFields: ['3', '2'],
+            resourceNames: ['Jung', 'Dave'],
             name: 'seminar',
             title: 'Online seminar',
             from: new Date(2021, 11, 14, 8),
             to: new Date(2021, 11, 16)
         },
         {
-            keyFields: ['1', '3'],
+            resourceNames: ['Nina', 'Jung'],
             name: 'write-spec',
             title: 'Write specifications',
             from: new Date(2021, 11, 15),
             allDay: true
         },
         {
-            keyFields: ['2'],
+            resourceNames: ['Dave'],
             name: 'create-wireframe',
             title: 'Create wireframe',
             from: new Date(2021, 11, 13, 10, 15),
             to: new Date(2021, 11, 16, 12)
         },
         {
-            keyFields: ['4'],
+            resourceNames: ['Lily'],
             name: 'create-mockup',
             title: 'Create mockup',
             from: new Date(2021, 11, 20, 7),
             to: new Date(2021, 11, 22, 10, 30)
         },
         {
-            keyFields: ['2'],
+            resourceNames: ['Dave'],
             name: 'test-new-ui',
             title: 'Test new UI',
             from: new Date(2021, 11, 17, 15),
             to: new Date(2021, 11, 21)
         },
         {
-            keyFields: ['5'],
+            resourceNames: ['Reginald'],
             name: 'implement-feature',
             title: 'Implement feature',
             from: new Date(2021, 11, 13, 14),
             to: new Date(2021, 11, 15, 16)
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'push-to-prod',
             title: 'Push to production',
             from: new Date(2021, 11, 16, 11),
             to: new Date(2021, 11, 16, 12)
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'phone-meeting',
             title: 'Phone meeting',
             from: new Date(2021, 11, 21, 10),
             to: new Date(2021, 11, 21, 12)
         },
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             name: 'update-documentation',
             title: 'Update documentation',
             from: new Date(2021, 11, 17, 11),
             to: new Date(2021, 11, 17, 18)
         },
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             name: 'presentation',
             title: 'Presentation at the conference',
             from: new Date(2021, 11, 16, 11),
             to: new Date(2021, 11, 16, 18)
         },
         {
-            keyFields: ['2', '4'],
+            resourceNames: ['Dave', 'Lily'],
             name: 'ux-ui-team-meeting',
             title: 'UI/UX team meeting',
             from: new Date(2021, 11, 17, 11),
@@ -125,14 +125,14 @@ export default class SchedulerVertical extends LightningElement {
             recurrence: 'weekly'
         },
         {
-            keyFields: ['1', '2', '3', '4', '5'],
+            resourceNames: ['Nina', 'Dave', 'Jung', 'Lily', 'Reginald'],
             name: 'office-party',
             title: 'Office party',
             from: new Date(2021, 11, 24, 12),
             to: new Date(2021, 11, 25)
         },
         {
-            keyFields: ['1', '5'],
+            resourceNames: ['Nina', 'Reginald'],
             name: 'standup',
             title: 'Stand-up meeting',
             from: new Date(2021, 11, 13, 9, 30),
@@ -163,47 +163,42 @@ export default class SchedulerVertical extends LightningElement {
 
     resources = [
         {
-            id: '1',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar2.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'NG',
-            resourceName: 'Nina',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'NG',
+            name: 'Nina',
             role: 'Lead developer',
             sharedField: `This shouldn't show up`
         },
         {
-            id: '2',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar1.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'DM',
-            resourceName: 'Dave',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'DM',
+            name: 'Dave',
             role: 'UX Specialist',
             customRowField: 'Label coming from a custom field in the row'
         },
         {
-            id: '3',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'JP',
-            resourceName: 'Jung',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'JP',
+            name: 'Jung',
             role: 'Product Owner'
         },
         {
-            id: '4',
-            resourceAvatarFallbackIconName: 'standard:article',
-            resourceAvatarInitials: 'LM',
-            resourceName: 'Lily',
+            avatarFallbackIconName: 'standard:article',
+            avatarInitials: 'LM',
+            name: 'Lily',
             role: 'Graphic Designer',
             customField: "This comes from the row's custom field"
         },
         {
-            id: '5',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar3.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'RM',
-            resourceName: 'Reginald',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'RM',
+            name: 'Reginald',
             role: 'Developer'
         }
     ];

--- a/src/modules/base/scheduler/__examples__/zoomToFit/zoomToFit.html
+++ b/src/modules/base/scheduler/__examples__/zoomToFit/zoomToFit.html
@@ -3,12 +3,11 @@
         columns={columns}
         events={events}
         events-palette="pond"
-        headers="monthAndYear"
-        resources-key-field="id"
         resources={resources}
+        selected-time-span="year"
         start={start}
         time-span={timeSpan}
-        toolbar-time-spans={toolbarTimeSpans}
+        time-spans={timeSpans}
         zoom-to-fit
     ></avonni-scheduler>
 </template>

--- a/src/modules/base/scheduler/__examples__/zoomToFit/zoomToFit.js
+++ b/src/modules/base/scheduler/__examples__/zoomToFit/zoomToFit.js
@@ -4,76 +4,76 @@ export default class SchedulerReadOnly extends LightningElement {
     columns = [
         {
             label: 'Employee',
-            fieldName: 'resourceName'
+            fieldName: 'name'
         }
     ];
 
     events = [
         {
-            keyFields: ['3', '4', '5'],
+            resourceNames: ['Jung', 'Lily', 'Reginald'],
             name: 'event-1',
             title: 'Event 1',
             from: new Date(2021, 2, 1),
             to: new Date(2021, 3, 1)
         },
         {
-            keyFields: ['5', '3', '4'],
+            resourceNames: ['Reginald', 'Jung', 'Lily'],
             name: 'event-2',
             title: 'Event 2',
             from: new Date(2021, 1, 15),
             to: new Date(2021, 3, 30)
         },
         {
-            keyFields: ['3', '4', '2'],
+            resourceNames: ['Jung', 'Lily', 'Dave'],
             name: 'event-3',
             title: 'Event 3',
             from: new Date(2020, 11, 26),
             to: new Date(2021, 0, 31)
         },
         {
-            keyFields: ['1', '4'],
+            resourceNames: ['Nina', 'Lily'],
             name: 'event-4',
             title: 'Event 4',
             from: new Date(2021, 3, 12),
             to: new Date(2021, 4, 31)
         },
         {
-            keyFields: ['2', '1'],
+            resourceNames: ['Dave', 'Nina'],
             name: 'event-5',
             title: 'Event 5',
             from: new Date(2021, 7, 1),
             to: new Date(2021, 8, 31)
         },
         {
-            keyFields: ['1', '2', '3'],
+            resourceNames: ['Nina', 'Dave', 'Jung'],
             name: 'event-6',
             title: 'Event 6',
             from: new Date(2021, 5, 20),
             to: new Date(2021, 6, 31)
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'event-7',
             title: 'Event 7',
             from: new Date(2021, 6, 1),
             to: new Date(2021, 7, 31)
         },
         {
-            keyFields: ['3'],
+            resourceNames: ['Jung'],
             name: 'event-8',
             title: 'Event 8',
             from: new Date(2021, 9, 10),
             to: new Date(2021, 10, 31)
         },
         {
-            keyFields: ['1'],
+            resourceNames: ['Nina'],
             name: 'event-9',
             title: 'Event 9',
             from: new Date(2021, 9, 1),
             to: new Date(2022, 2, 3)
         },
         {
-            keyFields: ['2', '3', '4'],
+            resourceNames: ['Dave', 'Jung', 'Lily'],
             name: 'event-10',
             title: 'Event 10',
             from: new Date(2021, 10, 1),
@@ -83,61 +83,69 @@ export default class SchedulerReadOnly extends LightningElement {
 
     resources = [
         {
-            id: '1',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar2.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'NG',
-            resourceName: 'Nina',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'NG',
+            name: 'Nina',
             role: 'Lead developer',
             sharedField: `This shouldn't show up`
         },
         {
-            id: '2',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar1.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'DM',
-            resourceName: 'Dave',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'DM',
+            name: 'Dave',
             role: 'UX Specialist',
             customRowField: 'Label coming from a custom field in the row'
         },
         {
-            id: '3',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'JP',
-            resourceName: 'Jung',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'JP',
+            name: 'Jung',
             role: 'Product Owner'
         },
         {
-            id: '4',
-            resourceAvatarFallbackIconName: 'standard:article',
-            resourceAvatarInitials: 'LM',
-            resourceName: 'Lily',
+            avatarFallbackIconName: 'standard:article',
+            avatarInitials: 'LM',
+            name: 'Lily',
             role: 'Graphic Designer',
             customField: "This comes from the row's custom field"
         },
         {
-            id: '5',
-            resourceAvatarSrc:
+            avatarSrc:
                 'https://www.lightningdesignsystem.com/assets/images/avatar3.jpg',
-            resourceAvatarFallbackIconName: 'standard:person_account',
-            resourceAvatarInitials: 'RM',
-            resourceName: 'Reginald',
+            avatarFallbackIconName: 'standard:person_account',
+            avatarInitials: 'RM',
+            name: 'Reginald',
             role: 'Developer'
         }
     ];
 
     start = new Date(2021, 0, 1);
 
-    timeSpan = {
-        unit: 'year',
-        span: 1
-    };
-
-    toolbarTimeSpans = [
-        { unit: 'week', span: 1, label: 'Week', headers: 'dayAndWeek' },
-        { unit: 'month', span: 1, label: 'Month', headers: 'dayAndMonth' },
-        { unit: 'year', span: 1, label: 'Year', headers: 'monthAndYear' }
+    timeSpans = [
+        {
+            unit: 'week',
+            span: 1,
+            label: 'Week',
+            headers: 'dayAndWeek',
+            name: 'week'
+        },
+        {
+            unit: 'month',
+            span: 1,
+            label: 'Month',
+            headers: 'dayAndMonth',
+            name: 'month'
+        },
+        {
+            unit: 'year',
+            span: 1,
+            label: 'Year',
+            headers: 'monthAndYear',
+            name: 'year'
+        }
     ];
 }

--- a/src/modules/base/scheduler/__tests__/data.js
+++ b/src/modules/base/scheduler/__tests__/data.js
@@ -50,35 +50,33 @@ export const COLUMNS = [
 export const RESOURCES = [
     {
         name: 'resource-1',
-        resourceName: 'Resource 1',
-        resourceAvatarSrc: 'some fake avatar src',
-        resourceAvatarFallbackIconName: 'utility:user',
-        resourceAvatarInitials: 'R1',
+        label: 'Resource 1',
+        avatarSrc: 'some fake avatar src',
+        avatarFallbackIconName: 'utility:user',
+        avatarInitials: 'R1',
         col1: 'Resource 1, column 1',
         col2: 'Resource 1, column 2',
         col3: 'Resource 1, column 3'
     },
     {
         name: 'resource-2',
-        resourceName: 'Resource 2',
+        label: 'Resource 2',
         col1: 'Resource 2, column 1',
         col2: 'Resource 2, column 2',
         col3: 'Resource 2, column 3'
     },
     {
         name: 'resource-3',
-        resourceName: 'Resource 3',
+        label: 'Resource 3',
         col1: 'Resource 3, column 1',
         col2: 'Resource 3, column 2',
         col3: 'Resource 3, column 3'
     }
 ];
 
-export const RESOURCES_KEY_FIELD = 'name';
-
 export const EVENTS = [
     {
-        keyFields: ['resource-2', 'resource-1'],
+        resourceNames: ['resource-2', 'resource-1'],
         name: 'event-1',
         title: 'Event 1',
         from: new Date(2021, 8, 2),
@@ -86,14 +84,14 @@ export const EVENTS = [
         color: '#333'
     },
     {
-        keyFields: ['resource-3'],
+        resourceNames: ['resource-3'],
         name: 'event-2',
         title: 'Event 2',
         from: new Date(2021, 8, 2),
         to: new Date(2021, 8, 3)
     },
     {
-        keyFields: ['resource-3'],
+        resourceNames: ['resource-3'],
         name: 'event-3',
         title: 'Event 3',
         from: new Date(2021, 8, 3),
@@ -103,20 +101,20 @@ export const EVENTS = [
 
 export const DISABLED_DATES_TIMES = [
     {
-        keyFields: ['resource-2', 'resource-1'],
+        resourceNames: ['resource-2', 'resource-1'],
         title: 'Disabled date 1',
         iconName: 'utility:apps',
         from: new Date(2021, 8, 2, 10),
         to: new Date(2021, 8, 3)
     },
     {
-        keyFields: ['resource-3'],
+        resourceNames: ['resource-3'],
         title: 'Disabled date 2',
         from: new Date(2021, 8, 2),
         to: new Date(2021, 8, 3)
     },
     {
-        keyFields: ['resource-3'],
+        resourceNames: ['resource-3'],
         title: 'Disabled date 3',
         from: new Date(2021, 7, 31),
         to: new Date(2021, 8, 5)
@@ -127,3 +125,46 @@ export const MONTH_TIME_SPAN = {
     unit: 'month',
     span: 1
 };
+
+export const TIME_SPANS = [
+    {
+        name: 'monthSpan',
+        unit: 'month',
+        span: 3,
+        label: '3 months',
+        headers: 'weekMonthAndYear'
+    },
+    {
+        unit: 'day',
+        name: 'daySpan',
+        span: 1,
+        label: '1 day',
+        headers: 'dayAndWeek',
+        customHeaders: [
+            {
+                unit: 'day',
+                span: 3,
+                label: 'dd'
+            },
+            {
+                unit: 'month',
+                span: 1,
+                label: 'mmmm'
+            }
+        ]
+    },
+    {
+        unit: 'hour',
+        name: 'hourSpan',
+        span: 6,
+        label: '6 hours',
+        headers: 'hourDayAndWeek'
+    },
+    {
+        unit: 'year',
+        name: 'yearSpan',
+        span: 2,
+        label: '2 years',
+        headers: 'quartersAndYear'
+    }
+];

--- a/src/modules/base/scheduler/__tests__/scheduler.test.js
+++ b/src/modules/base/scheduler/__tests__/scheduler.test.js
@@ -36,11 +36,11 @@ import { DateTime, Interval } from 'c/luxon';
 import {
     COLUMNS,
     RESOURCES,
-    RESOURCES_KEY_FIELD,
     EVENTS,
     START,
     DISABLED_DATES_TIMES,
-    MONTH_TIME_SPAN
+    MONTH_TIME_SPAN,
+    TIME_SPANS
 } from './data';
 
 // Not tested:
@@ -99,7 +99,6 @@ describe('Scheduler', () => {
         expect(element.contextMenuEventActions).toMatchObject([]);
         expect(element.contextMenuEmptySpotActions).toMatchObject([]);
         expect(element.customEventsPalette).toMatchObject([]);
-        expect(element.customHeaders).toMatchObject([]);
         expect(element.dateFormat).toBe('ff');
         expect(element.disabledDatesTimes).toMatchObject([]);
         expect(element.dialogLabels).toMatchObject({
@@ -123,7 +122,6 @@ describe('Scheduler', () => {
         });
         expect(element.eventsPalette).toBe('aurora');
         expect(element.eventsTheme).toBe('default');
-        expect(element.headers).toBe('hourAndDay');
         expect(element.hideToolbar).toBeFalsy();
         expect(element.isLoading).toBeFalsy();
         expect(element.loadingStateAlternativeText).toBe('Loading');
@@ -132,14 +130,37 @@ describe('Scheduler', () => {
         expect(element.referenceLines).toMatchObject([]);
         expect(element.resizeColumnDisabled).toBeFalsy();
         expect(element.resources).toMatchObject([]);
-        expect(element.resourcesKeyField).toBeUndefined();
+        expect(element.selectedTimeSpan).toBe('Standard.Scheduler.DayTimeSpan');
         expect(element.start).toBeInstanceOf(DateTime);
-        expect(element.timeSpan).toMatchObject({ unit: 'day', span: 1 });
-        expect(element.toolbarTimeSpans).toEqual([
-            { unit: 'day', span: 1, label: 'Day', headers: 'hourAndDay' },
-            { unit: 'week', span: 1, label: 'Week', headers: 'hourAndDay' },
-            { unit: 'month', span: 1, label: 'Month', headers: 'dayAndMonth' },
-            { unit: 'year', span: 1, label: 'Year', headers: 'dayAndMonth' }
+        expect(element.timeSpans).toEqual([
+            {
+                headers: 'hourAndDay',
+                label: 'Day',
+                name: 'Standard.Scheduler.DayTimeSpan',
+                span: 1,
+                unit: 'day'
+            },
+            {
+                headers: 'hourAndDay',
+                label: 'Week',
+                name: 'Standard.Scheduler.WeekTimeSpan',
+                span: 1,
+                unit: 'week'
+            },
+            {
+                headers: 'dayAndMonth',
+                label: 'Month',
+                name: 'Standard.Scheduler.MonthTimeSpan',
+                span: 1,
+                unit: 'month'
+            },
+            {
+                headers: 'dayAndMonth',
+                label: 'Year',
+                name: 'Standard.Scheduler.YearTimeSpan',
+                span: 1,
+                unit: 'year'
+            }
         ]);
         expect(element.variant).toBe('horizontal');
         expect(element.zoomToFit).toBeFalsy();
@@ -194,7 +215,7 @@ describe('Scheduler', () => {
     });
 
     // collapse-disabled
-    // Depends on resources, resourcesKeyField and columns
+    // Depends on resources and columns
     it('Scheduler: collapseDisabled = false', () => {
         document.body.appendChild(element);
         element.collapseDisabled = false;
@@ -222,7 +243,6 @@ describe('Scheduler', () => {
     it('Scheduler: collapse and open first column', () => {
         document.body.appendChild(element);
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.columns = COLUMNS;
 
         const datatableCol = element.shadowRoot.querySelector(
@@ -276,6 +296,16 @@ describe('Scheduler', () => {
                 expect(datatableCol.classList).toContain(
                     'avonni-scheduler__first-col_open'
                 );
+
+                leftIcon.click();
+            }).then(() => {
+                // Reset to initial state
+                expect(datatableCol.classList).not.toContain(
+                    'avonni-scheduler__first-col_hidden'
+                );
+                expect(datatableCol.classList).not.toContain(
+                    'avonni-scheduler__first-col_open'
+                );
             });
     });
 
@@ -293,14 +323,13 @@ describe('Scheduler', () => {
     });
 
     // context-menu-event-actions
-    // Depends on start, events, columns, resources and resourcesKeyField
+    // Depends on start, events, columns, resources
     it('Scheduler: contextMenuEventActions', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval(START);
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
         const menu = [
             {
@@ -350,7 +379,6 @@ describe('Scheduler', () => {
         setVisibleInterval(START);
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
 
         let title;
@@ -400,7 +428,6 @@ describe('Scheduler', () => {
         setVisibleInterval(START);
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
 
         return Promise.resolve()
@@ -442,14 +469,13 @@ describe('Scheduler', () => {
     });
 
     // context-menu-empty-spot-actions
-    // Depends on resources and resourcesKeyField
+    // Depends on resources
     it('Scheduler: contextMenuEmptySpotActions', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval(START);
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         const menu = [
             {
                 name: 'first-action',
@@ -494,7 +520,6 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.dialogLabels = {
             newEventTitle: 'Title of the new event'
         };
@@ -535,7 +560,7 @@ describe('Scheduler', () => {
     });
 
     // custom-events-palette
-    // Depends on resources, resourcesKeyField, start and events
+    // Depends on resources, start and events
     it('Scheduler: customEventsPalette', () => {
         element.start = START;
         document.body.appendChild(element);
@@ -543,7 +568,6 @@ describe('Scheduler', () => {
 
         element.events = EVENTS;
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         const palette = ['#333', '#444', '#555'];
         element.customEventsPalette = palette;
 
@@ -557,41 +581,14 @@ describe('Scheduler', () => {
         });
     });
 
-    // custom-headers
-    it('Scheduler: customHeaders', () => {
-        document.body.appendChild(element);
-
-        const headers = [
-            {
-                unit: 'year',
-                label: 'yy',
-                span: 2
-            },
-            {
-                unit: 'day',
-                label: 'dd',
-                span: 1
-            }
-        ];
-        element.customHeaders = headers;
-
-        return Promise.resolve().then(() => {
-            const header = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-primitive-scheduler-header-group"]'
-            );
-            expect(header.headers).toMatchObject(headers);
-        });
-    });
-
     // date-format
-    // Depends on start, events, resources and resourcesKeyField
+    // Depends on start, events, resources
     it('Scheduler: dateFormat', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
         element.dateFormat = 'hh:mm';
 
@@ -609,7 +606,6 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
         element.dateFormat = 'HH:mm';
 
@@ -652,7 +648,7 @@ describe('Scheduler', () => {
     });
 
     // disabled-dates-times
-    // Depends on start, resources and resourcesKeyField
+    // Depends on start, resources
     it('Scheduler: disabledDatesTimes', () => {
         const start = new Date(2021, 0, 1);
         const timeSpan = {
@@ -660,12 +656,11 @@ describe('Scheduler', () => {
             span: 1
         };
         element.start = start;
-        element.timeSpan = timeSpan;
+        element.selectedTimeSpan = 'Standard.Scheduler.YearTimeSpan';
         document.body.appendChild(element);
         setVisibleInterval(start, timeSpan);
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.disabledDatesTimes = DISABLED_DATES_TIMES;
 
         return Promise.resolve().then(() => {
@@ -673,7 +668,7 @@ describe('Scheduler', () => {
                 '[data-element-id="avonni-primitive-scheduler-event-occurrence"]'
             );
             DISABLED_DATES_TIMES.forEach((event) => {
-                event.keyFields.forEach((key) => {
+                event.resourceNames.forEach((key) => {
                     const occurrence = Array.from(occurrences).find((occ) => {
                         return (
                             occ.resourceKey === key && occ.title === event.title
@@ -715,15 +710,14 @@ describe('Scheduler', () => {
             span: 1
         };
         element.start = start;
-        element.timeSpan = timeSpan;
+        element.selectedTimeSpan = 'Standard.Scheduler.YearTimeSpan';
         document.body.appendChild(element);
         setVisibleInterval(start, timeSpan);
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.disabledDatesTimes = [
             {
-                keyFields: ['row-3'],
+                resourceNames: ['row-3'],
                 title: 'Event 2',
                 from: new Date(2021, 8, 2),
                 to: new Date(2021, 8, 3),
@@ -748,7 +742,6 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
         const labels = {
             title: 'Title label',
@@ -825,10 +818,9 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = [
             {
-                keyFields: ['row-2', 'row1'],
+                resourceNames: ['row-2', 'row1'],
                 name: 'event-1',
                 title: 'Event 1',
                 from: new Date(2021, 8, 1, 14),
@@ -898,10 +890,9 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = [
             {
-                keyFields: ['row-2', 'row1'],
+                resourceNames: ['row-2', 'row1'],
                 name: 'event-1',
                 title: 'Event 1',
                 from: new Date(2021, 8, 2, 14),
@@ -993,7 +984,6 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
         const labels = {
             deleteButton: 'This is the delete',
@@ -1057,15 +1047,14 @@ describe('Scheduler', () => {
     });
 
     // events
-    // Depends on start, resources, and resourcesKeyField
+    // Depends on start, resources
     it('Scheduler: events', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval(START, MONTH_TIME_SPAN);
 
         element.resources = RESOURCES;
-        element.timeSpan = MONTH_TIME_SPAN;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
+        element.selectedTimeSpan = 'Standard.Scheduler.MonthTimeSpan';
         element.events = EVENTS;
 
         return Promise.resolve().then(() => {
@@ -1073,7 +1062,7 @@ describe('Scheduler', () => {
                 '[data-element-id="avonni-primitive-scheduler-event-occurrence"]'
             );
             EVENTS.forEach((event) => {
-                event.keyFields.forEach((key) => {
+                event.resourceNames.forEach((key) => {
                     const occurrence = Array.from(occurrences).find((occ) => {
                         return (
                             occ.resourceKey === key && occ.title === event.title
@@ -1110,15 +1099,14 @@ describe('Scheduler', () => {
 
     it('Scheduler: events, recurrence', () => {
         element.start = START;
-        element.timeSpan = MONTH_TIME_SPAN;
+        element.selectedTimeSpan = 'Standard.Scheduler.MonthTimeSpan';
         document.body.appendChild(element);
         setVisibleInterval(START, MONTH_TIME_SPAN);
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = [
             {
-                keyFields: ['row-3'],
+                resourceNames: ['row-3'],
                 title: 'Event 2',
                 from: new Date(2021, 8, 2),
                 to: new Date(2021, 8, 3),
@@ -1136,18 +1124,17 @@ describe('Scheduler', () => {
     });
 
     // events-labels
-    // Depends on start, resources, events and resourcesKeyField
+    // Depends on start, resources, events
     it('Scheduler: eventsLabels', () => {
-        element.timeSpan = MONTH_TIME_SPAN;
+        element.selectedTimeSpan = 'Standard.Scheduler.MonthTimeSpan';
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval(START, MONTH_TIME_SPAN);
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         const events = [
             {
-                keyFields: ['row-2', 'row1'],
+                resourceNames: ['row-2', 'row1'],
                 name: 'event-1',
                 title: 'Event 1',
                 from: new Date(2021, 8, 2),
@@ -1159,14 +1146,14 @@ describe('Scheduler', () => {
                 }
             },
             {
-                keyFields: ['row-3'],
+                resourceNames: ['row-3'],
                 name: 'event-2',
                 title: 'Event 2',
                 from: new Date(2021, 8, 2),
                 to: new Date(2021, 8, 3)
             },
             {
-                keyFields: ['row-3'],
+                resourceNames: ['row-3'],
                 name: 'event-3',
                 title: 'Event 3',
                 from: new Date(2021, 8, 3),
@@ -1196,7 +1183,7 @@ describe('Scheduler', () => {
             events.forEach((event) => {
                 const labelled = [];
                 const nonLabelled = [];
-                event.keyFields.forEach((key) => {
+                event.resourceNames.forEach((key) => {
                     const occurrence = Array.from(occurrences).find((occ) => {
                         return (
                             occ.resourceKey === key && occ.title === event.title
@@ -1220,7 +1207,7 @@ describe('Scheduler', () => {
     });
 
     // events-palette
-    // Depends on resources, resourcesKeyField, start and events
+    // Depends on resources, start and events
     it('Scheduler: eventsPalette', () => {
         element.start = START;
         document.body.appendChild(element);
@@ -1228,7 +1215,6 @@ describe('Scheduler', () => {
 
         element.events = EVENTS;
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.eventsPalette = 'lake';
         const lake = [
             '#98c9f5',
@@ -1250,7 +1236,7 @@ describe('Scheduler', () => {
     });
 
     // events-theme
-    // Depends on resources, resourcesKeyField, start and events
+    // Depends on resources, start and events
     it('Scheduler: eventsTheme', () => {
         element.start = START;
         document.body.appendChild(element);
@@ -1258,7 +1244,6 @@ describe('Scheduler', () => {
 
         element.events = EVENTS;
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.eventsTheme = 'line';
 
         return Promise.resolve().then(() => {
@@ -1268,32 +1253,6 @@ describe('Scheduler', () => {
             events.forEach((event) => {
                 expect(event.theme).toBe('line');
             });
-        });
-    });
-
-    // headers
-    it('Scheduler: headers', () => {
-        document.body.appendChild(element);
-
-        const dayLetterAndWeek = [
-            {
-                unit: 'day',
-                span: 1,
-                label: 'ccccc'
-            },
-            {
-                unit: 'week',
-                span: 1,
-                label: "'w.'W 'of' yyyy"
-            }
-        ];
-        element.headers = 'dayLetterAndWeek';
-
-        return Promise.resolve().then(() => {
-            const header = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-primitive-scheduler-header-group"]'
-            );
-            expect(header.headers).toMatchObject(dayLetterAndWeek);
         });
     });
 
@@ -1355,14 +1314,13 @@ describe('Scheduler', () => {
     });
 
     // read-only
-    // Depends on start, resources, resourcesKeyField and events
+    // Depends on start, resources and events
     it('Scheduler: readOnly', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
         element.readOnly = true;
 
@@ -1382,7 +1340,6 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
         element.readOnly = true;
 
@@ -1416,7 +1373,6 @@ describe('Scheduler', () => {
         document.body.appendChild(element);
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.readOnly = true;
 
         return Promise.resolve()
@@ -1447,7 +1403,6 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
         element.readOnly = true;
 
@@ -1492,17 +1447,16 @@ describe('Scheduler', () => {
     });
 
     // recurrent-edit-modes
-    // Depends on start, resources, resourcesKeyField, events and the edit/save flow
+    // Depends on start, resources, events and the edit/save flow
     it('Scheduler: recurrentEditModes, all', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = [
             {
-                keyFields: ['row-2', 'row1'],
+                resourceNames: ['row-2', 'row1'],
                 name: 'event-1',
                 title: 'Event 1',
                 from: new Date(2021, 8, 2, 14),
@@ -1575,10 +1529,9 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = [
             {
-                keyFields: ['row-2', 'row1'],
+                resourceNames: ['row-2', 'row1'],
                 name: 'event-1',
                 title: 'Event 1',
                 from: new Date(2021, 8, 2, 14),
@@ -1665,10 +1618,9 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = [
             {
-                keyFields: ['row-2', 'row1'],
+                resourceNames: ['row-2', 'row1'],
                 name: 'event-1',
                 title: 'Event 1',
                 from: new Date(2021, 8, 2, 14),
@@ -1720,15 +1672,14 @@ describe('Scheduler', () => {
     });
 
     // reference-lines
-    // Depends on start, resources and resourcesKeyField
+    // Depends on start, resources
     it('Scheduler: referenceLines', () => {
         element.start = START;
-        element.timeSpan = MONTH_TIME_SPAN;
+        element.selectedTimeSpan = 'Standard.Scheduler.MonthTimeSpan';
         document.body.appendChild(element);
         setVisibleInterval(START, MONTH_TIME_SPAN);
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         const references = [
             {
                 label: 'Reference 1',
@@ -1760,12 +1711,11 @@ describe('Scheduler', () => {
 
     it('Scheduler: referenceLines, recurrent', () => {
         element.start = START;
-        element.timeSpan = MONTH_TIME_SPAN;
+        element.selectedTimeSpan = 'Standard.Scheduler.MonthTimeSpan';
         document.body.appendChild(element);
         setVisibleInterval(START, MONTH_TIME_SPAN);
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         const references = [
             {
                 label: 'Reference 1',
@@ -1786,14 +1736,13 @@ describe('Scheduler', () => {
     });
 
     // resize-column-disabled
-    // Depends on columns, resources and resourcesKeyField
+    // Depends on columns, resources
     it('Scheduler: resizeColumnDisabled = false', () => {
         document.body.appendChild(element);
 
         element.resizeColumnDisabled = false;
         element.columns = COLUMNS;
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
 
         const wrapper = element.shadowRoot.querySelector(
             '.avonni-scheduler__wrapper'
@@ -1843,7 +1792,6 @@ describe('Scheduler', () => {
         element.resizeColumnDisabled = false;
         element.columns = COLUMNS;
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.variant = 'vertical';
 
         const wrapper = element.shadowRoot.querySelector(
@@ -1933,12 +1881,9 @@ describe('Scheduler', () => {
     });
 
     // resources
-    // Depends on resourcesKeyField
     it('Scheduler: resources', () => {
         document.body.appendChild(element);
-
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
 
         return Promise.resolve().then(() => {
             const resources = element.shadowRoot.querySelectorAll(
@@ -1953,19 +1898,34 @@ describe('Scheduler', () => {
         });
     });
 
-    // resources-key-field
-    // Depends on resources
-    it('Scheduler: resourcesKeyField', () => {
+    // selected-time-span
+    it('Scheduler: selectedTimeSpan', () => {
         document.body.appendChild(element);
-
-        element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
+        element.selectedTimeSpan = 'Standard.Scheduler.WeekTimeSpan';
 
         return Promise.resolve().then(() => {
-            const datatable = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-datatable"]'
+            const buttons = element.shadowRoot.querySelectorAll(
+                '[data-element-id="lightning-button-toolbar-time-span"]'
             );
-            expect(datatable.keyField).toBe(RESOURCES_KEY_FIELD);
+            expect(buttons[1].variant).toBe('brand');
+
+            const headers = element.shadowRoot.querySelector('[data-element-id="avonni-primitive-scheduler-header-group"]');
+            expect(headers.timeSpan).toMatchObject({
+                unit: 'week',
+                span: 1
+            });
+            expect(headers.headers).toEqual([
+                {
+                    unit: 'hour',
+                    span: 1,
+                    label: 'h a'
+                },
+                {
+                    unit: 'day',
+                    span: 1,
+                    label: 'ccc, LLL d'
+                }
+            ]);
         });
     });
 
@@ -1983,55 +1943,10 @@ describe('Scheduler', () => {
         });
     });
 
-    // time-span
-    it('Scheduler: timeSpan', () => {
+    // time-spans
+    it('Scheduler: timeSpans', () => {
         document.body.appendChild(element);
-
-        const timeSpan = {
-            unit: 'month',
-            span: 3
-        };
-        element.timeSpan = timeSpan;
-
-        return Promise.resolve().then(() => {
-            const header = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-primitive-scheduler-header-group"]'
-            );
-            expect(header.timeSpan).toMatchObject(timeSpan);
-        });
-    });
-
-    // toolbar-time-spans
-    it('Scheduler: toolbarTimeSpans', () => {
-        document.body.appendChild(element);
-
-        const timeSpans = [
-            {
-                unit: 'month',
-                span: 3,
-                label: '3 months',
-                headers: 'weekMonthAndYear'
-            },
-            {
-                unit: 'day',
-                span: 1,
-                label: '1 day',
-                headers: 'dayAndWeek'
-            },
-            {
-                unit: 'hour',
-                span: 6,
-                label: '6 hours',
-                headers: 'hourDayAndWeek'
-            },
-            {
-                unit: 'year',
-                span: 2,
-                label: '2 years',
-                headers: 'quartersAndYear'
-            }
-        ];
-        element.toolbarTimeSpans = timeSpans;
+        element.timeSpans = TIME_SPANS;
 
         return Promise.resolve().then(() => {
             const buttons = element.shadowRoot.querySelectorAll(
@@ -2040,14 +1955,12 @@ describe('Scheduler', () => {
             expect(buttons).toHaveLength(3);
 
             buttons.forEach((button, index) => {
-                expect(button.label).toBe(timeSpans[index].label);
-                expect(button.dataset.headers).toBe(timeSpans[index].headers);
-                expect(Number(button.dataset.span)).toBe(timeSpans[index].span);
-                expect(button.dataset.unit).toBe(timeSpans[index].unit);
+                expect(button.label).toBe(TIME_SPANS[index].label);
+                expect(button.value).toBe(TIME_SPANS[index].name);
             });
 
-            expect(buttons[1].variant).toBe('brand');
-            [0, 2].forEach((index) => {
+            expect(buttons[0].variant).toBe('brand');
+            [1, 2].forEach((index) => {
                 expect(buttons[index].variant).toBe('neutral');
             });
 
@@ -2055,6 +1968,38 @@ describe('Scheduler', () => {
                 '[data-element-id="avonni-button-menu-toolbar-spans"]'
             );
             expect(menu).toBeTruthy();
+
+            const headers = element.shadowRoot.querySelector('[data-element-id="avonni-primitive-scheduler-header-group"]');
+            expect(headers.timeSpan).toEqual(TIME_SPANS[0]);
+            expect(headers.headers).toEqual([
+                {
+                    unit: 'week',
+                    span: 1,
+                    label: "'w.'W 'of' yyyy"
+                },
+                {
+                    unit: 'month',
+                    span: 1,
+                    label: 'LLLL'
+                },
+                {
+                    unit: 'year',
+                    span: 1,
+                    label: 'yyyy'
+                }
+            ]);
+        });
+    });
+    
+    it('Scheduler: timeSpans with customHeaders', () => {
+        document.body.appendChild(element);
+        element.selectedTimeSpan = TIME_SPANS[1].name;
+        element.timeSpans = TIME_SPANS;
+
+        return Promise.resolve().then(() => {
+            const headers = element.shadowRoot.querySelector('[data-element-id="avonni-primitive-scheduler-header-group"]');
+            expect(headers.timeSpan).toEqual(TIME_SPANS[1]);
+            expect(headers.headers).toEqual(TIME_SPANS[1].customHeaders);
         });
     });
 
@@ -2067,7 +2012,6 @@ describe('Scheduler', () => {
 
         element.resources = RESOURCES;
         element.columns = COLUMNS;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.variant = 'horizontal';
 
         return Promise.resolve().then(() => {
@@ -2151,7 +2095,6 @@ describe('Scheduler', () => {
 
         element.resources = RESOURCES;
         element.columns = COLUMNS;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.variant = 'vertical';
 
         return Promise.resolve().then(() => {
@@ -2221,12 +2164,12 @@ describe('Scheduler', () => {
                 '[data-element-id="avonni-primitive-avatar"]'
             );
             expect(firstAvatar).toBeTruthy();
-            expect(firstAvatar.src).toBe(RESOURCES[0].resourceAvatarSrc);
+            expect(firstAvatar.src).toBe(RESOURCES[0].avatarSrc);
             expect(firstAvatar.initials).toBe(
-                RESOURCES[0].resourceAvatarInitials
+                RESOURCES[0].avatarInitials
             );
             expect(firstAvatar.fallbackIconName).toBe(
-                RESOURCES[0].resourceAvatarFallbackIconName
+                RESOURCES[0].avatarFallbackIconName
             );
 
             for (let i = 1; i < RESOURCES.length; i++) {
@@ -2241,8 +2184,32 @@ describe('Scheduler', () => {
                     '[data-element-id="div-vertical-resource-header-label"]'
                 );
                 expect(label).toBeTruthy();
-                expect(label.textContent).toBe(RESOURCES[index].resourceName);
+                expect(label.textContent).toBe(RESOURCES[index].label);
             });
+        });
+    });
+
+    it('Scheduler: vertical variant, simulate scroll', () => {
+        element.start = START;
+        document.body.appendChild(element);
+        setVisibleInterval();
+        jest.runAllTimers();
+
+        element.resources = RESOURCES;
+        element.columns = COLUMNS;
+        element.variant = 'vertical';
+
+        return Promise.resolve().then(() => {
+            const resourceHeaders = element.shadowRoot.querySelector(
+                '[data-element-id="div-resource-header-cells"]'
+            );
+            resourceHeaders.scroll = jest.fn((x, y) => {
+                expect(x).toBe(35);
+                expect(y).toBe(0);
+            });
+            const wrapper = element.shadowRoot.querySelector('[data-element-id="div-schedule-wrapper"]');
+            wrapper.scrollLeft = 35;
+            wrapper.dispatchEvent(new CustomEvent('scroll'));
         });
     });
 
@@ -2255,7 +2222,6 @@ describe('Scheduler', () => {
 
         element.resources = RESOURCES;
         element.columns = COLUMNS;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.zoomToFit = false;
 
         return Promise.resolve().then(() => {
@@ -2289,7 +2255,6 @@ describe('Scheduler', () => {
 
         element.resources = RESOURCES;
         element.columns = COLUMNS;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.zoomToFit = true;
 
         return Promise.resolve().then(() => {
@@ -2323,7 +2288,6 @@ describe('Scheduler', () => {
 
         element.resources = RESOURCES;
         element.columns = COLUMNS;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.zoomToFit = true;
         element.variant = 'vertical';
 
@@ -2340,33 +2304,31 @@ describe('Scheduler', () => {
     /* ----- METHODS ----- */
 
     // createEvent
-    // Depends on resources, resourcesKeyField and start
+    // Depends on resources and start
     it('Scheduler: createEvent method', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval(START);
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.createEvent(EVENTS[0]);
 
         return Promise.resolve().then(() => {
             const events = element.shadowRoot.querySelectorAll(
                 '[data-element-id="avonni-primitive-scheduler-event-occurrence"]'
             );
-            expect(events).toHaveLength(EVENTS[0].keyFields.length);
+            expect(events).toHaveLength(EVENTS[0].resourceNames.length);
         });
     });
 
     // deleteEvent
-    // Depends on resources, resourcesKeyField, start and events
+    // Depends on resources, start and events
     it('Scheduler: deleteEvent method', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
 
         let eventName;
@@ -2388,14 +2350,13 @@ describe('Scheduler', () => {
     });
 
     // focusEvent
-    // Depends on resources, resourcesKeyField, start and events
+    // Depends on resources, start and events
     it('Scheduler: focusEvent method', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
 
         return Promise.resolve().then(() => {
@@ -2426,14 +2387,13 @@ describe('Scheduler', () => {
     });
 
     // openNewEventDialog
-    // Depends on resources, resourcesKeyField and start
+    // Depends on resources and start
     it('Scheduler: openNewEventDialog method', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.openNewEventDialog();
 
         return Promise.resolve().then(() => {
@@ -2451,14 +2411,13 @@ describe('Scheduler', () => {
      */
 
     // actionclick
-    // Depends on start, resources, resourcesKeyField and events
+    // Depends on start, resources and events
     it('Scheduler: actionclick event', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
 
         const handler = jest.fn();
@@ -2506,17 +2465,16 @@ describe('Scheduler', () => {
     });
 
     // eventchange
-    // Depends on start, resources, resourcesKeyField and events
+    // Depends on start, resources and events
     it('Scheduler: eventchange event', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = [
             {
-                keyFields: ['row-2'],
+                resourceNames: ['row-2'],
                 name: 'event-1',
                 title: 'Event 1',
                 from: new Date(2021, 8, 2),
@@ -2581,8 +2539,8 @@ describe('Scheduler', () => {
                     new CustomEvent('change', {
                         detail: {
                             value: [
-                                RESOURCES[0][RESOURCES_KEY_FIELD],
-                                RESOURCES[1][RESOURCES_KEY_FIELD]
+                                RESOURCES[0].name,
+                                RESOURCES[1].name
                             ]
                         }
                     })
@@ -2611,9 +2569,9 @@ describe('Scheduler', () => {
                 expect(
                     handler.mock.calls[0][0].detail.draftValues
                 ).toMatchObject({
-                    keyFields: [
-                        RESOURCES[0][RESOURCES_KEY_FIELD],
-                        RESOURCES[1][RESOURCES_KEY_FIELD]
+                    resourceNames: [
+                        RESOURCES[0].name,
+                        RESOURCES[1].name
                     ],
                     title: 'New event title'
                 });
@@ -2624,7 +2582,7 @@ describe('Scheduler', () => {
     });
 
     // eventcreate
-    // Depends on openNewEventDialog(), resources, and resourcesKeyField
+    // Depends on openNewEventDialog(), resources
     it('Scheduler: eventcreate event', () => {
         element.start = START;
         document.body.appendChild(element);
@@ -2633,7 +2591,6 @@ describe('Scheduler', () => {
         const from = new Date(2021, 8, 2, 4).toISOString();
         const to = new Date(2021, 8, 2, 13).toISOString();
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
 
         const handler = jest.fn();
         element.addEventListener('eventcreate', handler);
@@ -2653,8 +2610,8 @@ describe('Scheduler', () => {
                 new CustomEvent('change', {
                     detail: {
                         value: [
-                            RESOURCES[0][RESOURCES_KEY_FIELD],
-                            RESOURCES[1][RESOURCES_KEY_FIELD]
+                            RESOURCES[0].name,
+                            RESOURCES[1].name
                         ]
                     }
                 })
@@ -2679,10 +2636,10 @@ describe('Scheduler', () => {
 
             expect(handler).toHaveBeenCalled();
             expect(
-                handler.mock.calls[0][0].detail.event.keyFields
+                handler.mock.calls[0][0].detail.event.resourceNames
             ).toMatchObject([
-                RESOURCES[0][RESOURCES_KEY_FIELD],
-                RESOURCES[1][RESOURCES_KEY_FIELD]
+                RESOURCES[0].name,
+                RESOURCES[1].name
             ]);
             expect(
                 handler.mock.calls[0][0].detail.event.name
@@ -2699,14 +2656,13 @@ describe('Scheduler', () => {
     });
 
     // eventdelete
-    // Depends on deleteEvent(), events, start, resources, and resourcesKeyField
+    // Depends on deleteEvent(), events, start, resources
     it('Scheduler: eventdelete event', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
 
         const handler = jest.fn();
@@ -2727,7 +2683,7 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
+        element.events = EVENTS;
 
         return Promise.resolve().then(() => {
             const headers = element.shadowRoot.querySelector(
@@ -2740,7 +2696,7 @@ describe('Scheduler', () => {
                     }
                 })
             );
-
+        }).then(() => {
             const resources = element.shadowRoot.querySelectorAll(
                 '[data-element-id="div-resource"]'
             );
@@ -2755,13 +2711,12 @@ describe('Scheduler', () => {
     /* ----- USER ACTIONS ----- */
 
     // Datatable resize
-    // Depends on the splitter resize flow, resources, resourcesKeyField and columns
+    // Depends on the splitter resize flow, resources and columns
     it('Scheduler: User resizes a datatable column', () => {
         document.body.appendChild(element);
 
         element.columns = COLUMNS;
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
 
         const wrapper = element.shadowRoot.querySelector(
             '.avonni-scheduler__wrapper'
@@ -2818,7 +2773,7 @@ describe('Scheduler', () => {
     });
 
     // Event delete
-    // Depends on resources, resourcesKeyField, events and start
+    // Depends on resources, events and start
     it('Scheduler: User deletes an event', () => {
         element.start = START;
         document.body.appendChild(element);
@@ -2826,7 +2781,6 @@ describe('Scheduler', () => {
 
         element.events = EVENTS;
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
 
         let eventName;
         return Promise.resolve()
@@ -2877,7 +2831,7 @@ describe('Scheduler', () => {
     });
 
     // Double click
-    // Depends on start, events, resources and resourcesKeyField
+    // Depends on start, events, resources
     it('Scheduler: User double-clicks on an event', () => {
         element.start = START;
         document.body.appendChild(element);
@@ -2885,7 +2839,6 @@ describe('Scheduler', () => {
 
         element.events = EVENTS;
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
 
         let eventTitle;
         return Promise.resolve()
@@ -2922,7 +2875,6 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
 
         return Promise.resolve()
             .then(() => {
@@ -2944,14 +2896,13 @@ describe('Scheduler', () => {
     });
 
     // Cancel button of the edit dialog
-    // Depends on start, events, resources and resourcesKeyField
+    // Depends on start, events, resources
     it('Scheduler: User cancels an event edition', () => {
         element.start = START;
         document.body.appendChild(element);
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = EVENTS;
 
         let eventName;
@@ -3021,10 +2972,9 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.events = [
             {
-                keyFields: ['row-2', 'row1'],
+                resourceNames: ['row-2', 'row1'],
                 name: 'event-1',
                 title: 'Event 1',
                 from: new Date(2021, 8, 2, 14),
@@ -3089,7 +3039,6 @@ describe('Scheduler', () => {
         setVisibleInterval();
 
         element.resources = RESOURCES;
-        element.resourcesKeyField = RESOURCES_KEY_FIELD;
         element.variant = 'vertical';
 
         return Promise.resolve()
@@ -3117,18 +3066,28 @@ describe('Scheduler', () => {
         element.start = START;
         document.body.appendChild(element);
 
+        const handler = jest.fn();
+        element.addEventListener('timespanselect', handler);
+
         return Promise.resolve()
             .then(() => {
-                const button = element.shadowRoot.querySelector(
-                    '[data-element-id="lightning-button-toolbar-time-span"][data-unit="week"]'
+                const buttons = element.shadowRoot.querySelectorAll(
+                    '[data-element-id="lightning-button-toolbar-time-span"]'
                 );
-                button.click();
+                buttons[1].click();
+
+                expect(handler).toHaveBeenCalled();
+                const call = handler.mock.calls[0][0];
+                expect(call.detail.name).toBe('Standard.Scheduler.WeekTimeSpan');
+                expect(call.bubbles).toBeFalsy();
+                expect(call.composed).toBeFalsy();
+                expect(call.cancelable).toBeFalsy();
             })
             .then(() => {
                 const header = element.shadowRoot.querySelector(
                     '[data-element-id="avonni-primitive-scheduler-header-group"]'
                 );
-                expect(header.timeSpan).toEqual({
+                expect(header.timeSpan).toMatchObject({
                     unit: 'week',
                     span: 1
                 });
@@ -3144,6 +3103,24 @@ describe('Scheduler', () => {
                         label: 'ccc, LLL d'
                     }
                 ]);
+            });
+    });
+
+    it('Scheduler: User clicks on the selected time span button', () => {
+        element.start = START;
+        document.body.appendChild(element);
+
+        const handler = jest.fn();
+        element.addEventListener('timespanselect', handler);
+
+        return Promise.resolve()
+            .then(() => {
+                const buttons = element.shadowRoot.querySelectorAll(
+                    '[data-element-id="lightning-button-toolbar-time-span"]'
+                );
+                buttons[0].click();
+
+                expect(handler).not.toHaveBeenCalled();
             });
     });
 
@@ -3247,6 +3224,46 @@ describe('Scheduler', () => {
                     '[data-element-id="avonni-primitive-scheduler-header-group"]'
                 );
                 expect(header.start.ts).toBe(new Date(2021, 8, 1).getTime());
+            });
+    });
+
+    it('Scheduler: User clicks on the previous button of the toolbar, and the previous time is unavailable', () => {
+        element.start = new Date(2022, 5, 17);
+        element.availableMonths = [3, 5, 6];
+        element.availableTimeFrames = ['08:00-14:00', '16:00-22:00'];
+        element.selectedTimeSpan = 'Standard.Scheduler.MonthTimeSpan';
+        document.body.appendChild(element);
+
+        return Promise.resolve()
+            .then(() => {
+                // Go to the previous month
+                const button = element.shadowRoot.querySelector(
+                    '[data-element-id="lightning-button-icon-toolbar-prev"]'
+                );
+                button.click();
+            })
+            .then(() => {
+                const header = element.shadowRoot.querySelector(
+                    '[data-element-id="avonni-primitive-scheduler-header-group"]'
+                );
+                expect(header.start.ts).toBe(new Date(2022, 3, 1).getTime());
+
+                // Change the headers for a smaller one
+                element.timeSpans = [{
+                    unit: 'hour',
+                    name: 'hourSpan',
+                    span: 1,
+                    label: 'Hour',
+                    headers: 'hourDayAndWeek'
+                }];
+                element.start = new Date(2022, 5, 17, 8);
+            }).then(() => {
+                // Go to the previous hour span
+                const button = element.shadowRoot.querySelector(
+                    '[data-element-id="lightning-button-icon-toolbar-prev"]'
+                );
+                button.click();
+                expect(element.start.ts).toBe(new Date(2022, 5, 16, 21).getTime());
             });
     });
 

--- a/src/modules/base/scheduler/__tests__/schedulerEvent.test.js
+++ b/src/modules/base/scheduler/__tests__/schedulerEvent.test.js
@@ -33,7 +33,7 @@
 import SchedulerEvent from '../event';
 import { DateTime } from 'c/luxon';
 
-const KEY_FIELDS = ['1'];
+const RESOURCE_NAMES = ['1'];
 const NAME = 'event-name';
 const SMALLEST_HEADER = {
     unit: 'hour',
@@ -42,7 +42,7 @@ const SMALLEST_HEADER = {
 const FROM = new Date(2021, 8, 1, 10);
 const TO = new Date(2021, 8, 4, 15, 30);
 const DEFAULTS = {
-    keyFields: KEY_FIELDS,
+    resourceNames: RESOURCE_NAMES,
     name: NAME,
     smallestHeader: SMALLEST_HEADER,
     from: FROM,
@@ -66,7 +66,7 @@ describe('SchedulerEvent', () => {
         expect(element.disabled).toBeFalsy();
         expect(element.from).toBeFalsy();
         expect(element.iconName).toBeUndefined();
-        expect(element.keyFields).toMatchObject([]);
+        expect(element.resourceNames).toMatchObject([]);
         expect(element.key).not.toBeUndefined();
         expect(element.labels).toMatchObject({
             center: { fieldName: 'title' }
@@ -89,7 +89,7 @@ describe('SchedulerEvent', () => {
     // allDay
     it('Scheduler event: allDay with undefined "to"', () => {
         const options = {
-            keyFields: KEY_FIELDS,
+            resourceNames: RESOURCE_NAMES,
             name: NAME,
             smallestHeader: SMALLEST_HEADER,
             from: new Date(2021, 8, 1, 10),
@@ -102,7 +102,7 @@ describe('SchedulerEvent', () => {
 
     it('Scheduler event: allDay set after event constructor', () => {
         const options = {
-            keyFields: KEY_FIELDS,
+            resourceNames: RESOURCE_NAMES,
             name: NAME,
             smallestHeader: SMALLEST_HEADER,
             from: new Date(2021, 8, 1, 10),
@@ -117,7 +117,7 @@ describe('SchedulerEvent', () => {
 
     it('Scheduler event: allDay spanning on several days', () => {
         const options = {
-            keyFields: KEY_FIELDS,
+            resourceNames: RESOURCE_NAMES,
             name: NAME,
             smallestHeader: SMALLEST_HEADER,
             from: new Date(2021, 8, 1, 10),
@@ -132,7 +132,7 @@ describe('SchedulerEvent', () => {
     // availableDaysOfTheWeek
     it('Scheduler event: availableDaysOfTheWeek, event contains available days', () => {
         const options = {
-            keyFields: KEY_FIELDS,
+            resourceNames: RESOURCE_NAMES,
             name: NAME,
             smallestHeader: SMALLEST_HEADER,
             from: FROM,
@@ -145,7 +145,7 @@ describe('SchedulerEvent', () => {
 
     it('Scheduler event: availableDaysOfTheWeek, event does not contain available days', () => {
         const options = {
-            keyFields: KEY_FIELDS,
+            resourceNames: RESOURCE_NAMES,
             name: NAME,
             smallestHeader: SMALLEST_HEADER,
             from: FROM,
@@ -159,7 +159,7 @@ describe('SchedulerEvent', () => {
     // availableMonths
     it('Scheduler event: availableMonths, event contains available months', () => {
         const options = {
-            keyFields: KEY_FIELDS,
+            resourceNames: RESOURCE_NAMES,
             name: NAME,
             smallestHeader: SMALLEST_HEADER,
             from: FROM,
@@ -172,7 +172,7 @@ describe('SchedulerEvent', () => {
 
     it('Scheduler event: availableMonths, event does not contain available months', () => {
         const options = {
-            keyFields: KEY_FIELDS,
+            resourceNames: RESOURCE_NAMES,
             name: NAME,
             smallestHeader: SMALLEST_HEADER,
             from: FROM,
@@ -186,7 +186,7 @@ describe('SchedulerEvent', () => {
     // availableTimeFrames
     it('Scheduler event: availableTimeFrames, event contains available time frames', () => {
         const options = {
-            keyFields: KEY_FIELDS,
+            resourceNames: RESOURCE_NAMES,
             name: NAME,
             smallestHeader: SMALLEST_HEADER,
             from: new Date(2021, 8, 1, 10),
@@ -199,7 +199,7 @@ describe('SchedulerEvent', () => {
 
     it('Scheduler event: availableTimeFrames, event does not contain available time frames', () => {
         const options = {
-            keyFields: KEY_FIELDS,
+            resourceNames: RESOURCE_NAMES,
             name: NAME,
             smallestHeader: SMALLEST_HEADER,
             from: new Date(2021, 8, 1, 10),
@@ -247,19 +247,19 @@ describe('SchedulerEvent', () => {
         expect(element.iconName).toBe('utility:apps');
     });
 
-    // keyFields
-    it('Scheduler event: keyFields', () => {
-        const keyFields = ['1', '2', '3'];
+    // resourceNames
+    it('Scheduler event: resourceNames', () => {
+        const resourceNames = ['1', '2', '3'];
         const element = new SchedulerEvent({
             name: NAME,
             smallestHeader: SMALLEST_HEADER,
             from: FROM,
             to: TO,
-            keyFields
+            resourceNames
         });
-        expect(element.occurrences).toHaveLength(keyFields.length);
+        expect(element.occurrences).toHaveLength(resourceNames.length);
         element.occurrences.forEach((occurrence, index) => {
-            expect(occurrence.key).toContain(keyFields[index]);
+            expect(occurrence.key).toContain(resourceNames[index]);
         });
     });
 
@@ -424,7 +424,7 @@ describe('SchedulerEvent', () => {
 
     it('Scheduler event: recurrenceAttributes, sameDaySameWeek', () => {
         const element = new SchedulerEvent({
-            keyFields: KEY_FIELDS,
+            resourceNames: RESOURCE_NAMES,
             name: NAME,
             smallestHeader: SMALLEST_HEADER,
             from: new Date(2021, 8, 15, 11),

--- a/src/modules/base/scheduler/defaults.js
+++ b/src/modules/base/scheduler/defaults.js
@@ -33,16 +33,12 @@
 const DEFAULT_AVAILABLE_TIME_FRAMES = ['00:00-23:59'];
 const DEFAULT_AVAILABLE_DAYS_OF_THE_WEEK = [0, 1, 2, 3, 4, 5, 6];
 const DEFAULT_AVAILABLE_MONTHS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
-const DEFAULT_START_DATE = new Date();
-const DEFAULT_TIME_SPAN = {
-    unit: 'day',
-    span: 1
-};
-const DEFAULT_TOOLBAR_TIME_SPANS = [
-    { unit: 'day', span: 1, label: 'Day', headers: 'hourAndDay' },
-    { unit: 'week', span: 1, label: 'Week', headers: 'hourAndDay' },
-    { unit: 'month', span: 1, label: 'Month', headers: 'dayAndMonth' },
-    { unit: 'year', span: 1, label: 'Year', headers: 'dayAndMonth' }
+const DEFAULT_CONTEXT_MENU_EMPTY_SPOT_ACTIONS = [
+    {
+        name: 'add-event',
+        label: 'Add event',
+        iconName: 'utility:add'
+    }
 ];
 const DEFAULT_CONTEXT_MENU_EVENT_ACTIONS = [
     {
@@ -56,14 +52,6 @@ const DEFAULT_CONTEXT_MENU_EVENT_ACTIONS = [
         iconName: 'utility:delete'
     }
 ];
-const DEFAULT_CONTEXT_MENU_EMPTY_SPOT_ACTIONS = [
-    {
-        name: 'add-event',
-        label: 'Add event',
-        iconName: 'utility:add'
-    }
-];
-
 const DEFAULT_DIALOG_LABELS = {
     title: 'Title',
     from: 'From',
@@ -79,18 +67,71 @@ const DEFAULT_DIALOG_LABELS = {
     deleteMessage: 'Are you sure you want to delete this event?',
     newEventTitle: 'New event'
 };
-
 const DEFAULT_EVENTS_LABELS = {
     center: {
         fieldName: 'title'
     }
 };
-
 const DEFAULT_LOADING_STATE_ALTERNATIVE_TEXT = 'Loading';
+const DEFAULT_SELECTED_TIME_SPAN = 'Standard.Scheduler.DayTimeSpan';
+const DEFAULT_START_DATE = new Date();
+const TIME_SPANS = {
+    default: [
+        {
+            headers: 'hourAndDay',
+            label: 'Day',
+            name: 'Standard.Scheduler.DayTimeSpan',
+            span: 1,
+            unit: 'day'
+        },
+        {
+            headers: 'hourAndDay',
+            label: 'Week',
+            name: 'Standard.Scheduler.WeekTimeSpan',
+            span: 1,
+            unit: 'week'
+        },
+        {
+            headers: 'dayAndMonth',
+            label: 'Month',
+            name: 'Standard.Scheduler.MonthTimeSpan',
+            span: 1,
+            unit: 'month'
+        },
+        {
+            headers: 'dayAndMonth',
+            label: 'Year',
+            name: 'Standard.Scheduler.YearTimeSpan',
+            span: 1,
+            unit: 'year'
+        }
+    ],
+    defaultHeaders: 'hourAndDay',
+    defaultUnit: 'day',
+    defaultSpan: 1
+};
 
-const EDIT_MODES = ['all', 'one'];
+const DISPLAYS = {
+    default: [
+        {
+            label: 'Agenda',
+            name: 'agenda'
+        },
+        {
+            label: 'Calendar',
+            name: 'calendar'
+        },
+        {
+            label: 'Timeline',
+            name: 'timeline'
+        }
+    ],
+    valid: ['agenda', 'calendar', 'timeline']
+};
 
 const DEFAULT_DATE_FORMAT = 'ff';
+
+const EDIT_MODES = ['all', 'one'];
 
 const EVENTS_THEMES = {
     valid: ['default', 'transparent', 'line', 'hollow', 'rounded'],
@@ -378,6 +419,8 @@ const REFERENCE_LINE_VARIANTS = {
     default: 'default'
 };
 
+const UNITS = ['minute', 'hour', 'day', 'week', 'month', 'year'];
+
 const VARIANTS = {
     valid: ['horizontal', 'vertical'],
     default: 'horizontal'
@@ -393,9 +436,9 @@ export {
     DEFAULT_DIALOG_LABELS,
     DEFAULT_EVENTS_LABELS,
     DEFAULT_LOADING_STATE_ALTERNATIVE_TEXT,
+    DEFAULT_SELECTED_TIME_SPAN,
     DEFAULT_START_DATE,
-    DEFAULT_TIME_SPAN,
-    DEFAULT_TOOLBAR_TIME_SPANS,
+    DISPLAYS,
     EDIT_MODES,
     EVENTS_THEMES,
     EVENTS_PALETTES,
@@ -404,5 +447,7 @@ export {
     PRESET_HEADERS,
     RECURRENCES,
     REFERENCE_LINE_VARIANTS,
+    TIME_SPANS,
+    UNITS,
     VARIANTS
 };

--- a/src/modules/base/scheduler/event.js
+++ b/src/modules/base/scheduler/event.js
@@ -70,7 +70,7 @@ import {
  *
  * @param {string} iconName The Lightning Design System name of the icon used if the event is disabled. Names are written in the format utility:user. The icon is appended to the left of the title.
  *
- * @param {string[]} keyFields Required. Array of unique resource IDs. The event will be shown in the scheduler for each of these resources.
+ * @param {string[]} resourceNames Required. Array of unique resource IDs. The event will be shown in the scheduler for each of these resources.
  *
  * @param {object} labels Labels of the events. See Scheduler for more details on the structure.
  *
@@ -118,7 +118,7 @@ export default class SchedulerEvent {
         this.from = props.from;
         this.to = props.to;
         this.iconName = props.iconName;
-        this.keyFields = props.keyFields;
+        this.resourceNames = props.resourceNames;
         this.labels = props.labels || DEFAULT_EVENTS_LABELS;
         this.referenceLine = props.referenceLine;
         this.recurrence = props.recurrence;
@@ -192,11 +192,11 @@ export default class SchedulerEvent {
         if (this._isCreated) this.initOccurrences();
     }
 
-    get keyFields() {
-        return this._keyFields;
+    get resourceNames() {
+        return this._resourceNames;
     }
-    set keyFields(value) {
-        this._keyFields = JSON.parse(JSON.stringify(normalizeArray(value)));
+    set resourceNames(value) {
+        this._resourceNames = JSON.parse(JSON.stringify(normalizeArray(value)));
 
         if (this._isCreated) this.initOccurrences();
     }
@@ -373,7 +373,7 @@ export default class SchedulerEvent {
      * @param {DateTime} to Ending date of the occurrence.
      */
     addOccurrence(from, to) {
-        const { schedulerEnd, schedulerStart, keyFields } = this;
+        const { schedulerEnd, schedulerStart, resourceNames } = this;
         const computedTo = to || this.computeOccurenceEnd(from);
 
         if (
@@ -404,13 +404,13 @@ export default class SchedulerEvent {
                 };
                 this.occurrences.push(occurrence);
             } else {
-                keyFields.forEach((keyField) => {
+                resourceNames.forEach((name) => {
                     const occurrence = {
                         from,
-                        key: `${this.name}-${keyField}-${from.ts}`,
-                        keyFields: keyFields,
+                        key: `${this.name}-${name}-${from.ts}`,
+                        resourceNames: resourceNames,
                         offsetTop: 0,
-                        resourceKey: keyField,
+                        resourceName: name,
                         title: this.title,
                         to: computedTo
                     };

--- a/src/modules/base/scheduler/resource.js
+++ b/src/modules/base/scheduler/resource.js
@@ -34,13 +34,15 @@ import { normalizeArray } from 'c/utilsPrivate';
 
 export default class SchedulerResource {
     constructor(props) {
+        this.avatarSrc = props.avatarSrc;
+        this.avatarFallbackIconName = props.avatarFallbackIconName;
+        this.avatarInitials = props.avatarInitials;
         this.color = props.color;
         this.data = props.data;
-        this.key = props.key && props.key.toString();
         this.cells = [];
         this.minHeight = 0;
         this.referenceCells = normalizeArray(props.referenceCells);
-        this.resourceName = props.resourceName;
+        this.name = props.name;
         this.events = normalizeArray(props.events);
         this._height = 0;
         this.initCells();
@@ -54,27 +56,22 @@ export default class SchedulerResource {
     }
 
     get avatar() {
-        const {
-            resourceAvatarSrc,
-            resourceAvatarFallbackIconName,
-            resourceAvatarInitials
-        } = this.data;
         if (
-            resourceAvatarFallbackIconName ||
-            resourceAvatarInitials ||
-            resourceAvatarSrc
+            this.avatarFallbackIconName ||
+            this.avatarInitials ||
+            this.avatarSrc
         ) {
             return {
-                src: resourceAvatarSrc,
-                fallbackIconName: resourceAvatarFallbackIconName,
-                initials: resourceAvatarInitials
+                src: this.avatarSrc,
+                fallbackIconName: this.avatarFallbackIconName,
+                initials: this.avatarInitials
             };
         }
         return null;
     }
 
     get label() {
-        return this.resourceName || this.key;
+        return this.name || this.name;
     }
 
     initCells() {

--- a/src/modules/base/scheduler/resource.js
+++ b/src/modules/base/scheduler/resource.js
@@ -38,6 +38,7 @@ export default class SchedulerResource {
         this.avatarFallbackIconName = props.avatarFallbackIconName;
         this.avatarInitials = props.avatarInitials;
         this.color = props.color;
+        this.label = props.label;
         this.data = props.data;
         this.cells = [];
         this.minHeight = 0;
@@ -68,10 +69,6 @@ export default class SchedulerResource {
             };
         }
         return null;
-    }
-
-    get label() {
-        return this.name || this.name;
     }
 
     initCells() {

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -50,9 +50,6 @@
                     label={button.label}
                     variant={button.variant}
                     value={button.name}
-                    data-headers={button.headers}
-                    data-span={button.span}
-                    data-unit={button.unit}
                     data-element-id="lightning-button-toolbar-time-span"
                 ></lightning-button>
             </template>
@@ -70,9 +67,6 @@
                         checked={menuItem.checked}
                         label={menuItem.label}
                         value={menuItem.name}
-                        data-headers={menuItem.headers}
-                        data-span={menuItem.span}
-                        data-unit={menuItem.unit}
                         data-element-id="lightning-menu-item-toolbar-time-span"
                     ></lightning-menu-item>
                 </template>

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -41,14 +41,15 @@
     >
         <!-- Toolbar time spans -->
         <lightning-button-group
-            if:true={toolbarTimeSpans.length}
+            if:true={showToolbarTimeSpans}
             onclick={handleToolbarTimeSpanClick}
         >
             <template for:each={toolbarTimeSpanButtons} for:item="button">
                 <lightning-button
-                    key={button.label}
+                    key={button.name}
                     label={button.label}
                     variant={button.variant}
+                    value={button.name}
                     data-headers={button.headers}
                     data-span={button.span}
                     data-unit={button.unit}
@@ -65,9 +66,10 @@
                     for:item="menuItem"
                 >
                     <lightning-menu-item
-                        key={menuItem.label}
+                        key={menuItem.name}
                         checked={menuItem.checked}
                         label={menuItem.label}
+                        value={menuItem.name}
                         data-headers={menuItem.headers}
                         data-span={menuItem.span}
                         data-unit={menuItem.unit}
@@ -77,14 +79,9 @@
             </c-button-menu>
         </lightning-button-group>
 
-        <!-- Toolbar middle calendar selector -->
+        <!-- Toolbar calendar selector -->
         <div
-            class="
-                slds-col
-                slds-text-align_center
-                slds-p-horizontal_small
-                slds-has-flexi-truncate
-            "
+            class={toolbarCalendarWrapperClass}
             onfocusin={handleToolbarCalendarFocusin}
             onfocusout={handleToolbarCalendarFocusout}
         >
@@ -167,7 +164,7 @@
         >
             <template for:each={computedResources} for:item="resource">
                 <div
-                    key={resource.key}
+                    key={resource.name}
                     class={verticalResourceHeaderCellClass}
                     data-element-id="div-vertical-resource-header"
                 >
@@ -212,7 +209,7 @@
                 columns={columns}
                 records={resources}
                 hide-checkbox-column
-                key-field={resourcesKeyField}
+                key-field="name"
                 resize-column-disabled={resizeColumnDisabled}
                 data-element-id="avonni-datatable"
                 onresize={handleDatatableResize}
@@ -227,11 +224,11 @@
                     available-days-of-the-week={availableDaysOfTheWeek}
                     available-months={availableMonths}
                     available-time-frames={availableTimeFrames}
-                    available-time-spans={availableToolbarTimeSpans}
+                    available-time-spans={timeSpans}
                     headers={computedHeaders}
                     scroll-left-offset={firstColWidth}
                     start={start}
-                    time-span={timeSpan}
+                    time-span={currentTimeSpan}
                     variant="vertical"
                     zoom-to-fit={zoomToFit}
                     data-element-id="avonni-primitive-scheduler-header-group"
@@ -288,11 +285,11 @@
                     available-days-of-the-week={availableDaysOfTheWeek}
                     available-months={availableMonths}
                     available-time-frames={availableTimeFrames}
-                    available-time-spans={availableToolbarTimeSpans}
+                    available-time-spans={timeSpans}
                     headers={computedHeaders}
                     scroll-left-offset={firstColWidth}
                     start={start}
-                    time-span={timeSpan}
+                    time-span={currentTimeSpan}
                     zoom-to-fit={zoomToFit}
                     data-element-id="avonni-primitive-scheduler-header-group"
                     onprivatecellsizechange={handleHeaderCellSizeChange}
@@ -310,11 +307,11 @@
                         for:index="index"
                     >
                         <div
-                            key={resource.key}
+                            key={resource.name}
                             class={resourceClass}
                             data-element-id="div-resource"
                             data-index={index}
-                            data-key={resource.key}
+                            data-name={resource.name}
                         >
                             <!-- Cells -->
                             <template for:each={resource.cells} for:item="cell">
@@ -357,7 +354,7 @@
                                         occurrence-key={occurrence.key}
                                         read-only={readOnly}
                                         reference-line={event.referenceLine}
-                                        resource-key={occurrence.resourceKey}
+                                        resource-key={occurrence.resourceName}
                                         resources={computedResources}
                                         scroll-offset={scrollOffset}
                                         title={occurrence.title}
@@ -368,7 +365,7 @@
                                         data-element-id="avonni-primitive-scheduler-event-occurrence"
                                         data-event-name={event.name}
                                         data-key={occurrence.key}
-                                        data-resource-key={occurrence.resourceKey}
+                                        data-resource-name={occurrence.resourceName}
                                         onprivatefocus={handleEventFocus}
                                         onprivateblur={hideDetailPopover}
                                         onprivatecontextmenu={handleEventContextMenu}
@@ -560,13 +557,13 @@
                 allow-search
                 is-multi-select
                 label={dialogLabels.resources}
-                value={selection.occurrence.keyFields}
+                value={selection.occurrence.resourceNames}
                 options={resourcesComboboxOptions}
                 remove-selected-options
                 dropdown-length="5-items"
                 required
                 data-element-id="avonni-combobox-event-resources"
-                onchange={handleEventKeyFieldsChange}
+                onchange={handleEventResourceNamesChange}
             ></c-combobox>
         </div>
         <div slot="footer" class="slds-text-align_right">

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -290,6 +290,7 @@
                     scroll-left-offset={firstColWidth}
                     start={start}
                     time-span={currentTimeSpan}
+                    visible-width={scheduleColWidth}
                     zoom-to-fit={zoomToFit}
                     data-element-id="avonni-primitive-scheduler-header-group"
                     onprivatecellsizechange={handleHeaderCellSizeChange}

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -1201,6 +1201,25 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
+     * Width of the schedule column, in pixels.
+     *
+     * @type {number}
+     */
+    get scheduleColWidth() {
+        const wrapper = this.template.querySelector(
+            '[data-element-id="div-schedule-wrapper"]'
+        );
+        const firstCol = this.firstCol;
+
+        if (wrapper && firstCol) {
+            const wrapperWidth = wrapper.getBoundingClientRect().width;
+            const firstColWidth = firstCol.getBoundingClientRect().width;
+            return wrapperWidth - firstColWidth;
+        }
+        return 0;
+    }
+
+    /**
      * Computed CSS class for the nested schedule column.
      *
      * @type {string}
@@ -1971,11 +1990,11 @@ export default class Scheduler extends LightningElement {
             '[data-element-id="avonni-primitive-scheduler-event-occurrence"]'
         );
         eventOccurrences.forEach((occurrence) => {
-            if (occurrence.disabled) {
-                occurrence.updateThickness();
-            }
             if (this._updateOccurrencesLength) {
                 occurrence.updateLength();
+            }
+            if (occurrence.disabled) {
+                occurrence.updateThickness();
             }
             occurrence.updatePosition();
         });
@@ -2629,7 +2648,6 @@ export default class Scheduler extends LightningElement {
         } else {
             this.cellWidth = cellSize;
         }
-        this.updateResourcesStyle();
     }
 
     /**

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -38,6 +38,9 @@ import {
     dateTimeObjectFrom,
     addToDate,
     deepCopy,
+    previousAllowedDay,
+    previousAllowedMonth,
+    previousAllowedTime,
     removeFromDate
 } from 'c/utilsPrivate';
 import { classSet } from 'c/utils';
@@ -3286,7 +3289,29 @@ export default class Scheduler extends LightningElement {
 
     handleToolbarPrevClick() {
         const { unit, span } = this.currentTimeSpan;
+
+        // If the date is set to one that is not available,
+        // the headers will automatically go to the next available date,
+        // preventing the schedule from going in the past
         let date = removeFromDate(this.start, unit, span);
+        if (unit === 'year' || unit === 'month') {
+            date = previousAllowedMonth(date, this.availableMonths);
+        } else if (unit === 'week' || unit === 'day') {
+            date = previousAllowedDay(
+                date,
+                this.availableMonths,
+                this.availableDaysOfTheWeek
+            );
+        } else {
+            date = previousAllowedTime(
+                date,
+                this.availableMonths,
+                this.availableDaysOfTheWeek,
+                this.availableTimeFrames,
+                unit,
+                span
+            );
+        }
         this.goToDate(date);
     }
 

--- a/src/modules/base/utilsPrivate/utilsPrivate.js
+++ b/src/modules/base/utilsPrivate/utilsPrivate.js
@@ -85,6 +85,9 @@ export {
     nextAllowedMonth,
     nextAllowedTime,
     numberOfUnitsBetweenDates,
+    previousAllowedDay,
+    previousAllowedMonth,
+    previousAllowedTime,
     removeFromDate
 } from './dateTimeUtils';
 import { smartSetAttribute } from './smartSetAttribute';


### PR DESCRIPTION
### Breaking Changes
**Scheduler**
- The `toolbar-time-spans` attribute is deprecated. The `time-spans` attribute replaces `toolbar-time-spans`.
- The `time-span` attribute is deprecated. The `selected-time-span` attribute replaces `time-span`.
- The `custom-headers` attribute is deprecated. Custom headers are now set in each time span object.
- The `headers` attribute is deprecated. Headers are now set in each time span object.
- The `resources-key-field` attribute is deprecated. The key field is always `name`: all resource objects must now have a `name` key.

### Features
**Scheduler**
- Added `timespanselect` event.

### Fixes
**Scheduler**
- Fixed the timeline headers not being narrowed when the visible time span changed.
- Fixed the "Previous" button of the toolbar blocking the navigation when the immediate previous time was unavailable. The "Previous" button now goes to the previous available time.