### PR TITLE
[defaults] (ABC-724): Remove default value in metric

### DIFF
--- a/src/modules/base/metric/__docs__/metric.stories.js
+++ b/src/modules/base/metric/__docs__/metric.stories.js
@@ -398,8 +398,7 @@ export default {
             description: 'Value of the statistic.',
             required: true,
             table: {
-                type: { summary: 'number' },
-                defaultValue: { summary: '0' }
+                type: { summary: 'number' }
             }
         },
         valueSign: {
@@ -426,7 +425,6 @@ export default {
         secondaryValueSign: 'negative',
         showTrendColor: false,
         trendBreakpointValue: 0,
-        value: 0,
         valueSign: 'negative'
     }
 };

--- a/src/modules/base/metric/__tests__/metric.test.js
+++ b/src/modules/base/metric/__tests__/metric.test.js
@@ -86,7 +86,7 @@ describe('Metric', () => {
         expect(element.tooltip).toBeUndefined();
         expect(element.trendBreakpointValue).toBe(0);
         expect(element.trendIcon).toBeUndefined();
-        expect(element.value).toBe(0);
+        expect(element.value).toBeUndefined();
         expect(element.valueSign).toBe('negative');
     });
 
@@ -438,9 +438,7 @@ describe('Metric', () => {
             const metric = element.shadowRoot.querySelector(
                 '[data-element-id="avonni-primitive-metric-secondary"]'
             );
-            expect(metric.className).toBe(
-                'slds-m-left_x-small avonni-metric__secondary'
-            );
+            expect(metric.className).toBe('avonni-metric__secondary');
         });
     });
 
@@ -456,7 +454,7 @@ describe('Metric', () => {
                     '[data-element-id="avonni-primitive-metric-secondary"]'
                 );
                 expect(metric.className).toBe(
-                    'slds-m-left_x-small avonni-metric__secondary avonni-metric__secondary_positive-trend'
+                    'avonni-metric__secondary avonni-metric__secondary_positive-trend'
                 );
 
                 element.secondaryValue = 8;
@@ -467,7 +465,7 @@ describe('Metric', () => {
                     '[data-element-id="avonni-primitive-metric-secondary"]'
                 );
                 expect(metric.className).toBe(
-                    'slds-m-left_x-small avonni-metric__secondary avonni-metric__secondary_negative-trend'
+                    'avonni-metric__secondary avonni-metric__secondary_negative-trend'
                 );
 
                 element.secondaryValue = 10;
@@ -478,7 +476,7 @@ describe('Metric', () => {
                     '[data-element-id="avonni-primitive-metric-secondary"]'
                 );
                 expect(metric.className).toBe(
-                    'slds-m-left_x-small avonni-metric__secondary avonni-metric__secondary_neutral-trend'
+                    'avonni-metric__secondary avonni-metric__secondary_neutral-trend'
                 );
             });
     });

--- a/src/modules/base/metric/metric.js
+++ b/src/modules/base/metric/metric.js
@@ -50,7 +50,6 @@ const CURRENCY_DISPLAYS = {
 };
 
 const DEFAULT_TREND_BREAKPOINT_VALUE = 0;
-const DEFAULT_VALUE = 0;
 
 const FORMAT_STYLES = {
     default: 'decimal',
@@ -162,7 +161,7 @@ export default class Metric extends LightningElement {
     _tooltip;
     _trendBreakpointValue = DEFAULT_TREND_BREAKPOINT_VALUE;
     _trendIcon;
-    _value = DEFAULT_VALUE;
+    _value;
     _valueSign = VALUE_SIGNS.default;
 
     renderedCallback() {
@@ -513,7 +512,7 @@ export default class Metric extends LightningElement {
         return this._secondaryValue;
     }
     set secondaryValue(value) {
-        const normalizedNumber = Number(value);
+        const normalizedNumber = value === null ? undefined : Number(value);
         this._secondaryValue = isFinite(normalizedNumber)
             ? normalizedNumber
             : undefined;
@@ -617,8 +616,6 @@ export default class Metric extends LightningElement {
      * Value of the primary metric.
      *
      * @type {number}
-     * @required
-     * @default 0
      * @public
      */
     @api
@@ -626,10 +623,8 @@ export default class Metric extends LightningElement {
         return this._value;
     }
     set value(value) {
-        const normalizedNumber = Number(value);
-        this._value = isFinite(normalizedNumber)
-            ? normalizedNumber
-            : DEFAULT_VALUE;
+        const normalizedNumber = value === null ? undefined : Number(value);
+        this._value = isFinite(normalizedNumber) ? normalizedNumber : undefined;
     }
 
     /**
@@ -705,9 +700,9 @@ export default class Metric extends LightningElement {
      * @type {string}
      */
     get secondaryClass() {
-        const classes = classSet(
-            'slds-m-left_x-small avonni-metric__secondary'
-        );
+        const classes = classSet('avonni-metric__secondary').add({
+            'slds-m-left_x-small': isFinite(this.value)
+        });
 
         if (this.secondaryShowTrendColor) {
             const isPositive =

--- a/src/modules/base/primitiveMetric/__tests__/primitiveMetric.test.js
+++ b/src/modules/base/primitiveMetric/__tests__/primitiveMetric.test.js
@@ -61,7 +61,7 @@ describe('Primitive Metric', () => {
         expect(element.suffix).toBeUndefined();
         expect(element.trendBreakpointValue).toBe(0);
         expect(element.trendIcon).toBeUndefined();
-        expect(element.value).toBe(0);
+        expect(element.value).toBeUndefined();
         expect(element.valueSign).toBe('negative');
     });
 
@@ -74,6 +74,7 @@ describe('Primitive Metric', () => {
     // currency-code
     it('Primitive Metric: currencyCode', () => {
         element.currencyCode = 'EUR';
+        element.value = 40;
 
         return Promise.resolve().then(() => {
             const number = element.shadowRoot.querySelector(
@@ -86,6 +87,7 @@ describe('Primitive Metric', () => {
     // currency-display-as
     it('Primitive Metric: currencyDisplayAs', () => {
         element.currencyDisplayAs = 'code';
+        element.value = 40;
 
         return Promise.resolve().then(() => {
             const number = element.shadowRoot.querySelector(
@@ -98,6 +100,7 @@ describe('Primitive Metric', () => {
     // format-style
     it('Primitive Metric: formatStyle', () => {
         element.formatStyle = 'percent-fixed';
+        element.value = 40;
 
         return Promise.resolve().then(() => {
             const number = element.shadowRoot.querySelector(
@@ -110,6 +113,7 @@ describe('Primitive Metric', () => {
     // maximum-fraction-digits
     it('Primitive Metric: maximumFractionDigits', () => {
         element.maximumFractionDigits = 2;
+        element.value = 40;
 
         return Promise.resolve().then(() => {
             const number = element.shadowRoot.querySelector(
@@ -122,6 +126,7 @@ describe('Primitive Metric', () => {
     // maximum-significant-digits
     it('Primitive Metric: maximumSignificantDigits', () => {
         element.maximumSignificantDigits = 2;
+        element.value = 40;
 
         return Promise.resolve().then(() => {
             const number = element.shadowRoot.querySelector(
@@ -134,6 +139,7 @@ describe('Primitive Metric', () => {
     // minimum-fraction-digits
     it('Primitive Metric: minimumFractionDigits', () => {
         element.minimumFractionDigits = 2;
+        element.value = 40;
 
         return Promise.resolve().then(() => {
             const number = element.shadowRoot.querySelector(
@@ -146,6 +152,7 @@ describe('Primitive Metric', () => {
     // minimum-integer-digits
     it('Primitive Metric: minimumIntegerDigits', () => {
         element.minimumIntegerDigits = 2;
+        element.value = 40;
 
         return Promise.resolve().then(() => {
             const number = element.shadowRoot.querySelector(
@@ -158,6 +165,7 @@ describe('Primitive Metric', () => {
     // minimum-significant-digits
     it('Primitive Metric: minimumSignificantDigits', () => {
         element.minimumSignificantDigits = 2;
+        element.value = 40;
 
         return Promise.resolve().then(() => {
             const number = element.shadowRoot.querySelector(
@@ -170,6 +178,7 @@ describe('Primitive Metric', () => {
     // prefix
     it('Primitive Metric: prefix', () => {
         element.prefix = 'some prefix';
+        element.value = 40;
 
         return Promise.resolve().then(() => {
             const prefix = element.shadowRoot.querySelector(
@@ -182,6 +191,7 @@ describe('Primitive Metric', () => {
     // suffix
     it('Primitive Metric: suffix', () => {
         element.suffix = 'some suffix';
+        element.value = 40;
 
         return Promise.resolve().then(() => {
             const suffix = element.shadowRoot.querySelector(
@@ -363,6 +373,17 @@ describe('Primitive Metric', () => {
                 '[data-element-id="lightning-formatted-number"]'
             );
             expect(number.value).toBe(30);
+        });
+    });
+
+    it('Primitive Metric: no value will hide the primitive', () => {
+        element.value = null;
+
+        return Promise.resolve().then(() => {
+            const wrapper = element.shadowRoot.querySelector(
+                '[data-element-id="div-wrapper"]'
+            );
+            expect(wrapper).toBeFalsy();
         });
     });
 

--- a/src/modules/base/primitiveMetric/primitiveMetric.html
+++ b/src/modules/base/primitiveMetric/primitiveMetric.html
@@ -33,7 +33,11 @@
 -->
 
 <template>
-    <div class="slds-grid slds-grid_vertical-align-end avonni-metric__wrapper">
+    <div
+        if:true={hasValue}
+        class="slds-grid slds-grid_vertical-align-end avonni-metric__wrapper"
+        data-element-id="div-wrapper"
+    >
         <!-- Trend icon -->
         <lightning-dynamic-icon
             if:true={showDynamicIcon}

--- a/src/modules/base/primitiveMetric/primitiveMetric.js
+++ b/src/modules/base/primitiveMetric/primitiveMetric.js
@@ -40,7 +40,6 @@ const CURRENCY_DISPLAYS = {
 };
 
 const DEFAULT_TREND_BREAKPOINT_VALUE = 0;
-const DEFAULT_VALUE = 0;
 
 const FORMAT_STYLES = {
     default: 'decimal',
@@ -95,7 +94,7 @@ export default class PrimitiveMetric extends LightningElement {
     _minimumSignificantDigits;
     _trendBreakpointValue = DEFAULT_TREND_BREAKPOINT_VALUE;
     _trendIcon = TREND_ICONS.default;
-    _value = DEFAULT_VALUE;
+    _value;
     _valueSign = VALUE_SIGNS.default;
 
     /*
@@ -270,8 +269,6 @@ export default class PrimitiveMetric extends LightningElement {
      * Value of the metric.
      *
      * @type {number}
-     * @required
-     * @default 0
      * @public
      */
     @api
@@ -279,10 +276,8 @@ export default class PrimitiveMetric extends LightningElement {
         return this._value;
     }
     set value(value) {
-        const normalizedNumber = Number(value);
-        this._value = isFinite(normalizedNumber)
-            ? normalizedNumber
-            : DEFAULT_VALUE;
+        const normalizedNumber = value === null ? undefined : Number(value);
+        this._value = isFinite(normalizedNumber) ? normalizedNumber : undefined;
     }
 
     /**
@@ -323,6 +318,15 @@ export default class PrimitiveMetric extends LightningElement {
                 'slds-m-right_xx-small': this.value <= this.trendBreakpointValue
             })
             .toString();
+    }
+
+    /**
+     * True if the value is a valid number.
+     *
+     * @type {boolean}
+     */
+    get hasValue() {
+        return isFinite(this.value);
     }
 
     /**


### PR DESCRIPTION
### Breaking change
**Metric**
- Removed the default value of 0 for the `value` attribute. The `value` attribute is not required anymore.
- A `null` value passed to `value` or `secondary-value` will not be normalized to 0 anymore.