### PR TITLE
[fix] (abc-539): Check if list can be sorted

### DIFF
--- a/src/modules/base/list/__tests__/list.test.js
+++ b/src/modules/base/list/__tests__/list.test.js
@@ -563,11 +563,13 @@ describe('List', () => {
         return Promise.resolve().then(() => {
             const bodyColor = element.shadowRoot.querySelector(
                 '[data-element-id="avonni-list-item-body-text-color"]'
-            )
+            );
 
-            expect(bodyColor.classList).toContain('avonni-list__item-text-color_inverse')
-        })
-    })
+            expect(bodyColor.classList).toContain(
+                'avonni-list__item-text-color_inverse'
+            );
+        });
+    });
 
     /* ----- METHOD ----- */
 
@@ -735,40 +737,37 @@ describe('List', () => {
 
     it('List: Media-Action, Actionclick event, multiple actions', () => {
         const handler = jest.fn();
-        element.addEventListener('actionclick', handler);
+        element.addEventListener('mediaactionclick', handler);
         element.items = ITEMS;
         element.mediaActions = ACTIONS;
 
-        return Promise.resolve()
-            .then(() => {
-                const actionMenu = element.shadowRoot.querySelector(
-                    '[data-element-id="media-action-menu"]'
-                );
-                actionMenu.dispatchEvent(
-                    new CustomEvent('select', {
-                        detail: {
-                            value: ACTIONS[0].name
-                        }
-                    })
-                );
-                expect(handler).toHaveBeenCalled();
-                expect(handler.mock.calls[0][0].detail.item).toMatchObject(
-                    ITEMS[0]
-                );
-                expect(handler.mock.calls[0][0].detail.name).toBe(
-                    ACTION[0].name
-                );
-                expect(handler.mock.calls[0][0].detail.targetName).toBe(
-                    ITEMS[0].name
-                );
-                expect(handler.mock.calls[0][0].bubbles).toBeFalsy();
-                expect(handler.mock.calls[0][0].cancelable).toBeFalsy();
-                expect(handler.mock.calls[0][0].composed).toBeFalsy();
-            });
+        return Promise.resolve().then(() => {
+            const actionMenu = element.shadowRoot.querySelector(
+                '[data-element-id="media-action-menu"]'
+            );
+            actionMenu.dispatchEvent(
+                new CustomEvent('select', {
+                    detail: {
+                        value: ACTIONS[0].name
+                    }
+                })
+            );
+            expect(handler).toHaveBeenCalled();
+            expect(handler.mock.calls[0][0].detail.item).toMatchObject(
+                ITEMS[0]
+            );
+            expect(handler.mock.calls[0][0].detail.name).toBe(ACTION[0].name);
+            expect(handler.mock.calls[0][0].detail.targetName).toBe(
+                ITEMS[0].name
+            );
+            expect(handler.mock.calls[0][0].bubbles).toBeFalsy();
+            expect(handler.mock.calls[0][0].cancelable).toBeFalsy();
+            expect(handler.mock.calls[0][0].composed).toBeFalsy();
+        });
     });
     it('List: Media-Action Actionclick event, one action', () => {
         const handler = jest.fn();
-        element.addEventListener('actionclick', handler);
+        element.addEventListener('mediaactionclick', handler);
         element.items = ITEMS;
         element.mediaActions = ACTION;
 
@@ -794,7 +793,7 @@ describe('List', () => {
 
     it('List: Media-Action, Actionclick event, one icon action', () => {
         const handler = jest.fn();
-        element.addEventListener('actionclick', handler);
+        element.addEventListener('mediaactionclick', handler);
         element.items = ITEMS;
         element.mediaActions = ACTION_NO_LABEL;
 

--- a/src/modules/base/list/list.html
+++ b/src/modules/base/list/list.html
@@ -251,8 +251,8 @@
                                         initials={item.avatar.initials}
                                         onmousedown={handleAvatarDragStart}
                                         variant={item.avatar.variant}
-                                        presence={item.presence}
-                                        presence-position={item.presencePosition}
+                                        presence={item.avatar.presence}
+                                        presence-position={item.avatar.presencePosition}
                                         hide-avatar-details="true"
                                         data-element-id="avonni-avatar"
                                     ></c-avatar>

--- a/src/modules/base/list/list.js
+++ b/src/modules/base/list/list.js
@@ -800,7 +800,8 @@ export default class List extends LightningElement {
         )
             .add({
                 'slds-grid_vertical': this._currentColumnCount === 1,
-                'slds-wrap': this._currentColumnCount > 1,
+                'slds-wrap':
+                    this._currentColumnCount > 1 && this.variant === 'base',
                 'avonni-list__items-without-divider': this.divider === '',
                 'avonni-list__has-card-style': this.divider === 'around',
                 'slds-has-dividers_top-space avonni-list__items-have-top-divider':
@@ -834,7 +835,9 @@ export default class List extends LightningElement {
         return classSet('avonni-list__item-wrapper avonni-list__item')
             .add({
                 'avonni-list__item-sortable':
-                    this.sortable && this._currentColumnCount === 1,
+                    this.sortable &&
+                    this._currentColumnCount === 1 &&
+                    this.variant === 'base',
                 'avonni-list__item-divider_top': this.divider === 'top',
                 'avonni-list__item-divider_bottom': this.divider === 'bottom',
                 'slds-col slds-size_12-of-12': this._currentColumnCount === 1,
@@ -851,8 +854,10 @@ export default class List extends LightningElement {
      * Only enable scrolling if enable or has been used
      */
     get computedListContainerClass() {
-        return classSet('slds-grid slds-col')
-            .add({'slds-scrollable_y': this._hasUsedInfiniteLoading})
+        return classSet('slds-grid slds-col').add({
+            'slds-scrollable_y':
+                this._hasUsedInfiniteLoading && this.variant === 'base'
+        });
     }
 
     /*
@@ -1581,9 +1586,6 @@ export default class List extends LightningElement {
      * @param {Event} event
      */
     dragStart(event) {
-        if (this._currentColumnCount > 1) {
-            return;
-        }
         if (event.button === 0) {
             const index = Number(event.currentTarget.dataset.index);
             const item = this.computedItems[index];
@@ -1614,13 +1616,9 @@ export default class List extends LightningElement {
             return;
         }
 
-        if (this._keyboardDragged) {
-            this._keyboardDragged = false;
-            return;
-        }
-
         // Stop dragging if the click was on a button menu
         if (
+            (this._currentColumnCount > 1 && this.variant !== 'base') ||
             !this.sortable ||
             event.target.tagName.startsWith('LIGHTNING-BUTTON') ||
             event.target.tagName.startsWith('A')
@@ -1663,11 +1661,7 @@ export default class List extends LightningElement {
      * @param {Event} event
      */
     drag(event) {
-        if (
-            !this._draggedElement ||
-            this._keyboardDragged ||
-            this._keyboardDragged
-        ) {
+        if (!this._draggedElement || this._keyboardDragged) {
             return;
         }
 
@@ -1695,7 +1689,6 @@ export default class List extends LightningElement {
             currentY = mouseY;
         }
         this._currentY = currentY;
-        this._currentY = currentY;
 
         if (!this._scrollStep) {
             // Stick the dragged item to the mouse position
@@ -1708,9 +1701,6 @@ export default class List extends LightningElement {
         if (buttonMenu) {
             buttonMenu.classList.remove('slds-is-open');
         }
-
-        this.stopPropagation(event);
-        this.autoScroll(this._currentY);
 
         this.stopPropagation(event);
         this.autoScroll(this._currentY);
@@ -1869,9 +1859,6 @@ export default class List extends LightningElement {
      * @param {Event} event
      */
     handleKeyDown(event) {
-        if (this._currentColumnCount > 1) {
-            return;
-        }
         // If space bar is pressed, select or drop the item
         if (event.key === 'Enter') {
             this.handleItemClick(event);
@@ -1897,11 +1884,17 @@ export default class List extends LightningElement {
             let targetIndex;
 
             if (
+                this._currentColumnCount === 1 &&
+                this.variant === 'base' &&
                 event.key === 'ArrowDown' &&
                 index + 1 < this.computedItems.length
             ) {
                 targetIndex = index + 1;
-            } else if (event.key === 'ArrowUp') {
+            } else if (
+                this._currentColumnCount === 1 &&
+                this.variant === 'base' &&
+                event.key === 'ArrowUp'
+            ) {
                 targetIndex = index - 1;
             }
 

--- a/src/modules/base/list/list.js
+++ b/src/modules/base/list/list.js
@@ -1792,7 +1792,7 @@ export default class List extends LightningElement {
     }
 
     /**
-     * Handles a click on an item action.
+     * Handles a click on an item's action.
      *
      * @param {Event} event
      */
@@ -1801,29 +1801,6 @@ export default class List extends LightningElement {
             ? event.detail.value
             : event.target.value;
         const itemIndex = event.currentTarget.dataset.itemIndex;
-        this.dispatchActionClickEvent(itemIndex, actionName);
-    }
-
-    /**
-     * Handles a click on an item media-action.
-     *
-     * @param {Event} event
-     */
-    handleMediaActionClick(event) {
-        const actionName = this.hasMultipleMediaActions
-            ? event.detail.value
-            : event.target.value;
-        const itemIndex = event.currentTarget.dataset.itemIndex;
-        this.dispatchActionClickEvent(itemIndex, actionName);
-    }
-
-    /**
-     * Dispatch the custom event triggered when actions and media-actions are clicked.
-     *
-     * @param {string} itemIndex
-     * @param {string} actionName
-     */
-    dispatchActionClickEvent(itemIndex, actionName) {
         /**
          * The event fired when a user clicks on an action.
          *
@@ -1836,6 +1813,38 @@ export default class List extends LightningElement {
          */
         this.dispatchEvent(
             new CustomEvent('actionclick', {
+                detail: {
+                    name: actionName,
+                    item: this.cleanUpItem(this.computedItems[itemIndex]),
+                    targetName: this.computedItems[itemIndex].name
+                }
+            })
+        );
+    }
+
+    /**
+     * Handles a click on an item's media action.
+     *
+     * @param {Event} event
+     */
+    handleMediaActionClick(event) {
+        const actionName = this.hasMultipleMediaActions
+            ? event.detail.value
+            : event.target.value;
+        const itemIndex = event.currentTarget.dataset.itemIndex;
+
+        /**
+         * The event fired when a user clicks on a media action.
+         *
+         * @event
+         * @name mediaactionclick
+         * @param {string} name  Name of the media action clicked.
+         * @param {object} item Item clicked.
+         * @param {string} targetName Name of the item.
+         * @public
+         */
+        this.dispatchEvent(
+            new CustomEvent('mediaactionclick', {
                 detail: {
                     name: actionName,
                     item: this.cleanUpItem(this.computedItems[itemIndex]),

--- a/src/modules/base/list/list.js
+++ b/src/modules/base/list/list.js
@@ -1618,7 +1618,8 @@ export default class List extends LightningElement {
 
         // Stop dragging if the click was on a button menu
         if (
-            (this._currentColumnCount > 1 && this.variant !== 'base') ||
+            this._currentColumnCount > 1 ||
+            this.variant !== 'base' ||
             !this.sortable ||
             event.target.tagName.startsWith('LIGHTNING-BUTTON') ||
             event.target.tagName.startsWith('A')


### PR DESCRIPTION
Make sure keyboard events are sent event if there is more than one column and list is not sortable.
Make overflow visible on single-line.
Delete repeating lines.
