### PR TITLE
[fix] (ABC-856): Fix popover closing on tab click in icon picker

### DIFF
--- a/src/modules/base/iconPicker/iconPicker.html
+++ b/src/modules/base/iconPicker/iconPicker.html
@@ -168,7 +168,7 @@
                                         class="slds-col"
                                         labels={allTabs}
                                         tabs-hidden={nHiddenCategories}
-                                        default-tab={defaultTab}
+                                        default-tab={currentTab}
                                         data-element-id="avonni-builder-tab-bar"
                                         onclick={stopPropagation}
                                         onselect={handleTabSelect}

--- a/src/modules/base/iconPicker/iconPicker.js
+++ b/src/modules/base/iconPicker/iconPicker.js
@@ -853,6 +853,14 @@ export default class IconPicker extends LightningElement {
         this.currentTab = event.detail.value;
         this.changeTabContentTo(event.detail.value);
         this.scrollTopIconList();
+
+        requestAnimationFrame(() => {
+            // Set the focus back on the tab bar after render
+            const tabBar = this.template.querySelector(
+                '[data-element-id="avonni-builder-tab-bar"]'
+            );
+            tabBar.focus();
+        });
     }
 
     /**
@@ -1115,10 +1123,11 @@ export default class IconPicker extends LightningElement {
         this.tabContent.forEach((tab) => {
             tab.showIcons = tab.title === tabName;
 
+            // Load the extended icons only after render
             if (tab.title === tabName) {
-                setTimeout(() => {
+                requestAnimationFrame(() => {
                     tab.showIconsExtended = true;
-                }, 0);
+                });
             } else {
                 tab.showIconsExtended = false;
             }

--- a/src/modules/base/tabBar/__tests__/tabBar.test.js
+++ b/src/modules/base/tabBar/__tests__/tabBar.test.js
@@ -25,7 +25,11 @@ describe('Tab Bar', () => {
         document.body.appendChild(element);
     });
 
-    /* ----- ATTRIBUTES ----- */
+    /*
+     * ------------------------------------------------------------
+     *  ATTRIBUTES
+     * -------------------------------------------------------------
+     */
 
     it('Tab bar: Default attributes', () => {
         expect(element.labels).toEqual([]);
@@ -120,7 +124,32 @@ describe('Tab Bar', () => {
             });
     });
 
-    /* ----- EVENTS ----- */
+    /*
+     * ------------------------------------------------------------
+     *  METHODS
+     * -------------------------------------------------------------
+     */
+
+    it('Tab bar: focus method', () => {
+        element.labels = labels;
+        element.defaultTab = 'Tab 2';
+
+        return Promise.resolve().then(() => {
+            const tabs = element.shadowRoot.querySelectorAll(
+                '[data-element-id="a-tab-link"]'
+            );
+            const spy = jest.spyOn(tabs[1], 'focus');
+
+            element.focus();
+            expect(spy).toHaveBeenCalled();
+        });
+    });
+
+    /*
+     * ------------------------------------------------------------
+     *  EVENTS
+     * -------------------------------------------------------------
+     */
 
     it('Tab bar: Select event', () => {
         element.labels = labels;

--- a/src/modules/base/tabBar/tabBar.js
+++ b/src/modules/base/tabBar/tabBar.js
@@ -150,6 +150,21 @@ export default class TabBar extends LightningElement {
     }
 
     /**
+     * Set the focus on the selected tab.
+     *
+     * @public
+     */
+    @api
+    focus() {
+        const defaultTab = this.template.querySelector(
+            '.slds-is-active [data-element-id="a-tab-link"]'
+        );
+        if (defaultTab) {
+            defaultTab.focus();
+        }
+    }
+
+    /**
      * Returns the computed CSS classes of a given tab during initialization.
      * @param {string} tabName - The name of the tab.
      * @return {string}


### PR DESCRIPTION
### Features
**Tab Bar**
- Added `focus()` method.

### Fixes
**Icon Picker**
- Prevented the popover from closing on click on a category tab.
