### PR TITLE
[fix] (abc-762): Fix avatar icon size and border radius hook

### DIFF
--- a/src/modules/base/avatar/__docs__/avatar.jsdoc.js
+++ b/src/modules/base/avatar/__docs__/avatar.jsdoc.js
@@ -247,7 +247,7 @@
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-avatar-status-unknwon-color-background
+ * @name --avonni-avatar-status-unknown-color-background
  * @default #706e6b
  * @type color
  */

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.css
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.css
@@ -67,13 +67,6 @@
     width: 56px;
     height: 56px;
 }
-/* Lightning-icon does not support x-large and xx-large */
-.avonni-avatar_x-large .avonni-avatar__icon {
-    scale: 1.8;
-}
-.avonni-avatar_xx-large .avonni-avatar__icon  {
-    scale: 2.2;
-}
 .avonni-avatar_xx-large .slds-avatar {
     font-size: 1.5rem;
     width: 72px;
@@ -93,6 +86,17 @@
 :host(.slds-avatar-grouped) .slds-avatar {
     width: 100%;
     height: 100%;
+}
+/* Fix icon size for x-large and xx-large icons */
+:host(.slds-avatar-grouped) .avonni-avatar_x-large .avonni-avatar__icon, 
+:host(.slds-avatar-grouped) .avonni-avatar_xx-large .avonni-avatar__icon {
+    scale: 1;
+}
+.avonni-avatar_x-large .avonni-avatar__icon {
+    scale: 1.8;
+}
+.avonni-avatar_xx-large .avonni-avatar__icon  {
+    scale: 2.2;
 }
 /**
 * Positioning

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.css
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.css
@@ -38,7 +38,7 @@
     border-style: var(--avonni-avatar-styling-border, solid);
     border-color: var(--avonni-avatar-color-border, transparent);
     border-width: var(--avonni-avatar-sizing-border, 0);
-    --sds-c-avatar-radius-border: var(--avonni-avatar-sizing-border-radius);
+    --sds-c-avatar-radius-border: var(--avonni-avatar-radius-border, 0.25rem);
 }
 /* If the avatar is in a group, the cursor changes for a pointer */
 :host(.avonni-avatar-group__avatar) .slds-avatar,
@@ -66,6 +66,12 @@
     font-size: 1.25rem;
     width: 56px;
     height: 56px;
+}
+.avonni-avatar_x-large .avonni-avatar__icon {
+    scale: 1.1;
+}
+.avonni-avatar_xx-large .avonni-avatar__icon  {
+    scale: 1.2;
 }
 .avonni-avatar_xx-large .slds-avatar {
     font-size: 1.5rem;

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.css
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.css
@@ -67,11 +67,12 @@
     width: 56px;
     height: 56px;
 }
+/* Lightning-icon does not support x-large and xx-large */
 .avonni-avatar_x-large .avonni-avatar__icon {
-    scale: 1.1;
+    scale: 1.8;
 }
 .avonni-avatar_xx-large .avonni-avatar__icon  {
-    scale: 1.2;
+    scale: 2.2;
 }
 .avonni-avatar_xx-large .slds-avatar {
     font-size: 1.5rem;
@@ -94,7 +95,7 @@
     height: 100%;
 }
 /**
-* Positionning
+* Positioning
 */
 .avonni-avatar_square .avonni-avatar_top-right {
     top: -4px;

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.html
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.html
@@ -56,7 +56,7 @@
             <!-- Fallback icon -->
             <lightning-icon
                 class={fallbackIconClass}
-                size={iconSize}
+                size={size}
                 if:true={showIcon}
                 icon-name={fallbackIconName}
                 alternative-text={alternativeText}

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.html
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.html
@@ -56,7 +56,7 @@
             <!-- Fallback icon -->
             <lightning-icon
                 class={fallbackIconClass}
-                size={size}
+                size={iconSize}
                 if:true={showIcon}
                 icon-name={fallbackIconName}
                 alternative-text={alternativeText}

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.js
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.js
@@ -406,14 +406,6 @@ export default class PrimitiveAvatar extends LightningElement {
         return Array.from(this.classList).includes('slds-avatar-grouped');
     }
 
-    get iconSize() {
-        let iconSize = this.size;
-        if (this.size === 'x-large' || this.size === 'xx-large') {
-            iconSize = 'large'
-        }
-        return iconSize
-    }
-    
     get showActions() {
         const { size, actions } = this;
         let _showAction = true;

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.js
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.js
@@ -359,6 +359,19 @@ export default class PrimitiveAvatar extends LightningElement {
      * -------------------------------------------------------------
      */
 
+    get actionMenuSize() {
+        switch (this.size) {
+            case 'x-large':
+                return 'x-small';
+            case 'large':
+                return 'xx-small';
+            case 'medium':
+                return 'xx-small';
+            default:
+                return 'small';
+        }
+    }
+
     get computedInitialsClass() {
         return classSet(
             'slds-avatar__initials avonni-avatar__initials_text-color'
@@ -376,6 +389,31 @@ export default class PrimitiveAvatar extends LightningElement {
         );
     }
 
+    get computedEntityInitialsClass() {
+        return classSet('slds-avatar__initials')
+            .add(computeSldsClass(this.entityIconName))
+            .toString();
+    }
+
+    get computedActionMenuIcon() {
+        if (this.actions.length === 1 && this.actions[0].iconName) {
+            return this.actions[0].iconName;
+        }
+        return this.actionMenuIcon;
+    }
+
+    get groupedAvatar() {
+        return Array.from(this.classList).includes('slds-avatar-grouped');
+    }
+
+    get iconSize() {
+        let iconSize = this.size;
+        if (this.size === 'x-large' || this.size === 'xx-large') {
+            iconSize = 'large'
+        }
+        return iconSize
+    }
+    
     get showActions() {
         const { size, actions } = this;
         let _showAction = true;
@@ -388,23 +426,6 @@ export default class PrimitiveAvatar extends LightningElement {
             _showAction = false;
         }
         return _showAction;
-    }
-
-    get actionMenuSize() {
-        switch (this.size) {
-            case 'x-large':
-                return 'x-small';
-            case 'large':
-                return 'xx-small';
-            case 'medium':
-                return 'xx-small';
-            default:
-                return 'small';
-        }
-    }
-
-    get groupedAvatar() {
-        return Array.from(this.classList).includes('slds-avatar-grouped');
     }
 
     get showAvatar() {
@@ -425,19 +446,6 @@ export default class PrimitiveAvatar extends LightningElement {
 
     get showEntity() {
         return this.entitySrc || this.entityInitials || this.entityIconName;
-    }
-
-    get computedEntityInitialsClass() {
-        return classSet('slds-avatar__initials')
-            .add(computeSldsClass(this.entityIconName))
-            .toString();
-    }
-
-    get computedActionMenuIcon() {
-        if (this.actions.length === 1 && this.actions[0].iconName) {
-            return this.actions[0].iconName;
-        }
-        return this.actionMenuIcon;
     }
 
     _updateClassList() {


### PR DESCRIPTION
### Fixes
** Avatar + Avatar group
- Fixed the size of the fallback icon for x-large and xx-large sizes.
- Fixed the `--avonni-avatar-radius-border` styling hook.

Correction to doc, --avonni-avatar-status-unknown-color-background had a typo. 