### PR TITLE
[feat](ABC-793): Carousel - currentPanel is chosen by name instead of index

### DIFF
--- a/src/modules/base/carousel/__docs__/carousel.stories.js
+++ b/src/modules/base/carousel/__docs__/carousel.stories.js
@@ -51,10 +51,10 @@ export default {
         currentPanel: {
             name: 'current-panel',
             control: {
-                type: 'number'
+                type: 'text'
             },
             description:
-                'Dictates the currently active/visible carousel panel.',
+                'Dictates the currently active/visible carousel panel. Use item’s name to select current panel.',
             table: {
                 type: { summary: 'number' }
             }

--- a/src/modules/base/carousel/__tests__/carousel.test.js
+++ b/src/modules/base/carousel/__tests__/carousel.test.js
@@ -336,18 +336,16 @@ describe('Carousel', () => {
 
     // current panel
     it('Carousel: current panel', () => {
-        element.currentPanel = 2;
+        element.currentPanel = '3';
         element.items = items;
 
-        return Promise.resolve()
-            .then(() => {})
-            .then(() => {
-                const panels = element.shadowRoot.querySelectorAll(
-                    '.avonni-carousel__panel'
-                );
-                const thirdPanel = panels[2];
-                expect(thirdPanel.ariaHidden).toBe('false');
-            });
+        return Promise.resolve().then(() => {
+            const panels = element.shadowRoot.querySelectorAll(
+                '.avonni-carousel__panel'
+            );
+            const thirdPanel = panels[2];
+            expect(thirdPanel.ariaHidden).toBe('false');
+        });
     });
 
     // hide indicator

--- a/src/modules/base/carousel/carousel.js
+++ b/src/modules/base/carousel/carousel.js
@@ -90,9 +90,9 @@ const i18n = {
  */
 export default class Carousel extends LightningElement {
     /**
-     * Dictates the currently active/visible carousel panel.
+     * Dictates the currently active/visible carousel panel. Use item’s name to select current panel.
      *
-     * @type {number}
+     * @type {string}
      * @public
      */
     @api currentPanel;
@@ -531,7 +531,10 @@ export default class Carousel extends LightningElement {
      * @param {number} numberOfPanels
      */
     initializeCurrentPanel(numberOfPanels) {
-        const firstPanel = parseInt(this.currentPanel, 10);
+        const currentPanelIndex = this.currentPanel
+            ? this.items.findIndex((item) => item.name === this.currentPanel)
+            : 0;
+        const firstPanel = parseInt(currentPanelIndex, 10);
         this.activeIndexPanel = firstPanel < numberOfPanels ? firstPanel : 0;
     }
 


### PR DESCRIPTION
### Features
**Carousel**
- current-panel is chosen by name of item instead of index
