### PR TITLE
[feat] (ABC-869): Add secondary-position attribute to metric

### DIFF
--- a/src/modules/base/metric/__docs__/metric.jsdoc.js
+++ b/src/modules/base/metric/__docs__/metric.jsdoc.js
@@ -106,6 +106,11 @@
  */
 /**
  * @memberof stylingHooks
+ * @name --avonni-metric-secondary-alignment
+ * @type string
+ */
+/**
+ * @memberof stylingHooks
  * @name --avonni-metric-secondary-negative-trend-color-background
  * @default #feded8
  * @type color

--- a/src/modules/base/metric/__docs__/metric.stories.js
+++ b/src/modules/base/metric/__docs__/metric.stories.js
@@ -257,6 +257,18 @@ export default {
                 type: { summary: 'number' }
             }
         },
+        secondaryPosition: {
+            name: 'secondary-position',
+            control: {
+                type: 'select'
+            },
+            options: ['right', 'left', 'top', 'bottom'],
+            description:
+                'Position of the secondary value, relative to the value.',
+            table: {
+                type: { summary: 'string' }
+            }
+        },
         secondaryPrefix: {
             name: 'secondary-prefix',
             control: {
@@ -420,6 +432,7 @@ export default {
         formatStyle: 'decimal',
         secondaryCurrencyDisplayAs: 'symbol',
         secondaryFormatStyle: 'decimal',
+        secondaryPosition: 'right',
         secondaryShowTrendColor: false,
         secondaryTrendBreakpointValue: 0,
         secondaryValueSign: 'negative',
@@ -471,7 +484,8 @@ TrendDown.args = {
     showTrendColor: true,
     suffix: 'overall',
     trendIcon: 'caret',
-    value: -14
+    value: -14,
+    secondaryPosition: 'bottom'
 };
 
 export const SecondaryTrendUp = Template.bind({});

--- a/src/modules/base/metric/__examples__/metric.js
+++ b/src/modules/base/metric/__examples__/metric.js
@@ -56,6 +56,7 @@ export const Metric = ({
     secondaryMinimumFractionDigits,
     secondaryMinimumIntegerDigits,
     secondaryMinimumSignificantDigits,
+    secondaryPosition,
     secondaryPrefix,
     secondaryShowTrendColor,
     secondarySuffix,
@@ -95,6 +96,7 @@ export const Metric = ({
     element.secondaryMinimumIntegerDigits = secondaryMinimumIntegerDigits;
     element.secondaryMinimumSignificantDigits =
         secondaryMinimumSignificantDigits;
+    element.secondaryPosition = secondaryPosition;
     element.secondaryPrefix = secondaryPrefix;
     element.secondaryShowTrendColor = secondaryShowTrendColor;
     element.secondarySuffix = secondarySuffix;

--- a/src/modules/base/metric/__examples__/trendDown/trendDown.html
+++ b/src/modules/base/metric/__examples__/trendDown/trendDown.html
@@ -3,6 +3,7 @@
         format-style="percent-fixed"
         secondary-format-style="percent-fixed"
         secondary-minimum-fraction-digits="1"
+        secondary-position="bottom"
         secondary-suffix="this month"
         secondary-value="8.6"
         secondary-value-sign="positive-and-negative"

--- a/src/modules/base/metric/__tests__/metric.test.js
+++ b/src/modules/base/metric/__tests__/metric.test.js
@@ -74,6 +74,7 @@ describe('Metric', () => {
         expect(element.secondaryMinimumFractionDigits).toBeUndefined();
         expect(element.secondaryMinimumIntegerDigits).toBeUndefined();
         expect(element.secondaryMinimumSignificantDigits).toBeUndefined();
+        expect(element.secondaryPosition).toBe('right');
         expect(element.secondaryPrefix).toBeUndefined();
         expect(element.secondarySuffix).toBeUndefined();
         expect(element.secondaryShowTrendColor).toBeFalsy();
@@ -402,6 +403,119 @@ describe('Metric', () => {
         });
     });
 
+    // secondary-position
+    it('Metric: secondaryPosition = right', () => {
+        element.secondaryPosition = 'right';
+        element.value = 13.6;
+        element.secondaryValue = 16;
+
+        return Promise.resolve().then(() => {
+            const wrapper = element.shadowRoot.querySelector(
+                '[data-element-id="div-metrics"]'
+            );
+            expect(wrapper.className).toBe(
+                'avonni-metric__primary-and-secondary-wrapper slds-grid slds-grid_vertical-align-end'
+            );
+
+            const primary = element.shadowRoot.querySelector(
+                '[data-element-id="avonni-primitive-metric-primary"]'
+            );
+            expect(primary.className).toBe('avonni-metric__primary slds-show');
+
+            const secondary = element.shadowRoot.querySelector(
+                '[data-element-id="avonni-primitive-metric-secondary"]'
+            );
+            expect(secondary.className).toBe(
+                'avonni-metric__secondary slds-m-left_x-small slds-show'
+            );
+        });
+    });
+
+    it('Metric: secondaryPosition = left', () => {
+        element.secondaryPosition = 'left';
+        element.value = 13.6;
+        element.secondaryValue = 16;
+
+        return Promise.resolve().then(() => {
+            const wrapper = element.shadowRoot.querySelector(
+                '[data-element-id="div-metrics"]'
+            );
+            expect(wrapper.className).toBe(
+                'avonni-metric__primary-and-secondary-wrapper slds-grid slds-grid_vertical-align-end slds-grid_reverse'
+            );
+
+            const primary = element.shadowRoot.querySelector(
+                '[data-element-id="avonni-primitive-metric-primary"]'
+            );
+            expect(primary.className).toBe('avonni-metric__primary slds-show');
+
+            const secondary = element.shadowRoot.querySelector(
+                '[data-element-id="avonni-primitive-metric-secondary"]'
+            );
+            expect(secondary.className).toBe(
+                'avonni-metric__secondary slds-m-right_x-small slds-show'
+            );
+        });
+    });
+
+    it('Metric: secondaryPosition = bottom', () => {
+        element.secondaryPosition = 'bottom';
+        element.value = 13.6;
+        element.secondaryValue = 16;
+
+        return Promise.resolve().then(() => {
+            const wrapper = element.shadowRoot.querySelector(
+                '[data-element-id="div-metrics"]'
+            );
+            expect(wrapper.className).toBe(
+                'avonni-metric__primary-and-secondary-wrapper'
+            );
+
+            const primary = element.shadowRoot.querySelector(
+                '[data-element-id="avonni-primitive-metric-primary"]'
+            );
+            expect(primary.className).toBe(
+                'avonni-metric__primary slds-show_inline-block'
+            );
+
+            const secondary = element.shadowRoot.querySelector(
+                '[data-element-id="avonni-primitive-metric-secondary"]'
+            );
+            expect(secondary.className).toBe(
+                'avonni-metric__secondary slds-show_inline-block'
+            );
+        });
+    });
+
+    it('Metric: secondaryPosition = top', () => {
+        element.secondaryPosition = 'top';
+        element.value = 13.6;
+        element.secondaryValue = 16;
+
+        return Promise.resolve().then(() => {
+            const wrapper = element.shadowRoot.querySelector(
+                '[data-element-id="div-metrics"]'
+            );
+            expect(wrapper.className).toBe(
+                'avonni-metric__primary-and-secondary-wrapper slds-grid slds-grid_vertical-reverse'
+            );
+
+            const primary = element.shadowRoot.querySelector(
+                '[data-element-id="avonni-primitive-metric-primary"]'
+            );
+            expect(primary.className).toBe(
+                'avonni-metric__primary slds-show_inline-block'
+            );
+
+            const secondary = element.shadowRoot.querySelector(
+                '[data-element-id="avonni-primitive-metric-secondary"]'
+            );
+            expect(secondary.className).toBe(
+                'avonni-metric__secondary slds-show_inline-block'
+            );
+        });
+    });
+
     // secondary-prefix
     it('Metric: secondaryPrefix', () => {
         element.secondaryPrefix = 'prefix';
@@ -438,7 +552,7 @@ describe('Metric', () => {
             const metric = element.shadowRoot.querySelector(
                 '[data-element-id="avonni-primitive-metric-secondary"]'
             );
-            expect(metric.className).toBe('avonni-metric__secondary');
+            expect(metric.className).toBe('avonni-metric__secondary slds-show');
         });
     });
 
@@ -454,7 +568,7 @@ describe('Metric', () => {
                     '[data-element-id="avonni-primitive-metric-secondary"]'
                 );
                 expect(metric.className).toBe(
-                    'avonni-metric__secondary avonni-metric__secondary_positive-trend'
+                    'avonni-metric__secondary slds-show avonni-metric__secondary_positive-trend'
                 );
 
                 element.secondaryValue = 8;
@@ -465,7 +579,7 @@ describe('Metric', () => {
                     '[data-element-id="avonni-primitive-metric-secondary"]'
                 );
                 expect(metric.className).toBe(
-                    'avonni-metric__secondary avonni-metric__secondary_negative-trend'
+                    'avonni-metric__secondary slds-show avonni-metric__secondary_negative-trend'
                 );
 
                 element.secondaryValue = 10;
@@ -476,7 +590,7 @@ describe('Metric', () => {
                     '[data-element-id="avonni-primitive-metric-secondary"]'
                 );
                 expect(metric.className).toBe(
-                    'avonni-metric__secondary avonni-metric__secondary_neutral-trend'
+                    'avonni-metric__secondary slds-show avonni-metric__secondary_neutral-trend'
                 );
             });
     });
@@ -529,7 +643,7 @@ describe('Metric', () => {
             const metric = element.shadowRoot.querySelector(
                 '[data-element-id="avonni-primitive-metric-primary"]'
             );
-            expect(metric.className).toBe('avonni-metric__primary');
+            expect(metric.className).toBe('avonni-metric__primary slds-show');
         });
     });
 
@@ -545,7 +659,7 @@ describe('Metric', () => {
                     '[data-element-id="avonni-primitive-metric-primary"]'
                 );
                 expect(metric.className).toBe(
-                    'avonni-metric__primary avonni-metric__primary_positive-trend'
+                    'avonni-metric__primary slds-show avonni-metric__primary_positive-trend'
                 );
 
                 element.value = 8;
@@ -556,7 +670,7 @@ describe('Metric', () => {
                     '[data-element-id="avonni-primitive-metric-primary"]'
                 );
                 expect(metric.className).toBe(
-                    'avonni-metric__primary avonni-metric__primary_negative-trend'
+                    'avonni-metric__primary slds-show avonni-metric__primary_negative-trend'
                 );
 
                 element.value = 10;
@@ -567,7 +681,7 @@ describe('Metric', () => {
                     '[data-element-id="avonni-primitive-metric-primary"]'
                 );
                 expect(metric.className).toBe(
-                    'avonni-metric__primary avonni-metric__primary_neutral-trend'
+                    'avonni-metric__primary slds-show avonni-metric__primary_neutral-trend'
                 );
             });
     });

--- a/src/modules/base/metric/metric.css
+++ b/src/modules/base/metric/metric.css
@@ -5,6 +5,10 @@
     justify-content: var(--avonni-metric-alignment, left);
 }
 
+.avonni-metric__secondary-wrapper {
+    text-align: var(--avonni-metric-secondary-alignment);
+}
+
 .avonni-metric__avatar_after-text {
     order: 1;
 }

--- a/src/modules/base/metric/metric.html
+++ b/src/modules/base/metric/metric.html
@@ -56,52 +56,51 @@
             >
                 {label}
             </div>
-            <div
-                class="
-                    slds-grid slds-grid_vertical-align-end
-                    avonni-metric__primary-and-secondary-wrapper
-                "
-            >
+            <div class={metricsClass} data-element-id="div-metrics">
                 <!-- Primary -->
-                <c-primitive-metric
-                    class={primaryClass}
-                    currency-code={currencyCode}
-                    currency-display-as={currencyDisplayAs}
-                    format-style={formatStyle}
-                    maximum-fraction-digits={maximumFractionDigits}
-                    maximum-significant-digits={maximumSignificantDigits}
-                    minimum-fraction-digits={minimumFractionDigits}
-                    minimum-integer-digits={minimumIntegerDigits}
-                    minimum-significant-digits={minimumSignificantDigits}
-                    prefix={prefix}
-                    suffix={suffix}
-                    trend-breakpoint-value={trendBreakpointValue}
-                    trend-icon={trendIcon}
-                    value={value}
-                    value-sign={valueSign}
-                    data-element-id="avonni-primitive-metric-primary"
-                ></c-primitive-metric>
+                <div>
+                    <c-primitive-metric
+                        class={primaryClass}
+                        currency-code={currencyCode}
+                        currency-display-as={currencyDisplayAs}
+                        format-style={formatStyle}
+                        maximum-fraction-digits={maximumFractionDigits}
+                        maximum-significant-digits={maximumSignificantDigits}
+                        minimum-fraction-digits={minimumFractionDigits}
+                        minimum-integer-digits={minimumIntegerDigits}
+                        minimum-significant-digits={minimumSignificantDigits}
+                        prefix={prefix}
+                        suffix={suffix}
+                        trend-breakpoint-value={trendBreakpointValue}
+                        trend-icon={trendIcon}
+                        value={value}
+                        value-sign={valueSign}
+                        data-element-id="avonni-primitive-metric-primary"
+                    ></c-primitive-metric>
+                </div>
 
                 <!-- Secondary -->
-                <c-primitive-metric
-                    if:true={showSecondaryMetric}
-                    class={secondaryClass}
-                    currency-code={secondaryCurrencyCode}
-                    currency-display-as={secondaryCurrencyDisplayAs}
-                    format-style={secondaryFormatStyle}
-                    maximum-fraction-digits={secondaryMaximumFractionDigits}
-                    maximum-significant-digits={secondaryMaximumSignificantDigits}
-                    minimum-fraction-digits={secondaryMinimumFractionDigits}
-                    minimum-integer-digits={secondaryMinimumIntegerDigits}
-                    minimum-significant-digits={secondaryMinimumSignificantDigits}
-                    prefix={secondaryPrefix}
-                    suffix={secondarySuffix}
-                    trend-breakpoint-value={secondaryTrendBreakpointValue}
-                    trend-icon={secondaryTrendIcon}
-                    value={secondaryValue}
-                    value-sign={secondaryValueSign}
-                    data-element-id="avonni-primitive-metric-secondary"
-                ></c-primitive-metric>
+                <div class="avonni-metric__secondary-wrapper">
+                    <c-primitive-metric
+                        if:true={showSecondaryMetric}
+                        class={secondaryClass}
+                        currency-code={secondaryCurrencyCode}
+                        currency-display-as={secondaryCurrencyDisplayAs}
+                        format-style={secondaryFormatStyle}
+                        maximum-fraction-digits={secondaryMaximumFractionDigits}
+                        maximum-significant-digits={secondaryMaximumSignificantDigits}
+                        minimum-fraction-digits={secondaryMinimumFractionDigits}
+                        minimum-integer-digits={secondaryMinimumIntegerDigits}
+                        minimum-significant-digits={secondaryMinimumSignificantDigits}
+                        prefix={secondaryPrefix}
+                        suffix={secondarySuffix}
+                        trend-breakpoint-value={secondaryTrendBreakpointValue}
+                        trend-icon={secondaryTrendIcon}
+                        value={secondaryValue}
+                        value-sign={secondaryValueSign}
+                        data-element-id="avonni-primitive-metric-secondary"
+                    ></c-primitive-metric>
+                </div>
             </div>
             <!-- Description -->
             <div

--- a/src/modules/base/metric/metric.js
+++ b/src/modules/base/metric/metric.js
@@ -56,6 +56,11 @@ const FORMAT_STYLES = {
     valid: ['currency', 'decimal', 'percent', 'percent-fixed']
 };
 
+const POSITIONS = {
+    valid: ['right', 'left', 'top', 'bottom'],
+    default: 'right'
+};
+
 const TREND_ICONS = {
     valid: ['dynamic', 'arrow', 'caret'],
     default: undefined
@@ -152,6 +157,7 @@ export default class Metric extends LightningElement {
     _secondaryMinimumFractionDigits;
     _secondaryMinimumIntegerDigits;
     _secondaryMinimumSignificantDigits;
+    _secondaryPosition = POSITIONS.default;
     _secondaryShowTrendColor = false;
     _secondaryTrendBreakpointValue = DEFAULT_TREND_BREAKPOINT_VALUE;
     _secondaryTrendIcon;
@@ -452,6 +458,24 @@ export default class Metric extends LightningElement {
     }
 
     /**
+     * Position of the secondary value, relative to the value.
+     *
+     * @type {string}
+     * @default right
+     * @public
+     */
+    @api
+    get secondaryPosition() {
+        return this._secondaryPosition;
+    }
+    set secondaryPosition(value) {
+        this._secondaryPosition = normalizeString(value, {
+            validValues: POSITIONS.valid,
+            fallbackValue: POSITIONS.default
+        });
+    }
+
+    /**
      * If present, the secondary value will change color and background depending on the trend direction.
      *
      * @type {boolean}
@@ -673,13 +697,31 @@ export default class Metric extends LightningElement {
         }).toString();
     }
 
+    get metricsClass() {
+        const position = this.secondaryPosition;
+        return classSet('avonni-metric__primary-and-secondary-wrapper')
+            .add({
+                'slds-grid': position !== 'bottom',
+                'slds-grid_vertical-align-end':
+                    position === 'left' || position === 'right',
+                'slds-grid_reverse': position === 'left',
+                'slds-grid_vertical-reverse': position === 'top'
+            })
+            .toString();
+    }
+
     /**
      * Computed CSS classes for the primary metric.
      *
      * @type {string}
      */
     get primaryClass() {
-        const classes = classSet('avonni-metric__primary');
+        const position = this.secondaryPosition;
+        const classes = classSet('avonni-metric__primary').add({
+            'slds-show_inline-block':
+                position === 'bottom' || position === 'top',
+            'slds-show': position === 'left' || position === 'right'
+        });
 
         if (this.showTrendColor) {
             const isPositive = this.value > this.trendBreakpointValue;
@@ -700,8 +742,13 @@ export default class Metric extends LightningElement {
      * @type {string}
      */
     get secondaryClass() {
+        const position = this.secondaryPosition;
         const classes = classSet('avonni-metric__secondary').add({
-            'slds-m-left_x-small': isFinite(this.value)
+            'slds-m-left_x-small': isFinite(this.value) && position === 'right',
+            'slds-m-right_x-small': isFinite(this.value) && position === 'left',
+            'slds-show_inline-block':
+                position === 'bottom' || position === 'top',
+            'slds-show': position === 'left' || position === 'right'
         });
 
         if (this.secondaryShowTrendColor) {


### PR DESCRIPTION
### Features
**Metric**
- Added `secondary-position` attribute.
- Added `--avonni-metric-secondary-alignment` styling hook, to change the text alignment of the secondary value block, when it is positioned at the top or the bottom of the value block.