### PR TITLE
[fix] (ABC-816): Speed up the color palette in salesforce

### DIFF
--- a/src/modules/base/colorPalette/colorPalette.js
+++ b/src/modules/base/colorPalette/colorPalette.js
@@ -381,15 +381,13 @@ export default class ColorPalette extends LightningElement {
             colors: []
         };
 
-        // Create an object with one key per group name used by a color
-        for (let i = 0; i < this.colors.length; i++) {
-            let color = this.colors[i];
+        this.colors.forEach((color) => {
+            let hasBeenAddedToAGroup = false;
 
             if (color instanceof Object) {
                 const colorGroups = normalizeArray(color.groups);
 
                 if (this.groups.length && colorGroups.length) {
-                    let hasBeenAddedToAGroup = false;
                     colorGroups.forEach((groupName) => {
                         // Make sure the group exists
                         const groupDefinition = this.groups.find(
@@ -409,16 +407,16 @@ export default class ColorPalette extends LightningElement {
                             hasBeenAddedToAGroup = true;
                         }
                     });
-                    if (hasBeenAddedToAGroup) continue;
                 }
             } else {
                 color = {
                     color: color
                 };
             }
-
-            undefinedGroup.colors.push(color);
-        }
+            if (!hasBeenAddedToAGroup) {
+                undefinedGroup.colors.push(color);
+            }
+        });
 
         // Create the computed groups, in the order of the groups array
         const computedGroups = [];

--- a/src/modules/base/colorPalette/colorPalette.js
+++ b/src/modules/base/colorPalette/colorPalette.js
@@ -35,8 +35,7 @@ import {
     normalizeArray,
     normalizeBoolean,
     normalizeString,
-    generateColors,
-    deepCopy
+    generateColors
 } from 'c/utilsPrivate';
 import { generateUUID } from 'c/utils';
 import grid from './grid.html';
@@ -136,7 +135,7 @@ export default class ColorPalette extends LightningElement {
         return this._colors;
     }
     set colors(value) {
-        const colors = deepCopy(normalizeArray(value));
+        const colors = normalizeArray(value);
         this._colors = colors.length ? colors : DEFAULT_COLORS;
 
         if (this._isConnected) this.initGroups();

--- a/src/modules/base/colorPalette/grid.html
+++ b/src/modules/base/colorPalette/grid.html
@@ -39,6 +39,7 @@
     >
         <lightning-spinner
             if:true={isLoading}
+            alternative-text="Loading..."
             size="small"
             data-element-id="lightning-spinner"
         ></lightning-spinner>

--- a/src/modules/base/colorPalette/list.html
+++ b/src/modules/base/colorPalette/list.html
@@ -35,6 +35,7 @@
 <template>
     <lightning-spinner
         if:true={isLoading}
+        alternative-text="Loading..."
         size="small"
         data-element-id="lightning-spinner"
     ></lightning-spinner>

--- a/src/modules/base/colorPicker/__tests__/colorPicker.test.js
+++ b/src/modules/base/colorPicker/__tests__/colorPicker.test.js
@@ -1412,6 +1412,7 @@ describe('Color Picker', () => {
     it('Color Picker: change event in the dropdown', () => {
         const handler = jest.fn();
         element.addEventListener('change', handler);
+        jest.useFakeTimers();
 
         const color = {
             hex: '#014486',
@@ -1429,9 +1430,18 @@ describe('Color Picker', () => {
 
         return Promise.resolve()
             .then(() => {
+                // The palette is loading when we open the popover
                 const palette = element.shadowRoot.querySelector(
                     '[data-element-id="avonni-color-palette"]'
                 );
+                expect(palette.isLoading).toBeTruthy();
+                jest.runAllTimers();
+            })
+            .then(() => {
+                const palette = element.shadowRoot.querySelector(
+                    '[data-element-id="avonni-color-palette"]'
+                );
+                expect(palette.isLoading).toBeFalsy();
                 palette.dispatchEvent(
                     new CustomEvent('change', {
                         detail: color,

--- a/src/modules/base/colorPicker/colorPicker.html
+++ b/src/modules/base/colorPicker/colorPicker.html
@@ -213,6 +213,7 @@
                                             colors={computedColors}
                                             columns={columns}
                                             groups={groups}
+                                            is-loading={paletteIsLoading}
                                             read-only={readOnly}
                                             variant={colorPaletteVariant}
                                             data-element-id="avonni-color-palette"

--- a/src/modules/base/colorPicker/colorPicker.js
+++ b/src/modules/base/colorPicker/colorPicker.js
@@ -203,6 +203,7 @@ export default class ColorPicker extends LightningElement {
     dropdownVisible = false;
     helpMessage;
     newValue;
+    paletteIsLoading = false;
     showError = false;
     tabPressed = false;
     shiftPressed = false;
@@ -1177,6 +1178,7 @@ export default class ColorPicker extends LightningElement {
             if (this.dropdownVisible) {
                 this._boundingRect = this.getBoundingClientRect();
                 this.pollBoundingRect();
+                this.loadPalette();
             }
 
             this.template
@@ -1192,6 +1194,16 @@ export default class ColorPicker extends LightningElement {
      */
     isAutoAlignment() {
         return this.menuAlignment.startsWith('auto');
+    }
+
+    /**
+     * Show a loading spinner while the palette is generated.
+     */
+    loadPalette() {
+        this.paletteIsLoading = true;
+        setTimeout(() => {
+            this.paletteIsLoading = false;
+        }, 0);
     }
 
     /**
@@ -1237,7 +1249,10 @@ export default class ColorPicker extends LightningElement {
         const palette = this.template.querySelector(
             '[data-element-id="avonni-color-palette-default"]'
         );
-        if (palette) palette.colors = [...this.computedColors];
+        if (palette) {
+            palette.colors = [...this.computedColors];
+        }
+        this.loadPalette();
     }
 
     /**


### PR DESCRIPTION
### Features
**Color picker**
- Added a loading spinner if the color palette is loading when the dropdown is opened.

### Fixes
**Color palette**
- Improved performance on first load.