### PR TITLE
[fix] (ABC-798): Ignore locale when adding time zone in input date range

### DIFF
--- a/src/modules/base/inputDateRange/inputDateRange.js
+++ b/src/modules/base/inputDateRange/inputDateRange.js
@@ -803,7 +803,7 @@ export default class InputDateRange extends LightningElement {
         let dateTime = date.replace(/T[^Z]+/, time);
         try {
             const formattedWithTimeZone = new Date(dateTime).toLocaleString(
-                'default',
+                'en-US',
                 {
                     timeZone: this.timezone,
                     timeZoneName: 'longOffset'


### PR DESCRIPTION
### Fixes
**Input Date Range**
- Fixed selected time zone not being properly added to the dates when the user's locale is not English.
