### PR TITLE
[fix] (ABC-736): Scroll back to top when changing combobox level

### DIFF
--- a/src/modules/base/primitiveCombobox/primitiveCombobox.js
+++ b/src/modules/base/primitiveCombobox/primitiveCombobox.js
@@ -1811,6 +1811,16 @@ export default class PrimitiveCombobox extends LightningElement {
                     }
                 })
             );
+
+            requestAnimationFrame(() => {
+                // Scroll back to top when opening a child option
+                const scrollableList = this.template.querySelector(
+                    '[data-element-id="ul-listbox"]'
+                );
+                if (scrollableList) {
+                    scrollableList.scrollTop = 0;
+                }
+            });
             return;
         }
 


### PR DESCRIPTION
### Fixes
**Combobox**
- Fixed scroll position not reset when the combobox level changed.