### PR TITLE
[fix] (ABC-800): Add checked key to activity timeline items

### DIFF
--- a/src/modules/base/activityTimeline/__docs__/activityTimeline.jsdoc.js
+++ b/src/modules/base/activityTimeline/__docs__/activityTimeline.jsdoc.js
@@ -12,6 +12,7 @@
  * @name items
  * @property {string} name Required. Unique name of the item.
  * @property {string} title Title of the item, displayed in the item header.
+ * @property {boolean} checked If true and `hasCheckbox` is true, the checkbox will be checked. Defaults to false.
  * @property {string} description Description of the item, displayed under the title.
  * @property {(Date|number|string)} datetimeValue Date/time value of the item. It can be a Date object, a timestamp, or an ISO8601 formatted string.
  * @property {string} href URL to use as a link for the title.

--- a/src/modules/base/activityTimeline/__docs__/data.js
+++ b/src/modules/base/activityTimeline/__docs__/data.js
@@ -149,6 +149,7 @@ export const items = [
         iconName: 'standard:dashboard',
         loadingStateAlternativeText: 'Is Loading',
         hasCheckbox: true,
+        checked: true,
         isLoading: true,
         buttonLabel: 'Public Sharing',
         buttonIconName: 'utility:world'
@@ -173,6 +174,7 @@ export const itemsWithoutIcons = [
         href: 'salesforce.com',
         icons: ['utility:refresh'],
         hasCheckbox: true,
+        checked: true,
         fields: [
             {
                 label: 'Name',
@@ -563,6 +565,7 @@ export const testItems = [
         iconName: 'standard:dashboard',
         loadingStateAlternativeText: 'Is Loading',
         hasCheckbox: true,
+        checked: true,
         isLoading: true,
         buttonLabel: 'Public Sharing',
         buttonIconName: 'utility:world'

--- a/src/modules/base/activityTimeline/__tests__/activityTimeline.test.js
+++ b/src/modules/base/activityTimeline/__tests__/activityTimeline.test.js
@@ -384,6 +384,8 @@ describe('Activity Timeline', () => {
                 href: '#',
                 datetimeValue: 1653141600000,
                 iconName: 'standard:log_a_call',
+                hasCheckbox: true,
+                checked: true,
                 fields: [
                     {
                         label: 'Name',
@@ -454,6 +456,7 @@ describe('Activity Timeline', () => {
 
             timelineItems.forEach((item, index) => {
                 expect(item.title).toBe(ITEM[index].title);
+                expect(item.checked).toBe(ITEM[index].checked || false);
                 expect(item.description).toBe(ITEM[index].description);
                 expect(item.datetimeValue).toBe(ITEM[index].datetimeValue);
                 expect(item.href).toBe(ITEM[index].href);
@@ -675,6 +678,7 @@ describe('Activity Timeline', () => {
                     bubbles: true
                 })
             );
+            expect(element.items[0].checked).toBeTruthy();
             expect(handler).toHaveBeenCalled();
             expect(handler.mock.calls[0][0].detail.checked).toBeTruthy();
             expect(handler.mock.calls[0][0].detail.targetName).toBe(

--- a/src/modules/base/activityTimeline/activityTimeline.js
+++ b/src/modules/base/activityTimeline/activityTimeline.js
@@ -36,6 +36,7 @@ import { HorizontalActivityTimeline } from './horizontalActivityTimeline';
 import horizontalTimeline from './horizontalActivityTimeline.html';
 import verticalTimeline from './verticalActivityTimeline.html';
 import {
+    deepCopy,
     normalizeBoolean,
     normalizeString,
     normalizeArray
@@ -436,7 +437,7 @@ export default class ActivityTimeline extends LightningElement {
     }
 
     set items(value) {
-        this._items = normalizeArray(value);
+        this._items = deepCopy(normalizeArray(value, 'object'));
         if (this._isConnected) {
             this.initActivityTimeline();
         }
@@ -897,6 +898,10 @@ export default class ActivityTimeline extends LightningElement {
     handleCheck(event) {
         event.stopPropagation();
         const { checked, name } = event.detail;
+        const item = this.items.find((it) => it.name === name);
+        if (item) {
+            item.checked = checked;
+        }
 
         /**
          * The event fired when an item is checked or unchecked.

--- a/src/modules/base/activityTimeline/verticalActivityTimeline.html
+++ b/src/modules/base/activityTimeline/verticalActivityTimeline.html
@@ -63,6 +63,7 @@
                     <li key={item.name}>
                         <c-primitive-activity-timeline-item
                             title={item.title}
+                            checked={item.checked}
                             description={item.description}
                             datetime-value={item.datetimeValue}
                             date-format={computedItemDateFormat}
@@ -113,6 +114,7 @@
                                 <li key={item.name}>
                                     <c-primitive-activity-timeline-item
                                         title={item.title}
+                                        checked={item.checked}
                                         description={item.description}
                                         datetime-value={item.datetimeValue}
                                         date-format={computedItemDateFormat}

--- a/src/modules/base/primitiveActivityTimelineItem/__tests__/primitiveActivityTimelineItem.test.js
+++ b/src/modules/base/primitiveActivityTimelineItem/__tests__/primitiveActivityTimelineItem.test.js
@@ -97,6 +97,7 @@ describe('Primitive Activity Timeline Item', () => {
         expect(element.buttonIconPosition).toBe('left');
         expect(element.buttonLabel).toBeUndefined();
         expect(element.buttonVariant).toBe('neutral');
+        expect(element.checked).toBeFalsy();
         expect(element.closed).toBeFalsy();
         expect(element.dateFormat).toBeUndefined();
         expect(element.datetimeValue).toBeUndefined();
@@ -381,6 +382,33 @@ describe('Primitive Activity Timeline Item', () => {
                 element.shadowRoot.querySelector('lightning-spinner');
             expect(spinner).toBeTruthy();
             expect(spinner.alternativeText).toBe('This is a loading text');
+        });
+    });
+
+    // checked
+    it('Activity timeline item: checked = false', () => {
+        element.fields = FIELDS;
+        element.hasCheckbox = true;
+        element.checked = false;
+
+        return Promise.resolve().then(() => {
+            const checkbox = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-input-checkbox"]'
+            );
+            expect(checkbox.checked).toBeFalsy();
+        });
+    });
+
+    it('Activity timeline item: checked = true', () => {
+        element.fields = FIELDS;
+        element.hasCheckbox = true;
+        element.checked = true;
+
+        return Promise.resolve().then(() => {
+            const checkbox = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-input-checkbox"]'
+            );
+            expect(checkbox.checked).toBeTruthy();
         });
     });
 

--- a/src/modules/base/primitiveActivityTimelineItem/primitiveActivityTimelineItem.html
+++ b/src/modules/base/primitiveActivityTimelineItem/primitiveActivityTimelineItem.html
@@ -89,6 +89,7 @@
                     >
                         <lightning-input
                             if:true={hasCheckbox}
+                            checked={checked}
                             type="checkbox"
                             label="checkbox"
                             variant="label-hidden"

--- a/src/modules/base/primitiveActivityTimelineItem/primitiveActivityTimelineItem.js
+++ b/src/modules/base/primitiveActivityTimelineItem/primitiveActivityTimelineItem.js
@@ -152,6 +152,7 @@ export default class PrimitiveActivityTimelineItem extends LightningElement {
     _buttonDisabled = false;
     _buttonIconPosition = BUTTON_ICON_POSITIONS.default;
     _buttonVariant = BUTTON_VARIANTS.default;
+    _checked = false;
     _closed = false;
     _dateFormat;
     _fields = [];
@@ -236,6 +237,21 @@ export default class PrimitiveActivityTimelineItem extends LightningElement {
             fallbackValue: BUTTON_VARIANTS.default,
             validValues: BUTTON_VARIANTS.valid
         });
+    }
+
+    /**
+     * If present and `has-checkbox` is true, the checkbox will be checked.
+     *
+     * @type {boolean}
+     * @public
+     * @default false
+     */
+    @api
+    get checked() {
+        return this._checked;
+    }
+    set checked(value) {
+        this._checked = normalizeBoolean(value);
     }
 
     /**
@@ -558,6 +574,7 @@ export default class PrimitiveActivityTimelineItem extends LightningElement {
      */
     handleCheck(event) {
         event.stopPropagation();
+        this._checked = event.detail.checked;
 
         /**
          * The check event returns the following parameters.
@@ -572,7 +589,7 @@ export default class PrimitiveActivityTimelineItem extends LightningElement {
         this.dispatchEvent(
             new CustomEvent('check', {
                 detail: {
-                    checked: event.detail.checked,
+                    checked: this.checked,
                     name: this.name
                 },
                 bubbles: true


### PR DESCRIPTION
### Fixes
**Activity Timeline**
- Added a `checked` key to the items, to allow for pre-checked items.