### PR TITLE
[feat] (ABC-823): Add hide clear icon to icon picker and remove fixed width

### DIFF
--- a/src/modules/base/colorPicker/colorPicker.html
+++ b/src/modules/base/colorPicker/colorPicker.html
@@ -273,11 +273,7 @@
 
             <!-- Input -->
             <div
-                class="
-                    slds-form-element
-                    slds-p-left_xx-small
-                    avonni-builder-icon-picker-input-container
-                "
+                class="slds-form-element slds-p-left_xx-small"
                 if:false={hideColorInput}
             >
                 <div

--- a/src/modules/base/iconPicker/__docs__/iconPicker.stories.js
+++ b/src/modules/base/iconPicker/__docs__/iconPicker.stories.js
@@ -207,10 +207,23 @@ export default {
                 defaultValue: { summary: 'false' },
                 type: { summary: 'boolean' }
             }
+        },
+        hideClearIcon: {
+            name: 'hide-clear-icon',
+            control: {
+                type: 'boolean'
+            },
+            description:
+                'If present, it is not possible to clear a selected option using the input clear icon.',
+            table: {
+                defaultValue: { summary: 'false' },
+                type: { summary: 'boolean' }
+            }
         }
     },
     args: {
         disabled: false,
+        hideClearIcon: false,
         hideFooter: false,
         hideInputText: false,
         menuIconSize: 'medium',

--- a/src/modules/base/iconPicker/__examples__/iconPicker.js
+++ b/src/modules/base/iconPicker/__examples__/iconPicker.js
@@ -20,6 +20,7 @@ export const IconPicker = ({
     menuIconSize,
     menuLabel,
     messageWhenBadInput,
+    hideClearIcon,
     hideInputText,
     hideFooter,
     placeholder
@@ -35,6 +36,7 @@ export const IconPicker = ({
     element.required = required;
     element.variant = variant;
     element.hiddenCategories = hiddenCategories;
+    element.hideClearIcon = hideClearIcon;
     element.menuVariant = menuVariant;
     element.menuIconSize = menuIconSize;
     element.menuLabel = menuLabel;

--- a/src/modules/base/iconPicker/__tests__/iconPicker.test.js
+++ b/src/modules/base/iconPicker/__tests__/iconPicker.test.js
@@ -63,6 +63,7 @@ describe('IconPicker', () => {
         expect(element.name).toBeUndefined();
         expect(element.variant).toBe('standard');
         expect(element.hiddenCategories).toEqual([]);
+        expect(element.hideClearIcon).toBeFalsy();
         expect(element.menuVariant).toBe('border');
         expect(element.menuIconSize).toBe('medium');
         expect(element.menuLabel).toBeUndefined();
@@ -164,6 +165,30 @@ describe('IconPicker', () => {
             );
             expect(button.disabled).toBeTruthy();
             expect(input.disabled).toBeTruthy();
+        });
+    });
+
+    it('Hide clear icon = false', () => {
+        element.hideClearIcon = false;
+        element.value = 'standard:apps';
+
+        return Promise.resolve().then(() => {
+            const clearButton = element.shadowRoot.querySelector(
+                '[data-element-id="button-clear"]'
+            );
+            expect(clearButton).toBeTruthy();
+        });
+    });
+
+    it('Hide clear icon = true', () => {
+        element.hideClearIcon = true;
+        element.value = 'standard:apps';
+
+        return Promise.resolve().then(() => {
+            const clearButton = element.shadowRoot.querySelector(
+                '[data-element-id="button-clear"]'
+            );
+            expect(clearButton).toBeFalsy();
         });
     });
 

--- a/src/modules/base/iconPicker/iconPicker.css
+++ b/src/modules/base/iconPicker/iconPicker.css
@@ -66,8 +66,8 @@ button:disabled {
     background-color: #ecebea;
 }
 
-.avonni-builder-icon-picker-input-container {
-    width: 17rem;
+.avonni-icon-picker__icon {
+    margin-right: 0.25rem;
 }
 
 .avonni-builder-icon-picker-icon-container {

--- a/src/modules/base/iconPicker/iconPicker.html
+++ b/src/modules/base/iconPicker/iconPicker.html
@@ -84,7 +84,10 @@
                         >
                         </lightning-icon>
                     </span>
-                    <span if:true={showEmptyIcon} class="slds-icon_container">
+                    <span
+                        if:true={showEmptyIcon}
+                        class="slds-icon_container avonni-icon-picker__icon"
+                    >
                         <svg
                             version="1.1"
                             baseProfile="full"

--- a/src/modules/base/iconPicker/iconPicker.html
+++ b/src/modules/base/iconPicker/iconPicker.html
@@ -325,18 +325,9 @@
             </div>
             <div
                 if:true={showInputText}
-                class="
-                    slds-form-element
-                    slds-p-left_xx-small
-                    avonni-builder-icon-picker-input-container
-                "
+                class="slds-form-element slds-p-left_xx-small"
             >
-                <div
-                    class="
-                        slds-form-element__control
-                        slds-input-has-icon slds-input-has-icon_right
-                    "
-                >
+                <div class={computedInputClass}>
                     <input
                         type="text"
                         id="icon_input"

--- a/src/modules/base/iconPicker/iconPicker.js
+++ b/src/modules/base/iconPicker/iconPicker.js
@@ -526,9 +526,9 @@ export default class IconPicker extends LightningElement {
             case MENU_ICON_SIZES.valid[2]:
                 return '16px';
             case MENU_ICON_SIZES.valid[3]:
-                return '18px';
+                return '24px';
             case MENU_ICON_SIZES.valid[4]:
-                return '18px';
+                return '24px';
             default:
                 return null;
         }
@@ -628,7 +628,9 @@ export default class IconPicker extends LightningElement {
      * @type {string}
      */
     get computedIconContainerClass() {
-        const classes = classSet('slds-icon_container');
+        const classes = classSet(
+            'slds-icon_container avonni-icon-picker__icon'
+        );
         if (this.value && this.value.split(':')[0] === 'action') {
             classes.add({
                 'avonni-icon-picker__action-icon_small-scaling':

--- a/src/modules/base/iconPicker/iconPicker.js
+++ b/src/modules/base/iconPicker/iconPicker.js
@@ -119,6 +119,7 @@ export default class IconPicker extends LightningElement {
 
     _disabled = false;
     _hiddenCategories = [];
+    _hideClearIcon = false;
     _hideFooter = false;
     _hideInputText = false;
     _menuIconSize = MENU_ICON_SIZES.default;
@@ -192,6 +193,22 @@ export default class IconPicker extends LightningElement {
                 this._hiddenCategories.splice(index, 1);
             }
         }
+    }
+
+    /**
+     * If present, it is not possible to clear a selected option using the input clear icon.
+     *
+     * @type {boolean}
+     * @public
+     * @default false
+     */
+    @api
+    get hideClearIcon() {
+        return this._hideClearIcon;
+    }
+
+    set hideClearIcon(value) {
+        this._hideClearIcon = normalizeBoolean(value);
     }
 
     /**
@@ -451,12 +468,26 @@ export default class IconPicker extends LightningElement {
     }
 
     /**
+     * Computed CSS class for the input wrapper.
+     *
+     * @type {string}
+     */
+    get computedInputClass() {
+        return classSet('slds-form-element__control')
+            .add({
+                'slds-input-has-icon slds-input-has-icon_right':
+                    !this.hideClearIcon && !this.disabled
+            })
+            .toString();
+    }
+
+    /**
      * Whether the clear button in the input is visible.
      *
      * @type {boolean}
      */
     get allowClearInput() {
-        return this.value && !this.disabled;
+        return this.value && !this.disabled && !this.hideClearIcon;
     }
 
     /**


### PR DESCRIPTION
### Features
**Icon Picker**
- Added `hide-clear-icon` attribute.

### Fixes
**Icon Picker**
- Removed fixed width of 17rem. The icon picker width will now adapt to its parent.
