### PR TITLE
[Fix](ABC-718): Carousel - Styling hook for active indicator not working

### DIFF
--- a/src/modules/base/carousel/carousel.css
+++ b/src/modules/base/carousel/carousel.css
@@ -111,11 +111,10 @@
     ) !important;
 }
 
-.avonni-carousel__progress-indicator_shaded-active:hover,
-.avonni-carousel__progress-indicator_shaded-active:focus {
+.avonni-carousel__progress-indicator_shaded-active:hover {
     --avonni-carousel-active-indicator-shaded-color-background: var(
         --avonni-carousel-active-indicator-shaded-color-background-hover,
-        #dddbda
+        red
     );
     --avonni-carousel-active-indicator-shaded-color-border: var(
         --avonni-carousel-active-indicator-shaded-color-border-hover,

--- a/src/modules/base/carousel/carousel.css
+++ b/src/modules/base/carousel/carousel.css
@@ -68,7 +68,7 @@
 }
 
 .avonni-carousel__progress-indicator_active:hover {
-    background: var(
+    --avonni-carousel-active-indicator-color-background: var(
         --avonni-carousel-active-indicator-color-background-hover,
         #0176d3
     );
@@ -90,11 +90,11 @@
 }
 
 .avonni-carousel__progress-indicator_inactive:hover {
-    background: var(
+    --avonni-carousel-inactive-indicator-color-background: var(
         --avonni-carousel-inactive-indicator-color-background-hover,
         #fafaf9
     );
-    border-color: var(
+    --avonni-carousel-inactive-indicator-color-border: var(
         --avonni-carousel-inactive-indicator-color-border-hover,
         #dddbda
     );
@@ -113,11 +113,11 @@
 
 .avonni-carousel__progress-indicator_shaded-active:hover,
 .avonni-carousel__progress-indicator_shaded-active:focus {
-    background-color: var(
+    --avonni-carousel-active-indicator-shaded-color-background: var(
         --avonni-carousel-active-indicator-shaded-color-background-hover,
         #dddbda
     );
-    border-color: var(
+    --avonni-carousel-active-indicator-shaded-color-border: var(
         --avonni-carousel-active-indicator-shaded-color-border-hover,
         #dddbda
     );
@@ -135,11 +135,11 @@
 }
 
 .avonni-carousel__progress-indicator_shaded-inactive:hover {
-    background-color: var(
+    --avonni-carousel-inactive-indicator-shaded-color-background: var(
         --avonni-carousel-inactive-indicator-shaded-color-background,
         #fafaf9
     );
-    border-color: var(
+    --avonni-carousel-inactive-indicator-shaded-color-border: var(
         --avonni-carousel-inactive-indicator-shaded-color-border,
         #dddbda
     );

--- a/src/modules/base/carousel/carousel.css
+++ b/src/modules/base/carousel/carousel.css
@@ -114,7 +114,7 @@
 .avonni-carousel__progress-indicator_shaded-active:hover {
     --avonni-carousel-active-indicator-shaded-color-background: var(
         --avonni-carousel-active-indicator-shaded-color-background-hover,
-        red
+        #dddbda
     );
     --avonni-carousel-active-indicator-shaded-color-border: var(
         --avonni-carousel-active-indicator-shaded-color-border-hover,


### PR DESCRIPTION
### Fixes
**Carousel**
- Fix issues with indicators styling hooks
