### PR TITLE
[fix] (ABC-822): Remove event.target in pill container

### DIFF
--- a/src/modules/base/pillContainer/pillContainer.html
+++ b/src/modules/base/pillContainer/pillContainer.html
@@ -68,8 +68,6 @@
             aria-orientation="horizontal"
             tabindex={listboxTabIndex}
             data-element-id="ul"
-            onactionclick={handleActionClick}
-            onclick={handlePillClick}
             onfocusin={handlePillFocus}
             onfocusout={handlePillBlur}
             onkeydown={handleKeyDown}
@@ -81,6 +79,7 @@
                     role="presentation"
                     data-element-id="li"
                     data-index={index}
+                    onclick={handlePillClick}
                     onmousemove={handlePillMouseMove}
                     onmousedown={handlePillMouseDown}
                 >
@@ -95,6 +94,7 @@
                         tabindex="-1"
                         data-element-id="avonni-primitive-pill"
                         data-index={index}
+                        onactionclick={handleActionClick}
                     ></c-primitive-pill>
                 </li>
             </template>

--- a/src/modules/base/pillContainer/pillContainer.js
+++ b/src/modules/base/pillContainer/pillContainer.js
@@ -570,7 +570,7 @@ export default class PillContainer extends LightningElement {
             new CustomEvent('actionclick', {
                 detail: {
                     name: event.detail.name,
-                    index: Number(event.target.dataset.index),
+                    index: Number(event.currentTarget.dataset.index),
                     targetName: event.detail.targetName
                 }
             })
@@ -724,7 +724,7 @@ export default class PillContainer extends LightningElement {
      * @param {Event} event
      */
     handlePillClick(event) {
-        const index = Number(event.target.dataset.index);
+        const index = Number(event.currentTarget.dataset.index);
 
         if (index >= 0 && this._focusedIndex !== index) {
             this.switchFocus(index);


### PR DESCRIPTION
### Fixes

**Pill Container**
- Fixed error on action click, when the component is implemented in a Salesforce platform where Lightning Locker is enabled.
