### PR TITLE
[fix] (ABC-871): Fix property updates after first render

### DIFF
--- a/src/modules/base/slider/__tests__/slider.test.js
+++ b/src/modules/base/slider/__tests__/slider.test.js
@@ -401,7 +401,7 @@ describe('Slider', () => {
 
         return Promise.resolve().then(() => {
             const wrapper = element.shadowRoot.querySelector(
-                '[data-element-id="div-wrapper"]'
+                '[data-element-id="div-range"]'
             );
             expect(wrapper.className).toBe(
                 'avonni-slider__container-horizontal-size_responsive'
@@ -424,7 +424,7 @@ describe('Slider', () => {
 
         return Promise.resolve().then(() => {
             const wrapper = element.shadowRoot.querySelector(
-                '[data-element-id="div-wrapper"]'
+                '[data-element-id="div-range"]'
             );
             expect(wrapper.classList).toContain(
                 'avonni-slider__container-vertical-origin_responsive'
@@ -443,7 +443,7 @@ describe('Slider', () => {
 
         return Promise.resolve().then(() => {
             const wrapper = element.shadowRoot.querySelector(
-                '[data-element-id="div-wrapper"]'
+                '[data-element-id="div-range"]'
             );
             expect(wrapper.classList).toContain(
                 'avonni-slider__container-vertical-origin_responsive'
@@ -456,7 +456,7 @@ describe('Slider', () => {
 
         return Promise.resolve().then(() => {
             const wrapper = element.shadowRoot.querySelector(
-                '[data-element-id="div-wrapper"]'
+                '[data-element-id="div-range"]'
             );
             expect(wrapper.classList).toContain(
                 'avonni-slider__container-horizontal-size_x-small'
@@ -469,7 +469,7 @@ describe('Slider', () => {
 
         return Promise.resolve().then(() => {
             const wrapper = element.shadowRoot.querySelector(
-                '[data-element-id="div-wrapper"]'
+                '[data-element-id="div-range"]'
             );
             expect(wrapper.classList).toContain(
                 'avonni-slider__container-horizontal-size_small'
@@ -482,7 +482,7 @@ describe('Slider', () => {
 
         return Promise.resolve().then(() => {
             const wrapper = element.shadowRoot.querySelector(
-                '[data-element-id="div-wrapper"]'
+                '[data-element-id="div-range"]'
             );
             expect(wrapper.classList).toContain(
                 'avonni-slider__container-horizontal-size_medium'
@@ -495,7 +495,7 @@ describe('Slider', () => {
 
         return Promise.resolve().then(() => {
             const wrapper = element.shadowRoot.querySelector(
-                '[data-element-id="div-wrapper"]'
+                '[data-element-id="div-range"]'
             );
             expect(wrapper.classList).toContain(
                 'avonni-slider__container-horizontal-size_large'

--- a/src/modules/base/slider/__tests__/slider.test.js
+++ b/src/modules/base/slider/__tests__/slider.test.js
@@ -198,8 +198,10 @@ describe('Slider', () => {
         element.value = 15;
 
         return Promise.resolve().then(() => {
-            expect(element.max).toEqual(10);
-            expect(element.value).toEqual(10);
+            const input = element.shadowRoot.querySelector(
+                '[data-group-name="input"]'
+            );
+            expect(input.value).toBe('10');
         });
     });
 
@@ -210,8 +212,10 @@ describe('Slider', () => {
         element.value = 0;
 
         return Promise.resolve().then(() => {
-            expect(element.min).toEqual(10);
-            expect(element.value).toEqual(10);
+            const input = element.shadowRoot.querySelector(
+                '[data-group-name="input"]'
+            );
+            expect(input.value).toBe('10');
         });
     });
 
@@ -940,24 +944,6 @@ describe('Slider', () => {
             expect(
                 element.shadowRoot.querySelector('[data-element-id="track"]')
             ).toBeFalsy();
-        });
-    });
-
-    it('value = 0 && 0 < min', () => {
-        element.min = 10;
-        element.value = 0;
-
-        return Promise.resolve().then(() => {
-            expect(element.value).toEqual(10);
-        });
-    });
-
-    it('value = 20 && 20 > max', () => {
-        element.max = 10;
-        element.value = 20;
-
-        return Promise.resolve().then(() => {
-            expect(element.value).toEqual(10);
         });
     });
 

--- a/src/modules/base/slider/slider.html
+++ b/src/modules/base/slider/slider.html
@@ -45,7 +45,7 @@
             >
         </span>
     </label>
-    <div class={computedSliderWrapperClass}>
+    <div class={computedSliderWrapperClass} data-element-id="div-wrapper">
         <div
             if:true={isNormalVertical}
             class={computedUnitContainerClass}
@@ -65,7 +65,7 @@
                 data-element-id="lightning-formatted-number-max-vertical"
             ></lightning-formatted-number>
         </div>
-        <div class={computedContainerClass} data-element-id="div-wrapper">
+        <div class={computedContainerClass} data-element-id="div-range">
             <template for:each={values} for:item="value" for:index="index">
                 <div class="slds-form-element" key={generateKey}>
                     <div class="slds-form-element__control">

--- a/src/modules/base/slider/slider.js
+++ b/src/modules/base/slider/slider.js
@@ -1534,7 +1534,7 @@ export default class Slider extends LightningElement {
             spacer.offsetHeight - this._thumbRadius
         );
         const wrapper = this.template.querySelector(
-            '[data-element-id="div-wrapper"]'
+            '[data-element-id="div-range"]'
         );
         wrapper.style.transformOrigin = `${
             (parentHeight + this._thumbRadius) / 2

--- a/src/modules/base/slider/slider.js
+++ b/src/modules/base/slider/slider.js
@@ -180,9 +180,7 @@ export default class Slider extends LightningElement {
             this._resizeObserver = this.initResizeObserver();
         }
         if (!this._rendered || this._domModified) {
-            if (this.isVerticalResponsive) {
-                this.setVerticalResponsiveHeight();
-            }
+            this.setVerticalResponsiveHeight();
             if (this.showTrack) {
                 this.updateTrack(this._computedValues);
             } else {
@@ -1355,9 +1353,7 @@ export default class Slider extends LightningElement {
             return null;
         }
         return new AvonniResizeObserver(wrapper, () => {
-            if (this.isVerticalResponsive) {
-                this.setVerticalResponsiveHeight();
-            }
+            this.setVerticalResponsiveHeight();
             if (this.showAnyTickMarks) {
                 this.drawRuler(true);
             }
@@ -1529,6 +1525,14 @@ export default class Slider extends LightningElement {
      * @param {Event} event
      */
     setVerticalResponsiveHeight() {
+        const wrapper = this.template.querySelector(
+            '[data-element-id="div-range"]'
+        );
+        if (!this.isVerticalResponsive) {
+            wrapper.style.transformOrigin = '';
+            wrapper.style.width = '';
+            return;
+        }
         this.template.host.style.height = '100%';
         this.template.host.style.display = 'block';
         const spacer = this.template.querySelector(
@@ -1537,9 +1541,6 @@ export default class Slider extends LightningElement {
         const parentHeight = Math.max(
             -this._thumbRadius,
             spacer.offsetHeight - this._thumbRadius
-        );
-        const wrapper = this.template.querySelector(
-            '[data-element-id="div-range"]'
         );
         wrapper.style.transformOrigin = `${
             (parentHeight + this._thumbRadius) / 2

--- a/src/modules/base/slider/slider.js
+++ b/src/modules/base/slider/slider.js
@@ -124,7 +124,7 @@ export default class Slider extends LightningElement {
     _unit = SLIDER_UNITS.default;
     _unitAttributes = {};
     _variant = LABEL_VARIANTS.default;
-    _value = [DEFAULT_VALUE];
+    _value = DEFAULT_VALUE;
 
     computedMax;
     computedMin = DEFAULT_MIN;
@@ -533,16 +533,20 @@ export default class Slider extends LightningElement {
         }
 
         if (!isNaN(Number(value))) {
-            this._value = [Number(value)];
+            this._value = Number(value);
+            this._computedValues = [this._value];
+        } else if (!value) {
+            this._value = DEFAULT_VALUE;
+            this._computedValues = [this._value];
         } else {
             const normalizedValue = normalizeArray(value, 'number');
             this._value = normalizedValue.length
                 ? normalizedValue
                 : [DEFAULT_VALUE];
             this._value.sort((a, b) => a - b);
+            this._computedValues = [...this._value];
         }
 
-        this._computedValues = [...this._value];
         if (this._connected) {
             this.scaleValues();
             this.capValues();
@@ -1089,7 +1093,6 @@ export default class Slider extends LightningElement {
                 Math.round(this._computedValues[index] / this._step) *
                 this._step;
         });
-        this.updatePublicValue();
     }
 
     /**

--- a/src/modules/base/slider/slider.js
+++ b/src/modules/base/slider/slider.js
@@ -259,6 +259,7 @@ export default class Slider extends LightningElement {
         if (this._connected) {
             this.scaleValues();
             this.capValues();
+            this._domModified = true;
         }
     }
 
@@ -282,6 +283,7 @@ export default class Slider extends LightningElement {
         if (this._connected) {
             this.scaleValues();
             this.capValues();
+            this._domModified = true;
         }
     }
 


### PR DESCRIPTION
### Fixes
**Slider**
- Prevented the update of the given value, when it is outside of the min/max range.
- Fixed the update of the track display when updating the min/max after the first render.
- Fixed the update of the slider height, when the slider is vertical and the parent height is set after the slider render.
