### PR TITLE
[feat](ABC-721): Metric - Added font style styling hooks

### DIFF
--- a/src/modules/base/metric/__docs__/metric.jsdoc.js
+++ b/src/modules/base/metric/__docs__/metric.jsdoc.js
@@ -28,6 +28,12 @@
  */
 /**
  * @memberof stylingHooks
+ * @name --avonni-metric-description-font-style
+ * @default normal
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
  * @name --avonni-metric-description-font-weight
  * @default normal
  * @type (string|number)
@@ -43,6 +49,12 @@
  * @name --avonni-metric-label-font-size
  * @default 0.875rem
  * @type dimension
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-metric-label-font-style
+ * @default normal
+ * @type font
  */
 /**
  * @memberof stylingHooks
@@ -73,6 +85,12 @@
  * @name --avonni-metric-prefix-font-size
  * @default 1rem
  * @type dimension
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-metric-prefix-font-style
+ * @default normal
+ * @type font
  */
 /**
  * @memberof stylingHooks
@@ -148,6 +166,12 @@
  */
 /**
  * @memberof stylingHooks
+ * @name --avonni-metric-secondary-prefix-font-style
+ * @default normal
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
  * @name --avonni-metric-secondary-prefix-font-weight
  * @default bold
  * @type (string|number)
@@ -163,6 +187,12 @@
  * @name --avonni-metric-secondary-suffix-font-size
  * @default 0.8125rem
  * @type dimension
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-metric-secondary-suffix-font-style
+ * @default normal
+ * @type font
  */
 /**
  * @memberof stylingHooks
@@ -184,6 +214,12 @@
  */
 /**
  * @memberof stylingHooks
+ * @name --avonni-metric-secondary-value-font-style
+ * @default normal
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
  * @name --avonni-metric-secondary-value-font-weight
  * @default bold
  * @type (string|number)
@@ -202,6 +238,12 @@
  */
 /**
  * @memberof stylingHooks
+ * @name --avonni-metric-suffix-font-style
+ * @default normal
+ * @type font
+ */
+/**
+ * @memberof stylingHooks
  * @name --avonni-metric-suffix-font-weight
  * @default bold
  * @type (string|number)
@@ -217,6 +259,12 @@
  * @name --avonni-metric-value-font-size
  * @default 1.5rem
  * @type dimension
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-metric-value-font-style
+ * @default normal
+ * @type font
  */
 /**
  * @memberof stylingHooks

--- a/src/modules/base/metric/metric.css
+++ b/src/modules/base/metric/metric.css
@@ -12,12 +12,14 @@
 /* Texts and value */
 .avonni-metric__description {
     font-size: var(--avonni-metric-description-font-size, 0.75rem);
+    font-style: var(--avonni-metric-description-font-style, normal);
     font-weight: var(--avonni-metric-description-font-weight, normal);
     color: var(--avonni-metric-description-text-color, #747474);
 }
 
 .avonni-metric__label {
     font-size: var(--avonni-metric-label-font-size, 0.875rem);
+    font-style: var(--avonni-metric-label-font-style, normal);
     font-weight: var(--avonni-metric-label-font-weight, normal);
     color: var(--avonni-metric-label-text-color, #444444);
 }
@@ -26,6 +28,10 @@
     --avonni-primitive-metric-prefix-font-size: var(
         --avonni-metric-prefix-font-size,
         1rem
+    );
+    --avonni-primitive-metric-prefix-font-style: var(
+        --avonni-metric-prefix-font-style,
+        normal
     );
     --avonni-primitive-metric-prefix-font-weight: var(
         --avonni-metric-prefix-font-weight,
@@ -40,6 +46,10 @@
         --avonni-metric-suffix-font-size,
         1rem
     );
+    --avonni-primitive-metric-suffix-font-style: var(
+        --avonni-metric-suffix-font-style,
+        normal
+    );
     --avonni-primitive-metric-suffix-font-weight: var(
         --avonni-metric-suffix-font-weight,
         bold
@@ -52,6 +62,10 @@
     --avonni-primitive-metric-value-font-size: var(
         --avonni-metric-value-font-size,
         1.5rem
+    );
+    --avonni-primitive-metric-value-font-style: var(
+        --avonni-metric-value-font-style,
+        normal
     );
     --avonni-primitive-metric-value-font-weight: var(
         --avonni-metric-value-font-weight,
@@ -117,7 +131,10 @@
         --avonni-metric-secondary-prefix-font-size,
         0.8125rem
     );
-
+    --avonni-primitive-metric-prefix-font-style: var(
+        --avonni-metric-secondary-prefix-font-style,
+        normal
+    );
     --avonni-primitive-metric-prefix-font-weight: var(
         --avonni-metric-secondary-prefix-font-weight,
         bold
@@ -131,6 +148,10 @@
         --avonni-metric-secondary-suffix-font-size,
         0.8125rem
     );
+    --avonni-primitive-metric-suffix-font-style: var(
+        --avonni-metric-secondary-suffix-font-style,
+        normal
+    );
     --avonni-primitive-metric-suffix-font-weight: var(
         --avonni-metric-secondary-suffix-font-weight,
         bold
@@ -143,6 +164,10 @@
     --avonni-primitive-metric-value-font-size: var(
         --avonni-metric-secondary-value-font-size,
         0.8125rem
+    );
+    --avonni-primitive-metric-value-font-style: var(
+        --avonni-metric-secondary-value-font-style,
+        normal
     );
     --avonni-primitive-metric-value-font-weight: var(
         --avonni-metric-secondary-value-font-weight,

--- a/src/modules/base/primitiveMetric/primitiveMetric.css
+++ b/src/modules/base/primitiveMetric/primitiveMetric.css
@@ -16,18 +16,21 @@
 
 .avonni-metric__prefix {
     font-size: var(--avonni-primitive-metric-prefix-font-size);
+    font-style: var(--avonni-primitive-metric-prefix-font-style);
     font-weight: var(--avonni-primitive-metric-prefix-font-weight);
     color: var(--avonni-primitive-metric-prefix-text-color);
 }
 
 .avonni-metric__suffix {
     font-size: var(--avonni-primitive-metric-suffix-font-size);
+    font-style: var(--avonni-primitive-metric-suffix-font-style);
     font-weight: var(--avonni-primitive-metric-suffix-font-weight);
     color: var(--avonni-primitive-metric-suffix-text-color);
 }
 
 .avonni-metric__value {
     font-size: var(--avonni-primitive-metric-value-font-size);
+    font-style: var(--avonni-primitive-metric-value-font-style);
     font-weight: var(--avonni-primitive-metric-value-font-weight);
     line-height: var(--avonni-primitive-metric-value-line-height);
     color: var(--avonni-primitive-metric-value-text-color);


### PR DESCRIPTION
### Features
**Metric**
- Added font style styling hooks :
--avonni-metric-description-font-style
--avonni-metric-label-font-style
--avonni-metric-prefix-font-style
--avonni-metric-secondary-prefix-font-style
--avonni-metric-secondary-suffix-font-size
--avonni-metric-secondary-value-font-style
--avonni-metric-suffix-font-style
--avonni-metric-value-font-style
