### PR TITLE
[fix] (ABC-728): Fix calendar interval display in Salesforce

### DIFF
--- a/src/modules/base/calendar/calendar.css
+++ b/src/modules/base/calendar/calendar.css
@@ -177,7 +177,7 @@ lightning-combobox {
     position: absolute;
     height: 100%;
     width: var(--avonni-calendar-cell-sizing-width);
-    transform: translateX(calc(-var(--avonni-calendar-cell-sizing-width) / 2));
+    transform: translateX(-0.5rem);
     z-index: -1;
     background: var(--avonni-calendar-selected-date-color-background, #0176d3);
 }


### PR DESCRIPTION
### Fixes
**Calendar**
- Fixed the interval display when the component is used on the Salesforce platform.