### PR TITLE
[defaults] (ABC-882): Use black as input pen default color value

### DIFF
--- a/src/modules/base/inputPen/inputPen.js
+++ b/src/modules/base/inputPen/inputPen.js
@@ -285,7 +285,7 @@ export default class InputPen extends LightningElement {
         const colorValue =
             typeof value === 'string' || value instanceof String
                 ? value
-                : DEFAULT_BACKGROUND_COLOR;
+                : DEFAULT_COLOR;
         const style = new Option().style;
         style.color = colorValue;
         if (


### PR DESCRIPTION
### Fixes
**Input Pen**
- Fixed color being set to white instead of black, when an invalid value was passed.
