### PR TITLE
[feat] (ABC-780): Standardize tree default actions

### DIFF
--- a/src/modules/base/primitiveTreeItem/__tests__/primitiveTreeItem.test.js
+++ b/src/modules/base/primitiveTreeItem/__tests__/primitiveTreeItem.test.js
@@ -36,7 +36,7 @@ import PrimitiveTreeItem from '../primitiveTreeItem';
 const ACTIONS = [
     {
         label: 'Some action',
-        name: 'edit',
+        name: 'Standard.Tree.Edit',
         iconName: 'utility:apps',
         visible: true
     },
@@ -47,7 +47,7 @@ const ACTIONS = [
     },
     {
         label: 'Some third action',
-        name: 'delete'
+        name: 'Standard.Tree.Delete'
     },
     {
         label: 'Some fourth action',
@@ -487,7 +487,7 @@ describe('Primitive Tree Item', () => {
         element.actions = [
             {
                 label: 'Edit',
-                name: 'edit',
+                name: 'Standard.Tree.Edit',
                 visible: true,
                 iconName: 'utility:edit'
             }
@@ -1268,7 +1268,9 @@ describe('Primitive Tree Item', () => {
                     'object'
                 );
                 expect(handler.mock.calls[0][0].detail.key).toBe('someKey');
-                expect(handler.mock.calls[0][0].detail.name).toBe('edit');
+                expect(handler.mock.calls[0][0].detail.name).toBe(
+                    'Standard.Tree.Edit'
+                );
                 expect(handler.mock.calls[0][0].bubbles).toBeTruthy();
                 expect(handler.mock.calls[0][0].cancelable).toBeTruthy();
                 expect(handler.mock.calls[0][0].composed).toBeTruthy();

--- a/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
+++ b/src/modules/base/primitiveTreeItem/primitiveTreeItem.js
@@ -1012,7 +1012,10 @@ export default class PrimitiveTreeItem extends LightningElement {
         });
         this.dispatchEvent(actionClickEvent);
 
-        if (name === 'edit' && !actionClickEvent.defaultPrevented) {
+        if (
+            name === 'Standard.Tree.Edit' &&
+            !actionClickEvent.defaultPrevented
+        ) {
             this.togglePopoverVisibility();
         }
     }

--- a/src/modules/base/tree/__docs__/data.js
+++ b/src/modules/base/tree/__docs__/data.js
@@ -1,22 +1,22 @@
 export const ACTIONS = [
     {
-        name: 'edit',
+        name: 'Standard.Tree.Edit',
         label: 'Edit',
         iconName: 'utility:edit',
         visible: true
     },
     {
-        name: 'add',
+        name: 'Standard.Tree.Add',
         label: 'Add',
         visible: true,
         iconName: 'utility:add'
     },
     {
-        name: 'duplicate',
+        name: 'Standard.Tree.Duplicate',
         label: 'Duplicate'
     },
     {
-        name: 'delete',
+        name: 'Standard.Tree.Delete',
         label: 'Delete'
     },
     {
@@ -27,13 +27,13 @@ export const ACTIONS = [
 
 export const ACTIONS_WHEN_DISABLED = [
     {
-        name: 'edit',
+        name: 'Standard.Tree.Edit',
         label: 'Edit',
         iconName: 'utility:edit',
         visible: true
     },
     {
-        name: 'delete',
+        name: 'Standard.Tree.Delete',
         label: 'Delete',
         iconName: 'utility:delete',
         visible: true

--- a/src/modules/base/tree/__docs__/tree.jsdoc.js
+++ b/src/modules/base/tree/__docs__/tree.jsdoc.js
@@ -2,10 +2,10 @@
  * @typedef {object} TreeAction
  * @name actions
  * @property {boolean} visible If true, the action is always visible. If false, the action will be displayed in a button menu. Defaults to false.
- * @property {string} iconName Required if <code>visible</code> is true. The Lightning Design System name of the action icon. Names are written in the format 'utility:down' where 'utility' is the category, and 'down' is the specific icon to be displayed.
- * @property {string} label Required. Label of the action. If <code>visible</code> is true, the label will be used as alternative text.
+ * @property {string} iconName Required if `visible` is true. The Lightning Design System name of the action icon. Names are written in the format 'utility:down' where 'utility' is the category, and 'down' is the specific icon to be displayed.
+ * @property {string} label Required. Label of the action. If `visible` is true, the label will be used as alternative text.
  * @property {string} name Required. Unique name of the action.
- * Reserved action names are: <code>edit</code>, <code>add</code>, <code>duplicate</code> and <code>delete</code>. If a reserved action name is used, the standard action will be executed on top of the dispatch of the <code>actionclick</code> event. To prevent the default behavior of a reserved action, <code>preventDefault()</code> can be called on the <code>actionclick</code> event.
+ * Reserved action names are: `Standard.Tree.Edit`, `Standard.Tree.Add`, `Standard.Tree.Duplicate` and `Standard.Tree.Delete`. If a reserved action name is used, the standard action will be executed on top of the dispatch of the `actionclick` event. To prevent the default behavior of a reserved action, `preventDefault()` can be called on the `actionclick` event.
  */
 
 /**
@@ -27,7 +27,7 @@
  * @property {string} label Required. Label of the item.
  * @property {string} metatext Text to provide users with supplemental information and aid with identifiation or diambiguation.
  * @property {object[]} items Nested item objects.
- * @property {string} name Required. The unique name of the item. It will be returned by the <code>onselect</code> event handler.
+ * @property {string} name Required. The unique name of the item. It will be returned by the `onselect` event handler.
  * @property {string} href If the item label should be a link, URL of the link.
  * Links are incompatible with inline edition and multi-select trees.
  * @property {boolean} expanded If true, the item branch is expanded. An expanded branch displays its nested items visually. Defaults to false.

--- a/src/modules/base/tree/__docs__/tree.stories.js
+++ b/src/modules/base/tree/__docs__/tree.stories.js
@@ -219,7 +219,7 @@ export const CustomEditableFields = Template.bind({});
 CustomEditableFields.args = {
     actions: [
         {
-            name: 'edit',
+            name: 'Standard.Tree.Edit',
             label: 'Edit Item'
         }
     ],

--- a/src/modules/base/tree/__examples__/actions/actions.js
+++ b/src/modules/base/tree/__examples__/actions/actions.js
@@ -3,23 +3,23 @@ import { LightningElement } from 'lwc';
 export default class TreeActions extends LightningElement {
     actions = [
         {
-            name: 'edit',
+            name: 'Standard.Tree.Edit',
             label: 'Edit',
             iconName: 'utility:edit',
             visible: true
         },
         {
-            name: 'add',
+            name: 'Standard.Tree.Add',
             label: 'Add',
             visible: true,
             iconName: 'utility:add'
         },
         {
-            name: 'duplicate',
+            name: 'Standard.Tree.Duplicate',
             label: 'Duplicate'
         },
         {
-            name: 'delete',
+            name: 'Standard.Tree.Delete',
             label: 'Delete'
         },
         {
@@ -30,13 +30,13 @@ export default class TreeActions extends LightningElement {
 
     actionswhenDisabled = [
         {
-            name: 'edit',
+            name: 'Standard.Tree.Edit',
             label: 'Edit',
             iconName: 'utility:edit',
             visible: true
         },
         {
-            name: 'delete',
+            name: 'Standard.Tree.Delete',
             label: 'Delete',
             iconName: 'utility:delete',
             visible: true

--- a/src/modules/base/tree/__examples__/customEditFields/customEditFields.js
+++ b/src/modules/base/tree/__examples__/customEditFields/customEditFields.js
@@ -3,7 +3,7 @@ import { LightningElement } from 'lwc';
 export default class TreeCustomEditableFields extends LightningElement {
     actions = [
         {
-            name: 'edit',
+            name: 'Standard.Tree.Edit',
             label: 'Edit Item'
         }
     ];

--- a/src/modules/base/tree/__examples__/multiSelect/multiSelect.js
+++ b/src/modules/base/tree/__examples__/multiSelect/multiSelect.js
@@ -3,23 +3,23 @@ import { LightningElement } from 'lwc';
 export default class TreeMultiSelect extends LightningElement {
     actions = [
         {
-            name: 'edit',
+            name: 'Standard.Tree.Edit',
             label: 'Edit',
             iconName: 'utility:edit',
             visible: true
         },
         {
-            name: 'add',
+            name: 'Standard.Tree.Add',
             label: 'Add',
             visible: true,
             iconName: 'utility:add'
         },
         {
-            name: 'duplicate',
+            name: 'Standard.Tree.Duplicate',
             label: 'Duplicate'
         },
         {
-            name: 'delete',
+            name: 'Standard.Tree.Delete',
             label: 'Delete'
         },
         {

--- a/src/modules/base/tree/__tests__/data.js
+++ b/src/modules/base/tree/__tests__/data.js
@@ -1,10 +1,10 @@
 export const ACTIONS = [
     {
-        name: 'edit',
+        name: 'Standard.Tree.Edit',
         label: 'Edit'
     },
     {
-        name: 'add',
+        name: 'Standard.Tree.Add',
         label: 'Add',
         iconName: 'utility:add',
         visible: true

--- a/src/modules/base/tree/__tests__/tree.test.js
+++ b/src/modules/base/tree/__tests__/tree.test.js
@@ -440,7 +440,7 @@ describe('Tree', () => {
             items[1].dispatchEvent(
                 new CustomEvent('privateactionclick', {
                     detail: {
-                        name: 'edit',
+                        name: 'Standard.Tree.Edit',
                         key: '2'
                     },
                     bubbles: true
@@ -449,7 +449,7 @@ describe('Tree', () => {
             items[2].dispatchEvent(
                 new CustomEvent('privateactionclick', {
                     detail: {
-                        name: 'add',
+                        name: 'Standard.Tree.Add',
                         key: '3'
                     },
                     bubbles: true
@@ -476,7 +476,7 @@ describe('Tree', () => {
             );
             const event = new CustomEvent('privateactionclick', {
                 detail: {
-                    name: 'add',
+                    name: 'Standard.Tree.Add',
                     key: '2'
                 },
                 bubbles: true
@@ -510,7 +510,9 @@ describe('Tree', () => {
             item.expanded = true;
 
             expect(handler).toHaveBeenCalledTimes(1);
-            expect(handler.mock.calls[0][0].detail.action).toBe('expand');
+            expect(handler.mock.calls[0][0].detail.action).toBe(
+                'Standard.Tree.Expand'
+            );
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([2]);
             expect(handler.mock.calls[0][0].detail.previousLevelPath).toEqual([
                 2
@@ -530,7 +532,9 @@ describe('Tree', () => {
 
             items[2].dispatchEvent(event);
             expect(handler).toHaveBeenCalledTimes(2);
-            expect(handler.mock.calls[1][0].detail.action).toBe('collapse');
+            expect(handler.mock.calls[1][0].detail.action).toBe(
+                'Standard.Tree.Collapse'
+            );
         });
     });
 
@@ -557,7 +561,9 @@ describe('Tree', () => {
             item.expanded = true;
 
             expect(handler).toHaveBeenCalledTimes(1);
-            expect(handler.mock.calls[0][0].detail.action).toBe('expand');
+            expect(handler.mock.calls[0][0].detail.action).toBe(
+                'Standard.Tree.Expand'
+            );
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([2]);
             expect(handler.mock.calls[0][0].detail.previousLevelPath).toEqual([
                 2
@@ -574,7 +580,9 @@ describe('Tree', () => {
             event.detail.keyCode = 37;
             items[2].dispatchEvent(event);
             expect(handler).toHaveBeenCalledTimes(2);
-            expect(handler.mock.calls[1][0].detail.action).toBe('collapse');
+            expect(handler.mock.calls[1][0].detail.action).toBe(
+                'Standard.Tree.Collapse'
+            );
         });
     });
 
@@ -590,7 +598,7 @@ describe('Tree', () => {
             );
             const event = new CustomEvent('privateactionclick', {
                 detail: {
-                    name: 'add',
+                    name: 'Standard.Tree.Add',
                     key: '4'
                 },
                 bubbles: true
@@ -605,7 +613,9 @@ describe('Tree', () => {
             ];
 
             expect(handler).toHaveBeenCalledTimes(1);
-            expect(handler.mock.calls[0][0].detail.action).toBe('add');
+            expect(handler.mock.calls[0][0].detail.action).toBe(
+                'Standard.Tree.Add'
+            );
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([3]);
             expect(handler.mock.calls[0][0].detail.previousLevelPath).toEqual([
                 3
@@ -635,7 +645,9 @@ describe('Tree', () => {
             button.click();
 
             expect(handler).toHaveBeenCalledTimes(1);
-            expect(handler.mock.calls[0][0].detail.action).toBe('add');
+            expect(handler.mock.calls[0][0].detail.action).toBe(
+                'Standard.Tree.Add'
+            );
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([
                 ITEMS.length - 1
             ]);
@@ -665,7 +677,7 @@ describe('Tree', () => {
             );
             const event = new CustomEvent('privateactionclick', {
                 detail: {
-                    name: 'delete',
+                    name: 'Standard.Tree.Delete',
                     key: '4'
                 },
                 bubbles: true
@@ -673,7 +685,9 @@ describe('Tree', () => {
             items[3].dispatchEvent(event);
 
             expect(handler).toHaveBeenCalledTimes(1);
-            expect(handler.mock.calls[0][0].detail.action).toBe('delete');
+            expect(handler.mock.calls[0][0].detail.action).toBe(
+                'Standard.Tree.Delete'
+            );
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([3]);
             expect(handler.mock.calls[0][0].detail.previousLevelPath).toEqual([
                 3
@@ -698,7 +712,7 @@ describe('Tree', () => {
             );
             const event = new CustomEvent('privateactionclick', {
                 detail: {
-                    name: 'duplicate',
+                    name: 'Standard.Tree.Duplicate',
                     key: '4'
                 },
                 bubbles: true
@@ -706,7 +720,9 @@ describe('Tree', () => {
             items[3].dispatchEvent(event);
 
             expect(handler).toHaveBeenCalledTimes(1);
-            expect(handler.mock.calls[0][0].detail.action).toBe('duplicate');
+            expect(handler.mock.calls[0][0].detail.action).toBe(
+                'Standard.Tree.Duplicate'
+            );
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([3]);
             expect(handler.mock.calls[0][0].detail.previousLevelPath).toEqual([
                 3
@@ -738,7 +754,7 @@ describe('Tree', () => {
             items[0].dispatchEvent(
                 new CustomEvent('privateactionclick', {
                     detail: {
-                        name: 'edit',
+                        name: 'Standard.Tree.Edit',
                         key: '1'
                     }
                 })
@@ -763,7 +779,9 @@ describe('Tree', () => {
             item.name = 'new name';
 
             expect(handler).toHaveBeenCalledTimes(1);
-            expect(handler.mock.calls[0][0].detail.action).toBe('edit');
+            expect(handler.mock.calls[0][0].detail.action).toBe(
+                'Standard.Tree.Edit'
+            );
             expect(handler.mock.calls[0][0].detail.levelPath).toEqual([0]);
             expect(handler.mock.calls[0][0].detail.previousLevelPath).toEqual([
                 0
@@ -817,7 +835,9 @@ describe('Tree', () => {
             jest.runAllTimers();
             expect(element.items[1].expanded).toBeFalsy();
             expect(handler).toHaveBeenCalledTimes(1);
-            expect(handler.mock.calls[0][0].detail.action).toBe('collapse');
+            expect(handler.mock.calls[0][0].detail.action).toBe(
+                'Standard.Tree.Collapse'
+            );
             expect(handler.mock.calls[0][0].detail.name).toBe(ITEMS[1].name);
             expect(
                 handler.mock.calls[0][0].detail.previousName
@@ -858,7 +878,9 @@ describe('Tree', () => {
                 })
             );
             expect(handler).toHaveBeenCalledTimes(2);
-            expect(handler.mock.calls[1][0].detail.action).toBe('move');
+            expect(handler.mock.calls[1][0].detail.action).toBe(
+                'Standard.Tree.Move'
+            );
             expect(handler.mock.calls[1][0].detail.previousLevelPath).toEqual([
                 1
             ]);
@@ -938,7 +960,9 @@ describe('Tree', () => {
                 })
             );
             expect(handler).toHaveBeenCalledTimes(2);
-            expect(handler.mock.calls[1][0].detail.action).toBe('move');
+            expect(handler.mock.calls[1][0].detail.action).toBe(
+                'Standard.Tree.Move'
+            );
             expect(handler.mock.calls[1][0].detail.previousLevelPath).toEqual([
                 1
             ]);
@@ -1011,7 +1035,9 @@ describe('Tree', () => {
             // The item is expanded
             jest.runAllTimers();
             expect(handler).toHaveBeenCalledTimes(2);
-            expect(handler.mock.calls[1][0].detail.action).toBe('expand');
+            expect(handler.mock.calls[1][0].detail.action).toBe(
+                'Standard.Tree.Expand'
+            );
             expect(handler.mock.calls[1][0].detail.name).toBe(ITEMS[2].name);
 
             tree.dispatchEvent(
@@ -1021,7 +1047,9 @@ describe('Tree', () => {
                 })
             );
             expect(handler).toHaveBeenCalledTimes(3);
-            expect(handler.mock.calls[2][0].detail.action).toBe('move');
+            expect(handler.mock.calls[2][0].detail.action).toBe(
+                'Standard.Tree.Move'
+            );
             expect(handler.mock.calls[2][0].detail.previousLevelPath).toEqual([
                 1
             ]);
@@ -1124,7 +1152,7 @@ describe('Tree', () => {
             );
             expect(handler).toHaveBeenCalledTimes(1);
             const detail = handler.mock.calls[0][0].detail;
-            expect(detail.action).toBe('move');
+            expect(detail.action).toBe('Standard.Tree.Move');
             expect(detail.levelPath).toEqual([2, 0, 3]);
             expect(detail.previousLevelPath).toEqual([3]);
             expect(detail.name).toBe(ITEMS[3].name);

--- a/src/modules/base/tree/tree.js
+++ b/src/modules/base/tree/tree.js
@@ -40,7 +40,12 @@ import {
     normalizeBoolean
 } from 'c/utilsPrivate';
 
-const DEFAULT_ACTION_NAMES = ['add', 'edit', 'delete', 'duplicate'];
+const DEFAULT_ACTION_NAMES = [
+    'Standard.Tree.Add',
+    'Standard.Tree.Edit',
+    'Standard.Tree.Delete',
+    'Standard.Tree.Duplicate'
+];
 const DEFAULT_EDITABLE_FIELDS = [
     'label',
     'metatext',
@@ -323,7 +328,7 @@ export default class Tree extends LightningElement {
     get addAction() {
         return (
             !this.isLoading &&
-            this.actions.find((action) => action.name === 'add')
+            this.actions.find((action) => action.name === 'Standard.Tree.Add')
         );
     }
 
@@ -485,7 +490,7 @@ export default class Tree extends LightningElement {
             this.treedata.updateVisibleTreeItemsOnCollapse(node.key);
             this.dispatchChange({
                 name: node.name,
-                action: 'collapse',
+                action: 'Standard.Tree.Collapse',
                 key: node.key
             });
         }
@@ -586,15 +591,15 @@ export default class Tree extends LightningElement {
         }
 
         switch (action) {
-            case 'add': {
+            case 'Standard.Tree.Add': {
                 this.addItem(key);
                 break;
             }
-            case 'edit': {
+            case 'Standard.Tree.Edit': {
                 this._editedItemKey = key;
                 return;
             }
-            case 'delete': {
+            case 'Standard.Tree.Delete': {
                 const prevItem = this.treedata.findPrevNodeToFocus(item.index);
                 if (prevItem && !this.isMultiSelect) {
                     this.singleSelect(prevItem.treeNode.name);
@@ -603,7 +608,7 @@ export default class Tree extends LightningElement {
                 items.splice(index, 1);
                 break;
             }
-            case 'duplicate': {
+            case 'Standard.Tree.Duplicate': {
                 previousName = item.treeNode.name;
                 const duplicatedItem = this.duplicateItem(key);
                 name = duplicatedItem.name;
@@ -629,7 +634,7 @@ export default class Tree extends LightningElement {
             node.nodeRef.expanded = true;
             this.dispatchChange({
                 name: node.name,
-                action: 'expand',
+                action: 'Standard.Tree.Expand',
                 key: node.key
             });
         }
@@ -961,7 +966,7 @@ export default class Tree extends LightningElement {
      */
     handleActionClick(event) {
         event.stopPropagation();
-        const action = event.detail.name || 'add';
+        const action = event.detail.name || 'Standard.Tree.Add';
         const key = event.detail.key;
         const levelPath = this.treedata.getLevelPath(
             key || this.items.length.toString()
@@ -1027,7 +1032,7 @@ export default class Tree extends LightningElement {
         this.initItems();
         this.dispatchChange({
             name: item.name,
-            action: 'edit',
+            action: 'Standard.Tree.Edit',
             previousName,
             key
         });
@@ -1277,7 +1282,7 @@ export default class Tree extends LightningElement {
             this.initItems();
             this.dispatchChange({
                 name: initialItem.name,
-                action: 'move',
+                action: 'Standard.Tree.Move',
                 key
             });
         }
@@ -1336,7 +1341,7 @@ export default class Tree extends LightningElement {
         );
 
         const previousLevelPath = levelPath;
-        if (action === 'move') {
+        if (action === 'Standard.Tree.Move') {
             const newItem = this.treedata.getItemFromName(name);
             levelPath = this.treedata.getLevelPath(newItem.key);
         }


### PR DESCRIPTION
### Breaking Changes
**Tree**
- Standardized the default action names, to follow the format `Standard.Tree.ActionName`. For example, `edit` has been renamed to `Standard.Tree.Edit`.
