### PR TITLE
[Feat](ABC-715): Adding and Changing Styling hooks

### DIFF
--- a/src/modules/base/activityTimeline/__docs__/activityTimeline.stories.js
+++ b/src/modules/base/activityTimeline/__docs__/activityTimeline.stories.js
@@ -52,6 +52,107 @@ export default {
                 type: { summary: 'object[]' }
             }
         },
+        buttonShowLessIconName: {
+            name: 'button-show-less-icon-name',
+            control: {
+                type: 'text'
+            },
+            description:
+                "The Lightning Design System name of the button icon. Specify the name in the format 'utility:up' where 'utility' is the category, and 'up' is the specific icon to be displayed. This attribute is supported only for the vertical orientation.",
+            table: {
+                type: { summary: 'string' },
+                category: 'Buttons'
+            }
+        },
+        buttonShowLessIconPosition: {
+            name: 'button-show-less-icon-position',
+            control: {
+                type: 'radio'
+            },
+            options: ['left', 'right'],
+            description:
+                "Position of the show less button's icon. Valid values include left and right. This attribute is supported only for the vertical orientation.",
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: 'left' },
+                category: 'Buttons'
+            }
+        },
+        buttonShowLessLabel: {
+            name: 'button-show-less-label',
+            control: {
+                type: 'text'
+            },
+            description:
+                'Label of the button that appears when all items are displayed and max-visible-items value is set. This attribute is supported only for the vertical orientation.',
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: 'Show less' },
+                category: 'Buttons'
+            }
+        },
+        buttonShowMoreIconName: {
+            name: 'button-show-more-icon-name',
+            control: {
+                type: 'text'
+            },
+            description:
+                "The Lightning Design System name of the button icon. Specify the name in the format 'utility:down' where 'utility' is the category, and 'down' is the specific icon to be displayed. This attribute is supported only for the vertical orientation.",
+            table: {
+                type: { summary: 'string' },
+                category: 'Buttons'
+            }
+        },
+        buttonShowMoreIconPosition: {
+            name: 'button-show-more-icon-position',
+            control: {
+                type: 'radio'
+            },
+            options: ['left', 'right'],
+            description:
+                'Position of the showMore button’s icon. Valid values include left and right. This attribute is supported only for the vertical orientation.',
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: 'left' },
+                category: 'Buttons'
+            }
+        },
+        buttonShowMoreLabel: {
+            name: 'button-show-more-label',
+            control: {
+                type: 'text'
+            },
+            description:
+                'Label of the button that appears when the number of items exceeds the max-visible-items number. This attribute is supported only for the vertical orientation.',
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: 'Show more' },
+                category: 'Buttons'
+            }
+        },
+        buttonVariant: {
+            name: 'button-variant',
+            control: {
+                type: 'select'
+            },
+            options: [
+                'neutral',
+                'base',
+                'brand',
+                'brand-outline',
+                'destructive',
+                'destructive-text',
+                'inverse',
+                'success'
+            ],
+            description:
+                'Variant of the button that appears when the number of items exceeds the max-visible-items number. This attribute is supported only for the vertical orientation.',
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: 'neutral' },
+                category: 'Buttons'
+            }
+        },
         closed: {
             control: {
                 type: 'boolean'
@@ -199,107 +300,6 @@ export default {
                 'The title can include text, and is displayed in the header.',
             table: {
                 type: { summary: 'string' }
-            }
-        },
-        buttonShowMoreLabel: {
-            name: 'button-show-more-label',
-            control: {
-                type: 'text'
-            },
-            description:
-                'Label of the button that appears when the number of items exceeds the max-visible-items number. This attribute is supported only for the vertical orientation.',
-            table: {
-                type: { summary: 'string' },
-                defaultValue: { summary: 'Show more' },
-                category: 'Buttons'
-            }
-        },
-        buttonVariant: {
-            name: 'button-variant',
-            control: {
-                type: 'select'
-            },
-            options: [
-                'neutral',
-                'base',
-                'brand',
-                'brand-outline',
-                'destructive',
-                'destructive-text',
-                'inverse',
-                'success'
-            ],
-            description:
-                'Variant of the button that appears when the number of items exceeds the max-visible-items number. This attribute is supported only for the vertical orientation.',
-            table: {
-                type: { summary: 'string' },
-                defaultValue: { summary: 'neutral' },
-                category: 'Buttons'
-            }
-        },
-        buttonShowMoreIconName: {
-            name: 'button-show-more-icon-name',
-            control: {
-                type: 'text'
-            },
-            description:
-                "The Lightning Design System name of the button icon. Specify the name in the format 'utility:down' where 'utility' is the category, and 'down' is the specific icon to be displayed. This attribute is supported only for the vertical orientation.",
-            table: {
-                type: { summary: 'string' },
-                category: 'Buttons'
-            }
-        },
-        buttonShowMoreIconPosition: {
-            name: 'button-show-more-icon-position',
-            control: {
-                type: 'radio'
-            },
-            options: ['left', 'right'],
-            description:
-                'Position of the showMore button’s icon. Valid values include left and right. This attribute is supported only for the vertical orientation.',
-            table: {
-                type: { summary: 'string' },
-                defaultValue: { summary: 'left' },
-                category: 'Buttons'
-            }
-        },
-        buttonShowLessLabel: {
-            name: 'button-show-less-label',
-            control: {
-                type: 'text'
-            },
-            description:
-                'Label of the button that appears when all items are displayed and max-visible-items value is set. This attribute is supported only for the vertical orientation.',
-            table: {
-                type: { summary: 'string' },
-                defaultValue: { summary: 'Show less' },
-                category: 'Buttons'
-            }
-        },
-        buttonShowLessIconName: {
-            name: 'button-show-less-icon-name',
-            control: {
-                type: 'text'
-            },
-            description:
-                "The Lightning Design System name of the button icon. Specify the name in the format 'utility:up' where 'utility' is the category, and 'up' is the specific icon to be displayed. This attribute is supported only for the vertical orientation.",
-            table: {
-                type: { summary: 'string' },
-                category: 'Buttons'
-            }
-        },
-        buttonShowLessIconPosition: {
-            name: 'button-show-less-icon-position',
-            control: {
-                type: 'radio'
-            },
-            options: ['left', 'right'],
-            description:
-                "Position of the show less button's icon. Valid values include left and right. This attribute is supported only for the vertical orientation.",
-            table: {
-                type: { summary: 'string' },
-                defaultValue: { summary: 'left' },
-                category: 'Buttons'
             }
         }
     },

--- a/src/modules/base/activityTimeline/activityTimeline.js
+++ b/src/modules/base/activityTimeline/activityTimeline.js
@@ -107,12 +107,11 @@ export default class ActivityTimeline extends LightningElement {
     @api title;
 
     /**
-     * Label of the button that appears when the number of item exceeds the max-visible-items number. This attribute is supported only for the vertical orientation.
+     * The Lightning Design System name of the show less button icon. Specify the name in the format 'utility:down' where 'utility' is the category, and 'down' is the specific icon to be displayed. This attribute is supported only for the vertical orientation.
      * @type {string}
-     * @default Show more
      * @public
      */
-    @api buttonShowMoreLabel = DEFAULT_BUTTON_SHOW_MORE_LABEL;
+    @api buttonShowLessIconName;
 
     /**
      * Label of the button that appears when all items are displayed and max-visible-items value is set. This attribute is supported only for the vertical orientation.
@@ -130,25 +129,26 @@ export default class ActivityTimeline extends LightningElement {
     @api buttonShowMoreIconName;
 
     /**
-     * The Lightning Design System name of the show less button icon. Specify the name in the format 'utility:down' where 'utility' is the category, and 'down' is the specific icon to be displayed. This attribute is supported only for the vertical orientation.
+     * Label of the button that appears when the number of item exceeds the max-visible-items number. This attribute is supported only for the vertical orientation.
      * @type {string}
+     * @default Show more
      * @public
      */
-    @api buttonShowLessIconName;
+    @api buttonShowMoreLabel = DEFAULT_BUTTON_SHOW_MORE_LABEL;
 
     _actions = [];
-    _buttonShowMoreIconPosition = BUTTON_ICON_POSITIONS.default;
     _buttonShowLessIconPosition = BUTTON_ICON_POSITIONS.default;
+    _buttonShowMoreIconPosition = BUTTON_ICON_POSITIONS.default;
     _buttonVariant = BUTTON_VARIANTS.default;
     _closed = false;
     _collapsible = false;
-    _itemDateFormat = DEFAULT_ITEM_DATE_FORMAT;
     _groupBy = GROUP_BY_OPTIONS.default;
-    _items = [];
     _hideItemDate = false;
-    _maxVisibleItems;
     _iconSize = ICON_SIZES.default;
+    _itemDateFormat = DEFAULT_ITEM_DATE_FORMAT;
     _itemIconSize = DEFAULT_ITEM_ICON_SIZE;
+    _items = [];
+    _maxVisibleItems;
     _orientation = ORIENTATIONS.default;
     _sortedDirection = SORTED_DIRECTIONS.default;
 
@@ -354,6 +354,25 @@ export default class ActivityTimeline extends LightningElement {
     }
 
     /**
+     * The size of the title's icon. Valid values are xx-small, x-small, small, medium and large.
+     *
+     * @public
+     * @type {string}
+     * @default medium
+     */
+    @api
+    get iconSize() {
+        return this._iconSize;
+    }
+
+    set iconSize(value) {
+        this._iconSize = normalizeString(value, {
+            fallbackValue: ICON_SIZES.default,
+            validValues: ICON_SIZES.valid
+        });
+    }
+
+    /**
      * The date format to use for each item. See [Luxon’s documentation](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) for accepted format.
      * If you want to insert text in the label, you need to escape it using single quote.
      * For example, the format of "Jan 14 day shift" would be <code>"LLL dd 'day shift'"</code>.
@@ -371,6 +390,25 @@ export default class ActivityTimeline extends LightningElement {
             value && typeof value === 'string'
                 ? value
                 : DEFAULT_ITEM_DATE_FORMAT;
+    }
+
+    /**
+     * The size of all the items' icon. Valid values are xx-small, x-small, small, medium and large. This attribute is supported only for the vertical orientation.
+     *
+     * @public
+     * @type {string}
+     * @default small
+     */
+    @api
+    get itemIconSize() {
+        return this._itemIconSize;
+    }
+
+    set itemIconSize(value) {
+        this._itemIconSize = normalizeString(value, {
+            fallbackValue: DEFAULT_ITEM_ICON_SIZE,
+            validValues: ICON_SIZES.valid
+        });
     }
 
     /**
@@ -405,44 +443,6 @@ export default class ActivityTimeline extends LightningElement {
         if (value && value > 0) {
             this._maxVisibleItems = value;
         }
-    }
-
-    /**
-     * The size of the title's icon. Valid values are xx-small, x-small, small, medium and large.
-     *
-     * @public
-     * @type {string}
-     * @default medium
-     */
-    @api
-    get iconSize() {
-        return this._iconSize;
-    }
-
-    set iconSize(value) {
-        this._iconSize = normalizeString(value, {
-            fallbackValue: ICON_SIZES.default,
-            validValues: ICON_SIZES.valid
-        });
-    }
-
-    /**
-     * The size of all the items' icon. Valid values are xx-small, x-small, small, medium and large. This attribute is supported only for the vertical orientation.
-     *
-     * @public
-     * @type {string}
-     * @default small
-     */
-    @api
-    get itemIconSize() {
-        return this._itemIconSize;
-    }
-
-    set itemIconSize(value) {
-        this._itemIconSize = normalizeString(value, {
-            fallbackValue: DEFAULT_ITEM_ICON_SIZE,
-            validValues: ICON_SIZES.valid
-        });
     }
 
     /**

--- a/src/modules/base/avatarGroup/__docs__/avatarGroup.jsdoc.js
+++ b/src/modules/base/avatarGroup/__docs__/avatarGroup.jsdoc.js
@@ -50,3 +50,9 @@
  * @default #ffffff
  * @type color
  */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-avatar-group-avatar-stack-styling-border
+ * @default #ffffff
+ * @type color
+ */

--- a/src/modules/base/avatarGroup/avatarGroup.css
+++ b/src/modules/base/avatarGroup/avatarGroup.css
@@ -53,6 +53,10 @@ span .avonni-avatar-group_in-line {
         --avonni-avatar-group-avatar-stack-sizing-border,
         1px
     );
+    --avonni-avatar-styling-border: var(
+        --avonni-avatar-group-avatar-stack-styling-border,
+        solid
+    );
     background-color: var(
         --avonni-avatar-group-avatar-stack-color-border,
         #ffffff

--- a/src/modules/base/colorPicker/__docs__/colorPicker.jsdoc.js
+++ b/src/modules/base/colorPicker/__docs__/colorPicker.jsdoc.js
@@ -20,3 +20,31 @@
  * @property {string} color Valid CSS color.
  * @property {object[]} groups Array of group names the color belongs to. If empty, the color will appear at the top of the list.
  */
+
+/**
+ * @namespace stylingHooks
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-color-picker-label-text-color
+ * @default #3e3e3c
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-color-picker-label-font-size
+ * @default 0.75rem
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-color-picker-label-font-style
+ * @default normal
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-color-picker-label-font-weight
+ * @default 400
+ * @type font
+ */

--- a/src/modules/base/colorPicker/colorPicker.css
+++ b/src/modules/base/colorPicker/colorPicker.css
@@ -118,3 +118,10 @@
 .avonni-color-picker__dropdown {
     max-width: none;
 }
+
+.avonni-color-picker__label {
+    color: var(--avonni-color-picker-label-text-color, #3e3e3c);
+    font-size: var(--avonni-color-picker-label-font-size, 0.75rem);
+    font-weight: var(--avonni-color-picker-label-font-weight, 400);
+    font-style: var(--avonni-color-picker-label-font-style, normal);
+}

--- a/src/modules/base/colorPicker/colorPicker.js
+++ b/src/modules/base/colorPicker/colorPicker.js
@@ -712,7 +712,9 @@ export default class ColorPicker extends LightningElement {
      * @type {string}
      */
     get computedLabelClass() {
-        return classSet('slds-form-element__label slds-no-flex')
+        return classSet(
+            'slds-form-element__label avonni-color-picker__label slds-no-flex'
+        )
             .add({
                 'slds-assistive-text': this.variant === 'label-hidden'
             })

--- a/src/modules/base/combobox/combobox.css
+++ b/src/modules/base/combobox/combobox.css
@@ -12,4 +12,5 @@
     color: var(--avonni-combobox-label-text-color, #3e3e3c);
     font-size: var(--avonni-combobox-label-font-size, 0.75rem);
     font-weight: var(--avonni-combobox-label-font-weight, 400);
+    font-style: var(--avonni-combobox-label-font-style, normal);
 }

--- a/src/modules/base/dateTimePicker/__docs__/dateTimePicker.jsdoc.js
+++ b/src/modules/base/dateTimePicker/__docs__/dateTimePicker.jsdoc.js
@@ -1,0 +1,27 @@
+/**
+ * @namespace stylingHooks
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-date-time-picker-label-text-color
+ * @default #444444
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-date-time-picker-label-font-size
+ * @default 0.75rem
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-date-time-picker-label-font-style
+ * @default normal
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-date-time-picker-label-font-weight
+ * @default 700
+ * @type font
+ */

--- a/src/modules/base/dateTimePicker/dateTimePicker.css
+++ b/src/modules/base/dateTimePicker/dateTimePicker.css
@@ -30,8 +30,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
- .avonni-date-time-picker__label {
+.avonni-date-time-picker__label {
     float: none;
+    color: var(--avonni-date-time-picker-label-text-color, #444444);
+    font-size: var(--avonni-date-time-picker-label-font-size, 0.75rem);
+    font-weight: var(--avonni-date-time-picker-label-font-weight, 700);
+    font-style: var(--avonni-date-time-picker-label-font-style, normal);
 }
 
 .avonni-date-time-picker__day {

--- a/src/modules/base/iconPicker/__docs__/iconPicker.jsdoc.js
+++ b/src/modules/base/iconPicker/__docs__/iconPicker.jsdoc.js
@@ -1,0 +1,27 @@
+/**
+ * @namespace stylingHooks
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-icon-picker-label-text-color
+ * @default #444444
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-icon-picker-label-font-size
+ * @default 0.75rem
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-icon-picker-label-font-style
+ * @default normal
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-icon-picker-label-font-weight
+ * @default 400
+ * @type font
+ */

--- a/src/modules/base/iconPicker/iconPicker.css
+++ b/src/modules/base/iconPicker/iconPicker.css
@@ -114,3 +114,10 @@ button:disabled {
 .avonni-icon-picker__toggle-button_size-limit {
     max-height: 2rem;
 }
+
+.avonni-icon-picker__label {
+    color: var(--avonni-icon-picker-label-text-color, #444444);
+    font-size: var(--avonni-icon-picker-label-font-size, 0.75rem);
+    font-weight: var(--avonni-icon-picker-label-font-weight, 400);
+    font-style: var(--avonni-icon-picker-label-font-style, normal);
+}

--- a/src/modules/base/iconPicker/iconPicker.js
+++ b/src/modules/base/iconPicker/iconPicker.js
@@ -516,7 +516,9 @@ export default class IconPicker extends LightningElement {
      * @type {string}
      */
     get computedLegendClass() {
-        return classSet('slds-form-element__label slds-no-flex')
+        return classSet(
+            'slds-form-element__label avonni-icon-picker__label slds-no-flex'
+        )
             .add({
                 'slds-assistive-text': this.variant === 'label-hidden'
             })

--- a/src/modules/base/illustration/__docs__/illustration.jsdoc.js
+++ b/src/modules/base/illustration/__docs__/illustration.jsdoc.js
@@ -7,3 +7,31 @@
  * @memberof slots
  * @name default
  */
+
+/**
+ * @namespace stylingHooks
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-illustration-title-text-color
+ * @default #181818
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-illustration-title-font-size
+ * @default 1.25rem
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-illustration-title-font-style
+ * @default normal
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-illustration-title-font-weight
+ * @default 400
+ * @type font
+ */

--- a/src/modules/base/illustration/illustration.css
+++ b/src/modules/base/illustration/illustration.css
@@ -1,4 +1,3 @@
-<!--
 /**
  * BSD 3-Clause License
  *
@@ -30,21 +29,10 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
--->
 
-<template>
-    <div class={illustrationClass}>
-        <img
-            if:true={showSvg}
-            src={svgURL}
-            class="slds-illustration__svg"
-            data-element-id="img"
-        />
-        <div class="slds-text-longform">
-            <h3 class="avonni-illustration__title" data-element-id="h3">
-                {title}
-            </h3>
-        </div>
-        <slot></slot>
-    </div>
-</template>
+.avonni-illustration__title {
+    color: var(--avonni-illustration-title-text-color, #181818);
+    font-size: var(--avonni-illustration-title-font-size, 1.25rem);
+    font-weight: var(--avonni-illustration-title-font-weight, 400);
+    font-style: var(--avonni-illustration-title-font-style, normal);
+}

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.css
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.css
@@ -40,11 +40,11 @@
 }
 
 :host[aria-disabled='true'] .avonni-primitive-tree-item__header {
-    color: var(--avonni-tree-item-text-color-header-disabled, #dddbda);
+    color: var(--avonni-tree-item-header-text-color-disabled, #dddbda);
 }
 
 :host[aria-disabled='true'] .avonni-primitive-tree-item__metatext {
-    color: var(--avonni-tree-item-text-color-metatext-disabled, #dddbda);
+    color: var(--avonni-tree-item-metatext-text-color-disabled, #dddbda);
 }
 
 :host[aria-disabled='true'] .avonni-primitive-tree-item__item.slds-is-hovered,
@@ -68,12 +68,15 @@
 }
 
 .avonni-primitive-tree-item__header .avonni-primitive-item__link {
-    color: var(--avonni-tree-item-text-color-header, #080707);
+    color: var(--avonni-tree-item-header-text-color-header, #080707);
+    font-size: var(--avonni-tree-item-header-text-font-size, 0.8125rem);
+    font-style: var(--avonni-tree-item-header-text-font-style, normal);
+    font-weight: var(--avonni-tree-item-header-text-font-weight, 400);
 }
 
 .avonni-primitive-tree-item__metatext,
 .avonni-primitive-tree-item__metatext .avonni-primitive-item__link {
-    color: var(--avonni-tree-item-text-color-metatext, #3e3e3c);
+    color: var(--avonni-tree-item-metatext-text-color, #3e3e3c);
 }
 
 .avonni-primitive-item__link:hover {

--- a/src/modules/base/tree/__docs__/tree.jsdoc.js
+++ b/src/modules/base/tree/__docs__/tree.jsdoc.js
@@ -101,25 +101,43 @@
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-tree-item-text-color-header
+ * @name --avonni-tree-item-header-text-color
  * @type color
  * @default #080707
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-tree-item-text-color-header-disabled
+ * @name --avonni-tree-item-header-text-color-disabled
  * @type color
  * @default #dddbda
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-tree-item-text-color-metatext
+ * @name --avonni-tree-item-header-text-font-size
+ * @type font
+ * @default 0.8125rem
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-tree-item-header-text-font-style
+ * @type font
+ * @default normal
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-tree-item-header-text-font-weight
+ * @type font
+ * @default 400
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-tree-item-metatext-text-color
  * @type color
  * @default #3e3e3c
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-tree-item-text-color-metatext-disabled
+ * @name --avonni-tree-item-metatext-text-color-disabled
  * @type color
  * @default #dddbda
  */

--- a/src/modules/base/tree/tree.css
+++ b/src/modules/base/tree/tree.css
@@ -33,6 +33,7 @@
 .avonni-tree__group-header {
     font-size: var(--avonni-tree-header-font-size, 0.875rem);
     font-weight: var(--avonni-tree-header-font-weight, 700);
+    font-style: var(--avonni-tree-header-font-style, normal);
     color: var(--avonni-tree-header-text-color);
 }
 


### PR DESCRIPTION
### Features
**Avatar Group**
- Added new styling hook for border
  --avonni-avatar-group-avatar-stack-styling-border

**Color Picker**
- Added new styling hooks for label
  --avonni-color-picker-label-text-color
  --avonni-color-picker-label-font-size
  --avonni-color-picker-label-font-style
  --avonni-color-picker-label-font-weight

**DatetimePicker**
- Added new styling hooks for label
  --avonni-date-time-picker-label-text-color
  --avonni-date-time-picker-label-font-size
  --avonni-date-time-picker-label-font-weight
  --avonni-date-time-picker-label-font-style

**iconPicker**
- Added new styling hooks for label
  --avonni-icon-picker-label-text-color
  --avonni-icon-picker-label-font-size
  --avonni-icon-picker-label-font-weight
  --avonni-icon-picker-label-font-style

**illustration**
- Added new styling hooks for title
  --avonni-illustration-title-text-color
  --avonni-illustration-title-font-size
  --avonni-illustration-title-font-weight
  --avonni-illustration-title-font-style

**Tree**
- Added new styling hook for header
  --avonni-tree-header-font-style
- Added new styling hook for item header
  --avonni-tree-item-header-text-font-size
  --avonni-tree-item-header-text-font-style
  --avonni-tree-item-header-text-font-weight
- Changed styling hooks name
  --avonni-tree-item-text-color-header =>  --avonni-tree-item-header-text-color
  --avonni-tree-item-text-color-header-disabled =>  --avonni-tree-item-header-text-color-disabled
  --avonni-tree-item-text-color-metatext =>  --avonni-tree-item-metatext-text-color
  --avonni-tree-item-text-color-metatext-disabled =>  --avonni-tree-item-metatext-text-color-disabled