### PR TITLE
[fix] (ABC-711): Allow unselection of selected items in tree

### DIFF
--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
@@ -101,7 +101,7 @@ export default class PrimitiveTreeItem extends LightningElement {
     popoverVisible = false;
     _checkboxIsIndeterminate = false;
     _focusOn = false;
-    _isConnected = false;
+    _connected = false;
     _menuIsOpen = false;
 
     connectedCallback() {
@@ -141,7 +141,7 @@ export default class PrimitiveTreeItem extends LightningElement {
         this.addEventListener('mousedown', this.handleMouseDown);
         this.splitActions();
         this.computeSelection();
-        this._isConnected = true;
+        this._connected = true;
     }
 
     renderedCallback() {
@@ -181,7 +181,7 @@ export default class PrimitiveTreeItem extends LightningElement {
     }
     set actions(value) {
         this._actions = normalizeArray(value);
-        if (this._isConnected) this.splitActions();
+        if (this._connected) this.splitActions();
     }
 
     /**
@@ -196,7 +196,7 @@ export default class PrimitiveTreeItem extends LightningElement {
     }
     set actionsWhenDisabled(value) {
         this._actionsWhenDisabled = normalizeArray(value);
-        if (this._isConnected) this.splitActions();
+        if (this._connected) this.splitActions();
     }
 
     /**
@@ -240,7 +240,7 @@ export default class PrimitiveTreeItem extends LightningElement {
     }
     set childItems(value) {
         this._childItems = normalizeArray(value);
-        if (this._isConnected) this.computeSelection();
+        if (this._connected) this.computeSelection();
     }
 
     /**
@@ -301,7 +301,7 @@ export default class PrimitiveTreeItem extends LightningElement {
     }
     set disabled(value) {
         this._disabled = normalizeBoolean(value);
-        if (this._isConnected) this.splitActions();
+        if (this._connected) this.splitActions();
     }
 
     /**
@@ -317,7 +317,7 @@ export default class PrimitiveTreeItem extends LightningElement {
     }
     set independentMultiSelect(value) {
         this._independentMultiSelect = normalizeBoolean(value);
-        if (this._isConnected) this.computeSelection();
+        if (this._connected) this.computeSelection();
     }
 
     /**
@@ -437,7 +437,7 @@ export default class PrimitiveTreeItem extends LightningElement {
     }
     set selected(value) {
         this._selected = normalizeBoolean(value);
-        if (this._isConnected) this.computeSelection();
+        if (this._connected) this.computeSelection();
     }
 
     /**
@@ -453,7 +453,7 @@ export default class PrimitiveTreeItem extends LightningElement {
     }
     set showCheckbox(value) {
         this._showCheckbox = normalizeBoolean(value);
-        if (this._isConnected) this.computeSelection();
+        if (this._connected) this.computeSelection();
     }
 
     /**

--- a/src/modules/base/tree/tree.js
+++ b/src/modules/base/tree/tree.js
@@ -87,7 +87,7 @@ export default class Tree extends LightningElement {
     _dragState;
     _editedItemKey;
     _focusedItem;
-    _isConnected = false;
+    _connected = false;
     _mouseDownTimeout;
     _mouseOverItemTimeout;
     _selectTimeout;
@@ -98,7 +98,7 @@ export default class Tree extends LightningElement {
 
         window.addEventListener('mouseup', this.handleMouseUp);
         window.addEventListener('mousemove', this.handleMouseMove);
-        this._isConnected = true;
+        this._connected = true;
     }
 
     renderedCallback() {
@@ -229,7 +229,7 @@ export default class Tree extends LightningElement {
 
     set isMultiSelect(value) {
         this._isMultiSelect = value;
-        if (this._isConnected) this.resetSelection();
+        if (this._connected) this.resetSelection();
     }
 
     /**
@@ -249,7 +249,7 @@ export default class Tree extends LightningElement {
             return this.treedata.cloneItems(item);
         });
 
-        if (this._isConnected) this.initItems();
+        if (this._connected) this.initItems();
     }
 
     /**
@@ -290,7 +290,7 @@ export default class Tree extends LightningElement {
             typeof value === 'string'
                 ? [value]
                 : deepCopy(normalizeArray(value));
-        if (this._isConnected) this.resetSelection();
+        if (this._connected) this.resetSelection();
     }
 
     /**
@@ -908,6 +908,11 @@ export default class Tree extends LightningElement {
             if (selectedItem) {
                 this.treedata.expandTo(selectedItem);
                 this.setFocusToItem(selectedItem);
+            } else if (this._focusedItem) {
+                const callbacks = this.callbackMap[this._focusedItem.key];
+                callbacks.setSelected(false);
+                callbacks.unfocus();
+                this._focusedItem = null;
             }
             this.forceChildrenSelectionUpdate();
         }


### PR DESCRIPTION
### Fixes
**Tree**
- Fixed selection not being erased when an empty value was passed to `selected-items`.