### PR TITLE
[feat] (ABC-821): Update combobox styling hooks to follow convention

### DIFF
--- a/src/modules/base/combobox/__docs__/combobox.jsdoc.js
+++ b/src/modules/base/combobox/__docs__/combobox.jsdoc.js
@@ -99,25 +99,7 @@
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-combobox-input-radius-border-bottom-left
- * @default 0.25rem
- * @type dimension
- */
-/**
- * @memberof stylingHooks
- * @name --avonni-combobox-input-radius-border-bottom-right
- * @default 0.25rem
- * @type dimension
- */
-/**
- * @memberof stylingHooks
- * @name --avonni-combobox-input-radius-border-top-left
- * @default 0.25rem
- * @type dimension
- */
-/**
- * @memberof stylingHooks
- * @name --avonni-combobox-input-radius-border-top-right
+ * @name --avonni-combobox-input-radius-border
  * @default 0.25rem
  * @type dimension
  */
@@ -125,29 +107,11 @@
  * @memberof stylingHooks
  * @name --avonni-combobox-input-styling-border
  * @default solid
- * @type styling
+ * @type string
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-combobox-input-sizing-border-bottom
+ * @name --avonni-combobox-input-sizing-border
  * @default 1px
- * @type sizing
- */
-/**
- * @memberof stylingHooks
- * @name --avonni-combobox-input-sizing-border-left
- * @default 1px
- * @type sizing
- */
-/**
- * @memberof stylingHooks
- * @name --avonni-combobox-input-sizing-border-right
- * @default 1px
- * @type sizing
- */
-/**
- * @memberof stylingHooks
- * @name --avonni-combobox-input-sizing-border-top
- * @default 1px
- * @type sizing
+ * @type dimension
  */

--- a/src/modules/base/combobox/combobox.css
+++ b/src/modules/base/combobox/combobox.css
@@ -1,13 +1,3 @@
-.avonni-combobox__main-combobox:not(.avonni-combobox__main-combobox_no-scopes) {
-    --avonni-combobox-input-radius-border-top-left: 0;
-    --avonni-combobox-input-radius-border-bottom-left: 0;
-}
-
-.avonni-combobox__scopes {
-    --avonni-combobox-input-radius-border-bottom-right: 0;
-    --avonni-combobox-input-radius-border-top-right: 0;
-}
-
 .avonni-combobox__label {
     color: var(--avonni-combobox-label-text-color, #3e3e3c);
     font-size: var(--avonni-combobox-label-font-size, 0.75rem);

--- a/src/modules/base/combobox/combobox.js
+++ b/src/modules/base/combobox/combobox.js
@@ -643,12 +643,10 @@ export default class Combobox extends LightningElement {
      * @type {string}
      */
     get computedMainComboboxClass() {
-        return classSet('avonni-combobox__main-combobox')
-            .add({
-                'slds-combobox-addon_end slds-col': this.showScopes,
-                'avonni-combobox__main-combobox_no-scopes': !this.showScopes
-            })
-            .toString();
+        return classSet({
+            'slds-combobox-addon_end slds-col avonni-combobox__main-combobox_scopes':
+                this.showScopes
+        }).toString();
     }
 
     /**

--- a/src/modules/base/primitiveCombobox/primitiveCombobox.css
+++ b/src/modules/base/primitiveCombobox/primitiveCombobox.css
@@ -41,26 +41,20 @@
 input.avonni-primitive-combobox__input {
     border-color: var(--avonni-combobox-input-color-border, #dddbda);
     border-style: var(--avonni-combobox-input-styling-border, solid);
-    border-top-right-radius: var(
-        --avonni-combobox-input-radius-border-top-right,
-        0.25rem
-    );
-    border-top-left-radius: var(
-        --avonni-combobox-input-radius-border-top-left,
-        0.25rem
-    );
-    border-bottom-right-radius: var(
-        --avonni-combobox-input-radius-border-bottom-right,
-        0.25rem
-    );
-    border-bottom-left-radius: var(
-        --avonni-combobox-input-radius-border-bottom-left,
-        0.25rem
-    );
-    border-top-width: var(--avonni-combobox-input-sizing-border-top, 1px);
-    border-bottom-width: var(--avonni-combobox-input-sizing-border-bottom, 1px);
-    border-right-width: var(--avonni-combobox-input-sizing-border-right, 1px);
-    border-left-width: var(--avonni-combobox-input-sizing-border-left, 1px);
+    border-radius: var(--avonni-combobox-input-radius-border, 0.25rem);
+    border-width: var(--avonni-combobox-input-sizing-border, 1px);
+}
+
+:host.avonni-combobox__scopes input.avonni-primitive-combobox__input {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right-width: 0;
+}
+
+:host.avonni-combobox__main-combobox_scopes
+    input.avonni-primitive-combobox__input {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
 }
 
 .avonni-primitive-combobox__action,


### PR DESCRIPTION
### Breaking Changes

**Combobox**
- Merged border and border-radius styling hooks into two shorthands.
  - Removed: `--avonni-combobox-input-radius-border-bottom-left`, `--avonni-combobox-input-radius-border-bottom-right`, `--avonni-combobox-input-radius-border-top-left`, `--avonni-combobox-input-radius-border-top-right``--avonni-combobox-input-sizing-border-bottom`, `--avonni-combobox-input-sizing-border-top`, `--avonni-combobox-input-sizing-border-left` and `--avonni-combobox-input-sizing-border-right`.
  - Added: `--avonni-combobox-input-radius-border` and `--avonni-combobox-input-sizing-border`.

