### PR TITLE
[feat] (ABC-533): Add styling hooks to carousel images

### DIFF
--- a/src/modules/base/carousel/__docs__/carousel.jsdoc.js
+++ b/src/modules/base/carousel/__docs__/carousel.jsdoc.js
@@ -78,6 +78,17 @@
  */
 /**
  * @memberof stylingHooks
+ * @name --avonni-carousel-item-image-background
+ * @default #ffffff
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-carousel-item-sizing-height
+ * @type length-percentage
+ */
+/**
+ * @memberof stylingHooks
  * @name --avonni-carousel-item-title-text-color
  * @default #ffffff
  * @type color

--- a/src/modules/base/carousel/__docs__/carousel.jsdoc.js
+++ b/src/modules/base/carousel/__docs__/carousel.jsdoc.js
@@ -78,13 +78,13 @@
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-carousel-item-image-background
+ * @name --avonni-carousel-item-image-color-background
  * @default #ffffff
  * @type color
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-carousel-item-sizing-height
+ * @name --avonni-carousel-item-image-sizing-height
  * @type length-percentage
  */
 /**

--- a/src/modules/base/primitiveCarouselItem/noTag.html
+++ b/src/modules/base/primitiveCarouselItem/noTag.html
@@ -104,7 +104,12 @@
                     </div>
                 </div>
             </template>
-            <img src={src} alt={imageAssistiveText} data-element-id="img" />
+            <img
+                class="avonni-carousel__image"
+                alt={imageAssistiveText}
+                src={src}
+                data-element-id="img"
+            />
         </div>
         <div
             class={computedCarouselContentClass}

--- a/src/modules/base/primitiveCarouselItem/shared.css
+++ b/src/modules/base/primitiveCarouselItem/shared.css
@@ -11,6 +11,15 @@
     font-weight: var(--avonni-carousel-item-title-font-weight, 600);
 }
 
+.avonni-carousel__image {
+    height: var(--avonni-carousel-item-image-sizing-height);
+    background-color: var(
+        --avonni-carousel-item-image-color-background,
+        #ffffff
+    );
+    object-fit: contain;
+}
+
 .avonni-carousel__actions {
     display: flex;
     width: 100%;

--- a/src/modules/base/primitiveCarouselItem/tag.html
+++ b/src/modules/base/primitiveCarouselItem/tag.html
@@ -103,7 +103,12 @@
                     </div>
                 </div>
             </template>
-            <img src={src} alt={imageAssistiveText} data-element-id="img" />
+            <img
+                class="avonni-carousel__image"
+                alt={imageAssistiveText}
+                src={src}
+                data-element-id="img"
+            />
         </div>
         <div
             class={computedCarouselContentClass}


### PR DESCRIPTION
### Features
**Carousel**
- Added two styling hooks: `--avonni-carousel-item-image-background` and `--avonni-carousel-item-image-sizing-height`.
