### PR TITLE
[fix][refactor] (ABC-732): Refactor and support string dates in calendar

### DIFF
--- a/src/modules/base/calendar/__docs__/calendar.stories.js
+++ b/src/modules/base/calendar/__docs__/calendar.stories.js
@@ -232,7 +232,7 @@ Labels.args = {
             iconVariant: 'inverse'
         },
         {
-            date: new Date('05/25/2022'),
+            date: '05/25/2022',
             label: '25 may long label',
             variant: 'error',
             iconName: 'standard:lightning_component',

--- a/src/modules/base/calendar/__tests__/calendar.test.js
+++ b/src/modules/base/calendar/__tests__/calendar.test.js
@@ -479,6 +479,24 @@ describe('Calendar', () => {
         });
     });
 
+    it('Calendar: marked dates, a maximum of 3 per date is displayed', () => {
+        element.value = '05/09/2021';
+        element.markedDates = [
+            { date: new Date('05/05/2021'), color: 'tomato' },
+            { date: new Date('05/05/2021'), color: 'blue' },
+            { date: new Date('05/05/2021'), color: 'violet' },
+            { date: new Date('05/05/2021'), color: 'purple' },
+            { date: new Date('05/05/2021'), color: 'orange' }
+        ];
+
+        return Promise.resolve().then(() => {
+            const markedDates = element.shadowRoot.querySelectorAll(
+                '[data-element-id="div-marked-cells"]'
+            );
+            expect(markedDates).toHaveLength(3);
+        });
+    });
+
     // enable current month only
     it('Calendar: disable dates of previous and next months', () => {
         element.value = '05/09/2021';

--- a/src/modules/base/calendar/__tests__/calendar.test.js
+++ b/src/modules/base/calendar/__tests__/calendar.test.js
@@ -31,7 +31,7 @@
  */
 
 import { createElement } from 'lwc';
-import Calendar from 'c/calendar';
+import Calendar from '../calendar';
 
 // not tested : mouse over, mouse out events on calendar, keyboard selecting a date ouside current month, trying to select a disabled date, previous month and next month buttons
 
@@ -157,9 +157,7 @@ describe('Calendar', () => {
         element.value = '05/12/2022';
 
         return Promise.resolve().then(() => {
-            const day8 = element.shadowRoot
-                .querySelector('span[data-date="8"]')
-                .closest('td');
+            const day8 = element.shadowRoot.querySelector('td[data-date="8"]');
             const spy8 = jest.spyOn(day8, 'focus');
 
             element.focusDate('05/08/2022');
@@ -223,9 +221,7 @@ describe('Calendar', () => {
         element.value = '05/09/2021';
 
         return Promise.resolve().then(() => {
-            const day8 = element.shadowRoot
-                .querySelector('span[data-date="8"]')
-                .closest('td');
+            const day8 = element.shadowRoot.querySelector('td[data-date="8"]');
             const spy8 = jest.spyOn(day8, 'focus');
 
             jest.runOnlyPendingTimers();
@@ -243,9 +239,8 @@ describe('Calendar', () => {
         element.value = '05/09/2021';
 
         return Promise.resolve().then(() => {
-            const day10 = element.shadowRoot
-                .querySelector('span[data-date="10"]')
-                .closest('td');
+            const day10 =
+                element.shadowRoot.querySelector('td[data-date="10"]');
             const spy10 = jest.spyOn(day10, 'focus');
 
             jest.runOnlyPendingTimers();
@@ -263,9 +258,7 @@ describe('Calendar', () => {
         element.value = '05/09/2021';
 
         return Promise.resolve().then(() => {
-            const day2 = element.shadowRoot
-                .querySelector('span[data-date="2"]')
-                .closest('td');
+            const day2 = element.shadowRoot.querySelector('td[data-date="2"]');
             const spy2 = jest.spyOn(day2, 'focus');
 
             jest.runOnlyPendingTimers();
@@ -283,9 +276,8 @@ describe('Calendar', () => {
         element.value = '05/09/2021';
 
         return Promise.resolve().then(() => {
-            const day16 = element.shadowRoot
-                .querySelector('span[data-date="16"]')
-                .closest('td');
+            const day16 =
+                element.shadowRoot.querySelector('td[data-date="16"]');
             const spy16 = jest.spyOn(day16, 'focus');
 
             jest.runOnlyPendingTimers();
@@ -303,9 +295,7 @@ describe('Calendar', () => {
         element.value = '05/10/2022';
 
         return Promise.resolve().then(() => {
-            const day8 = element.shadowRoot
-                .querySelector('span[data-date="8"]')
-                .closest('td');
+            const day8 = element.shadowRoot.querySelector('td[data-date="8"]');
             const spy8 = jest.spyOn(day8, 'focus');
 
             jest.runAllTimers();
@@ -323,9 +313,8 @@ describe('Calendar', () => {
         element.value = '05/09/2022';
 
         return Promise.resolve().then(() => {
-            const day14 = element.shadowRoot
-                .querySelector('span[data-date="14"]')
-                .closest('td');
+            const day14 =
+                element.shadowRoot.querySelector('td[data-date="14"]');
             const spy14 = jest.spyOn(day14, 'focus');
 
             jest.runAllTimers();
@@ -344,9 +333,8 @@ describe('Calendar', () => {
 
         return Promise.resolve()
             .then(() => {
-                const day9 = element.shadowRoot
-                    .querySelector('span[data-date="9"]')
-                    .closest('td');
+                const day9 =
+                    element.shadowRoot.querySelector('td[data-date="9"]');
                 day9.dispatchEvent(
                     new KeyboardEvent('keydown', { keyCode: 34, bubbles: true })
                 );
@@ -366,9 +354,8 @@ describe('Calendar', () => {
 
         return Promise.resolve()
             .then(() => {
-                const day9 = element.shadowRoot
-                    .querySelector('span[data-date="9"]')
-                    .closest('td');
+                const day9 =
+                    element.shadowRoot.querySelector('td[data-date="9"]');
                 day9.dispatchEvent(
                     new KeyboardEvent('keydown', { keyCode: 33, bubbles: true })
                 );
@@ -388,9 +375,8 @@ describe('Calendar', () => {
 
         return Promise.resolve()
             .then(() => {
-                const day9 = element.shadowRoot
-                    .querySelector('span[data-date="9"]')
-                    .closest('td');
+                const day9 =
+                    element.shadowRoot.querySelector('td[data-date="9"]');
                 day9.dispatchEvent(
                     new KeyboardEvent('keydown', {
                         keyCode: 34,
@@ -413,9 +399,8 @@ describe('Calendar', () => {
 
         return Promise.resolve()
             .then(() => {
-                const day9 = element.shadowRoot
-                    .querySelector('span[data-date="9"]')
-                    .closest('td');
+                const day9 =
+                    element.shadowRoot.querySelector('td[data-date="9"]');
                 day9.dispatchEvent(
                     new KeyboardEvent('keydown', {
                         keyCode: 33,
@@ -973,12 +958,12 @@ describe('Calendar', () => {
             weeks.forEach((week) => {
                 weekNumbers.push(week.textContent);
             });
+            expect(weekNumbers.includes('17')).toBeTruthy();
             expect(weekNumbers.includes('18')).toBeTruthy();
             expect(weekNumbers.includes('19')).toBeTruthy();
             expect(weekNumbers.includes('20')).toBeTruthy();
             expect(weekNumbers.includes('21')).toBeTruthy();
             expect(weekNumbers.includes('22')).toBeTruthy();
-            expect(weekNumbers.includes('23')).toBeTruthy();
         });
     });
 
@@ -1162,9 +1147,8 @@ describe('Calendar', () => {
 
         return Promise.resolve()
             .then(() => {
-                const day9 = element.shadowRoot
-                    .querySelector('span[data-date="1"]')
-                    .closest('td');
+                const day9 =
+                    element.shadowRoot.querySelector('td[data-date="1"]');
                 day9.dispatchEvent(
                     new KeyboardEvent('keydown', { keyCode: 37, bubbles: true })
                 );
@@ -1187,9 +1171,8 @@ describe('Calendar', () => {
 
         return Promise.resolve()
             .then(() => {
-                const day9 = element.shadowRoot
-                    .querySelector('span[data-date="31"]')
-                    .closest('td');
+                const day9 =
+                    element.shadowRoot.querySelector('td[data-date="31"]');
                 day9.dispatchEvent(
                     new KeyboardEvent('keydown', { keyCode: 39, bubbles: true })
                 );
@@ -1212,9 +1195,8 @@ describe('Calendar', () => {
 
         return Promise.resolve()
             .then(() => {
-                const day9 = element.shadowRoot
-                    .querySelector('span[data-date="7"]')
-                    .closest('td');
+                const day9 =
+                    element.shadowRoot.querySelector('td[data-date="7"]');
                 day9.dispatchEvent(
                     new KeyboardEvent('keydown', { keyCode: 38, bubbles: true })
                 );
@@ -1237,9 +1219,8 @@ describe('Calendar', () => {
 
         return Promise.resolve()
             .then(() => {
-                const day9 = element.shadowRoot
-                    .querySelector('span[data-date="28"]')
-                    .closest('td');
+                const day9 =
+                    element.shadowRoot.querySelector('td[data-date="28"]');
                 day9.dispatchEvent(
                     new KeyboardEvent('keydown', { keyCode: 40, bubbles: true })
                 );
@@ -1262,9 +1243,8 @@ describe('Calendar', () => {
 
         return Promise.resolve()
             .then(() => {
-                const day9 = element.shadowRoot
-                    .querySelector('span[data-date="4"]')
-                    .closest('td');
+                const day9 =
+                    element.shadowRoot.querySelector('td[data-date="4"]');
                 day9.dispatchEvent(
                     new KeyboardEvent('keydown', { keyCode: 36, bubbles: true })
                 );
@@ -1287,9 +1267,8 @@ describe('Calendar', () => {
 
         return Promise.resolve()
             .then(() => {
-                const day9 = element.shadowRoot
-                    .querySelector('span[data-date="29"]')
-                    .closest('td');
+                const day9 =
+                    element.shadowRoot.querySelector('td[data-date="29"]');
                 day9.dispatchEvent(
                     new KeyboardEvent('keydown', { keyCode: 35, bubbles: true })
                 );
@@ -1312,9 +1291,8 @@ describe('Calendar', () => {
 
         return Promise.resolve()
             .then(() => {
-                const day9 = element.shadowRoot
-                    .querySelector('span[data-date="29"]')
-                    .closest('td');
+                const day9 =
+                    element.shadowRoot.querySelector('td[data-date="29"]');
                 day9.dispatchEvent(
                     new KeyboardEvent('keydown', { keyCode: 35, bubbles: true })
                 );
@@ -1337,9 +1315,8 @@ describe('Calendar', () => {
 
         return Promise.resolve()
             .then(() => {
-                const day9 = element.shadowRoot
-                    .querySelector('span[data-date="29"]')
-                    .closest('td');
+                const day9 =
+                    element.shadowRoot.querySelector('td[data-date="29"]');
                 day9.dispatchEvent(
                     new KeyboardEvent('keydown', { keyCode: 34, bubbles: true })
                 );

--- a/src/modules/base/calendar/calendar.html
+++ b/src/modules/base/calendar/calendar.html
@@ -107,7 +107,7 @@
                 </template>
                 <table
                     aria-labelledby="month"
-                    aria-multiselectable="true"
+                    aria-multiselectable={isMultiSelect}
                     class={tableClasses}
                     role="grid"
                 >
@@ -137,28 +137,28 @@
                             >
                                 <template for:each={week} for:item="day">
                                     <td
-                                        class={day.class}
-                                        role="gridcell"
+                                        class={day.wrapperClass}
                                         key={generateKey}
                                         aria-selected={day.selected}
-                                        aria-current={day.currentDate}
+                                        aria-current={day.ariaCurrent}
+                                        role="gridcell"
+                                        tabindex={day.tabIndex}
+                                        data-cell-day={day.date}
+                                        data-day={day.date}
                                         onmouseover={handleMouseOver}
                                         onmouseout={handleMouseOut}
                                         onfocus={handleDateFocus}
-                                        data-cell-day={day.fullDate}
-                                        data-day={day.fullDate}
-                                        tabindex={day.tabIndex}
                                     >
                                         <span
-                                            class={day.dayClass}
-                                            data-day={day.fullDate}
+                                            class={day.labelClass}
+                                            data-day={day.date}
                                             data-date={day.label}
                                             data-element-id="span-day-label"
                                             onclick={handlerSelectDate}
                                             >{day.label}
                                         </span>
                                         <div
-                                            if:true={day.marked}
+                                            if:true={day.markers.length}
                                             class="slds-is-relative"
                                         >
                                             <div
@@ -167,7 +167,7 @@
                                                 "
                                             >
                                                 <template
-                                                    for:each={day.markedColors}
+                                                    for:each={day.markers}
                                                     for:item="marker"
                                                 >
                                                     <div
@@ -176,22 +176,22 @@
                                                             avonni-calendar__marked-cells
                                                         "
                                                         data-element-id="div-marked-cells"
-                                                        style={marker.color}
+                                                        style={marker}
                                                     ></div>
                                                 </template>
                                             </div>
                                         </div>
                                         <c-chip
-                                            if:true={day.labeled}
-                                            class={day.chip.classes}
+                                            if:true={day.hasChip}
+                                            class={day.chip.computedClass}
                                             label={day.chip.label}
                                             variant={day.chip.variant}
                                             outline={day.chip.outline}
-                                            data-day={day.fullDate}
+                                            data-day={day.date}
                                             data-element-id="chip-date-label"
                                         >
                                             <c-primitive-icon
-                                                if:true={day.chip.showLeft}
+                                                if:true={day.chip.showLeftIcon}
                                                 class="
                                                     avonni-calendar-chip-icon-left
                                                 "
@@ -199,10 +199,10 @@
                                                 size="xx-small"
                                                 variant={day.chip.iconVariant}
                                                 icon-name={day.chip.iconName}
-                                                data-day={day.fullDate}
+                                                data-day={day.date}
                                             ></c-primitive-icon>
                                             <c-primitive-icon
-                                                if:true={day.chip.showRight}
+                                                if:true={day.chip.showRightIcon}
                                                 class="
                                                     avonni-calendar-chip-icon-right
                                                 "
@@ -210,7 +210,7 @@
                                                 size="xx-small"
                                                 variant={day.chip.iconVariant}
                                                 icon-name={day.chip.iconName}
-                                                data-day={day.fullDate}
+                                                data-day={day.date}
                                             ></c-primitive-icon>
                                         </c-chip>
                                     </td>

--- a/src/modules/base/calendar/calendar.html
+++ b/src/modules/base/calendar/calendar.html
@@ -143,20 +143,20 @@
                                         aria-current={day.ariaCurrent}
                                         role="gridcell"
                                         tabindex={day.tabIndex}
-                                        data-cell-day={day.date}
-                                        data-day={day.date}
+                                        data-full-date={day.date}
+                                        data-date={day.label}
                                         onmouseover={handleMouseOver}
                                         onmouseout={handleMouseOut}
                                         onfocus={handleDateFocus}
                                     >
                                         <span
                                             class={day.labelClass}
-                                            data-day={day.date}
+                                            data-full-date={day.date}
                                             data-date={day.label}
                                             data-element-id="span-day-label"
-                                            onclick={handlerSelectDate}
-                                            >{day.label}
-                                        </span>
+                                            onclick={handleSelectDate}
+                                            >{day.label}</span
+                                        >
                                         <div
                                             if:true={day.markers.length}
                                             class="slds-is-relative"
@@ -187,7 +187,7 @@
                                             label={day.chip.label}
                                             variant={day.chip.variant}
                                             outline={day.chip.outline}
-                                            data-day={day.date}
+                                            data-full-date={day.date}
                                             data-element-id="chip-date-label"
                                         >
                                             <c-primitive-icon
@@ -199,7 +199,7 @@
                                                 size="xx-small"
                                                 variant={day.chip.iconVariant}
                                                 icon-name={day.chip.iconName}
-                                                data-day={day.date}
+                                                data-full-date={day.date}
                                             ></c-primitive-icon>
                                             <c-primitive-icon
                                                 if:true={day.chip.showRightIcon}
@@ -210,7 +210,7 @@
                                                 size="xx-small"
                                                 variant={day.chip.iconVariant}
                                                 icon-name={day.chip.iconName}
-                                                data-day={day.date}
+                                                data-full-date={day.date}
                                             ></c-primitive-icon>
                                         </c-chip>
                                     </td>

--- a/src/modules/base/calendar/calendar.js
+++ b/src/modules/base/calendar/calendar.js
@@ -209,7 +209,7 @@ export default class Calendar extends LightningElement {
     }
 
     /**
-     * Array of marked date objects.
+     * Array of marked date objects. A maximum of three markers can be displayed on a same date.
      *
      * @public
      * @type {object[]}
@@ -816,7 +816,8 @@ export default class Calendar extends LightningElement {
                 markers.push(`background-color: ${marker.color}`);
             }
         });
-        return markers;
+        // A maximum of 3 markers are displayed per date
+        return markers.slice(0, 3);
     }
 
     /**

--- a/src/modules/base/calendar/date.js
+++ b/src/modules/base/calendar/date.js
@@ -1,0 +1,87 @@
+/**
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2021, Avonni Labs, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { classSet } from 'c/utils';
+import {
+    getWeekNumber,
+    normalizeArray,
+    normalizeBoolean,
+    normalizeObject
+} from 'c/utilsPrivate';
+import Label from './dateLabel';
+
+export default class CalendarDate {
+    constructor(props) {
+        this.adjacentMonth = props.adjacentMonth;
+        this.date = props.date;
+        this.disabled = normalizeBoolean(props.disabled);
+        this.isPartOfInterval = normalizeBoolean(props.isPartOfInterval);
+        this.isToday = normalizeBoolean(props.isToday);
+        this.isWeekNumber = normalizeBoolean(props.isWeekNumber);
+        this.chip = new Label(normalizeObject(props.chip));
+        this.markers = normalizeArray(props.markers);
+        this.selected = normalizeBoolean(props.selected);
+    }
+
+    get ariaCurrent() {
+        return this.isToday ? 'date' : null;
+    }
+
+    get hasChip() {
+        return this.chip.iconName || this.chip.label;
+    }
+
+    get label() {
+        if (this.isWeekNumber) {
+            return getWeekNumber(this.date);
+        }
+        return new Date(this.date).getDate();
+    }
+
+    get labelClass() {
+        return classSet({
+            'slds-day': !this.isWeekNumber,
+            'avonni-calendar__disabled-cell': this.disabled
+        }).toString();
+    }
+
+    get wrapperClass() {
+        return classSet({
+            'avonni-calendar__date-cell': !this.isWeekNumber,
+            'avonni-calendar__week-cell': this.isWeekNumber,
+            'slds-day_adjacent-month': this.adjacentMonth,
+            'slds-is-today': this.isToday,
+            'slds-is-selected': this.selected || this.isPartOfInterval,
+            'slds-is-selected-multi': this.isPartOfInterval
+        }).toString();
+    }
+}

--- a/src/modules/base/calendar/dateLabel.js
+++ b/src/modules/base/calendar/dateLabel.js
@@ -1,0 +1,95 @@
+/**
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2021, Avonni Labs, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { normalizeBoolean, normalizeString } from 'c/utilsPrivate';
+import { classSet } from 'c/utils';
+
+const POSITIONS = {
+    valid: ['left', 'right'],
+    default: 'left'
+};
+const VARIANTS = {
+    valid: [
+        'alt-inverse',
+        'base',
+        'brand',
+        'error',
+        'info',
+        'inverse',
+        'offline',
+        'success',
+        'warning'
+    ],
+    default: 'base'
+};
+
+const ICON_VARIANTS = {
+    valid: ['bare', 'error', 'inverse', 'warning', 'success'],
+    default: 'bare'
+};
+
+export default class CalendarDateLabel {
+    constructor(props) {
+        this.iconName = props.iconName;
+        this.iconPosition = normalizeString(props.iconPosition, {
+            fallbackValue: POSITIONS.default,
+            validValues: POSITIONS.valid
+        });
+        this.iconVariant = normalizeString(props.iconVariant, {
+            fallbackValue: ICON_VARIANTS.default,
+            validValues: ICON_VARIANTS.valid
+        });
+        this.label = props.label;
+        this.outline = normalizeBoolean(props.outline);
+        this.variant = normalizeString(props.variant, {
+            fallbackValue: VARIANTS.default,
+            validValues: VARIANTS.valid
+        });
+    }
+
+    get computedClass() {
+        return classSet('avonni-calendar__chip-label')
+            .add({
+                'avonni-calendar__chip-icon-only': this.iconName && !this.label,
+                'avonni-calendar__chip-without-icon': !this.iconName
+            })
+            .toString();
+    }
+
+    get showLeftIcon() {
+        return this.iconName && this.iconPosition === 'left';
+    }
+
+    get showRightIcon() {
+        return this.iconName && this.iconPosition === 'right';
+    }
+}

--- a/src/modules/base/utilsPrivate/dateTimeUtils.js
+++ b/src/modules/base/utilsPrivate/dateTimeUtils.js
@@ -102,6 +102,25 @@ const addToDate = (date, unit, span) => {
 };
 
 /**
+ * Get the week number of a date, starting the weeks from Sunday.
+ *
+ * @param {Date|DateTime|number|string} date The date we want to get the week number of.
+ * @returns {number|null} The week number or null if the date is not a valid date.
+ */
+const getWeekNumber = (date) => {
+    let normalizedDate = date;
+    if (!(date instanceof DateTime)) {
+        normalizedDate = dateTimeObjectFrom(date);
+        if (!normalizedDate) return null;
+    }
+
+    if (normalizedDate.weekday === 7) {
+        normalizedDate = addToDate(normalizedDate, 'day', 1);
+    }
+    return normalizedDate.weekNumber;
+};
+
+/**
  * Remove unit * span from the date.
  *
  * @param {DateTime} date The date we want to remove time from.
@@ -435,6 +454,7 @@ export {
     addToDate,
     containsAllowedDateTimes,
     dateTimeObjectFrom,
+    getWeekNumber,
     nextAllowedDay,
     nextAllowedMonth,
     nextAllowedTime,

--- a/src/modules/base/utilsPrivate/utilsPrivate.js
+++ b/src/modules/base/utilsPrivate/utilsPrivate.js
@@ -81,6 +81,7 @@ export {
     addToDate,
     containsAllowedDateTimes,
     dateTimeObjectFrom,
+    getWeekNumber,
     nextAllowedDay,
     nextAllowedMonth,
     nextAllowedTime,


### PR DESCRIPTION
<!-- Are you sure you're ready to open a pull request? -->
<!-- Checkout the list first: https://avonnicreator.atlassian.net/wiki/spaces/LDG/pages/2140766209/Can+I+open+a+pull+request -->
<!-- Then use this template to explain what you did: -->

### Fixes
**Calendar**
- Implemented support of string dates in `date-labels`
- Blocked the number of markers displayed on a single date to a maximum of three.