### PR TITLE
[fix] (ABC-863): Prevent itemclick on keyboard actionclick in list

### DIFF
--- a/src/modules/base/list/__tests__/list.test.js
+++ b/src/modules/base/list/__tests__/list.test.js
@@ -869,6 +869,23 @@ describe('List', () => {
         });
     });
 
+    it('List: Itemclick event, keyboard actionclick do not dispatch itemclick', () => {
+        const handler = jest.fn();
+        element.addEventListener('itemclick', handler);
+        element.items = ITEMS;
+        element.actions = ACTION;
+
+        return Promise.resolve().then(() => {
+            const button = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button"]'
+            );
+            const keydown = new CustomEvent('keydown', { bubbles: true });
+            keydown.key = 'Enter';
+            button.dispatchEvent(keydown);
+            expect(handler).not.toHaveBeenCalled();
+        });
+    });
+
     // itemmousedown
     it('List: Itemmousedown event', () => {
         const handler = jest.fn();

--- a/src/modules/base/list/list.html
+++ b/src/modules/base/list/list.html
@@ -116,7 +116,10 @@
                                 slot="media-actions"
                                 class="avonni-list__item-media-action-top-right"
                             >
-                                <div if:true={item.hasImage}>
+                                <div
+                                    if:true={item.hasImage}
+                                    onkeydown={handleStopKeyDown}
+                                >
                                     <lightning-button-menu
                                         if:true={hasMultipleMediaActions}
                                         menu-alignment="right"
@@ -387,6 +390,7 @@
                                 <div
                                     if:true={hasActions}
                                     class="slds-m-right_x-small"
+                                    onkeydown={handleStopKeyDown}
                                 >
                                     <lightning-button-menu
                                         if:true={hasMultipleActions}

--- a/src/modules/base/list/list.js
+++ b/src/modules/base/list/list.js
@@ -1898,8 +1898,8 @@ export default class List extends LightningElement {
         if (event.key === 'Enter') {
             this.handleItemClick(event);
         } else if (
-            (this.sortable && event.key === ' ') ||
-            event.key === 'Spacebar'
+            this.sortable &&
+            (event.key === ' ' || event.key === 'Spacebar')
         ) {
             event.preventDefault();
             if (this._draggedElement) {
@@ -2033,6 +2033,21 @@ export default class List extends LightningElement {
                 !this.isLoading)
         ) {
             this.handleLoadMore();
+        }
+    }
+
+    /**
+     * Handle a keydown event on an action button. If the button is actioned, prevent the `itemclick` event from being dispatched.
+     *
+     * @param {Event} event `keydown` event.
+     */
+    handleStopKeyDown(event) {
+        if (
+            event.key === 'Enter' ||
+            event.key === ' ' ||
+            event.key === 'Spacebar'
+        ) {
+            event.stopPropagation();
         }
     }
 }


### PR DESCRIPTION
### Fixes
**List**
- Prevented the `itemclick` event from being fired when the Enter or Space keys are pressed on an action.
