### PR TITLE
[fix] (ABC-886): Fix pill container actions popover position

### DIFF
--- a/src/modules/base/pillContainer/__tests__/pillContainer.test.js
+++ b/src/modules/base/pillContainer/__tests__/pillContainer.test.js
@@ -381,7 +381,9 @@ describe('Pill Container', () => {
             const wrapper = element.shadowRoot.querySelector(
                 '[data-element-id="div-wrapper"]'
             );
-            expect(wrapper.className).toBe('avonni-pill-container__wrapper');
+            expect(wrapper.className).toBe(
+                'avonni-pill-container__wrapper slds-is-relative'
+            );
 
             const ul = element.shadowRoot.querySelector(
                 '[data-element-id="ul"]'
@@ -407,7 +409,7 @@ describe('Pill Container', () => {
                 '[data-element-id="div-wrapper"]'
             );
             expect(wrapper.className).toBe(
-                'avonni-pill-container__wrapper slds-pill_container slds-p-top_none slds-p-bottom_none'
+                'avonni-pill-container__wrapper slds-is-relative slds-pill_container slds-p-top_none slds-p-bottom_none'
             );
 
             const ul = element.shadowRoot.querySelector(

--- a/src/modules/base/pillContainer/pillContainer.css
+++ b/src/modules/base/pillContainer/pillContainer.css
@@ -69,6 +69,10 @@
 
 .avonni-pill-container__action-menu {
     z-index: 7001;
+
+    /* Needed to prevent a potential scroll jump when the menu appears */
+    top: 0;
+    left: 0;
 }
 
 /*

--- a/src/modules/base/pillContainer/pillContainer.html
+++ b/src/modules/base/pillContainer/pillContainer.html
@@ -157,7 +157,7 @@
 
         <c-primitive-dropdown-menu
             if:true={showActionMenu}
-            class="slds-is-fixed avonni-pill-container__action-menu"
+            class="slds-is-absolute avonni-pill-container__action-menu"
             show={showActionMenu}
             items={actions}
             data-element-id="avonni-primitive-dropdown-menu"

--- a/src/modules/base/pillContainer/pillContainer.js
+++ b/src/modules/base/pillContainer/pillContainer.js
@@ -325,7 +325,7 @@ export default class PillContainer extends LightningElement {
      * @type {string}
      */
     get computedWrapperClass() {
-        return classSet('avonni-pill-container__wrapper').add({
+        return classSet('avonni-pill-container__wrapper slds-is-relative').add({
             'slds-pill_container slds-p-top_none slds-p-bottom_none':
                 this.singleLine
         });
@@ -410,6 +410,10 @@ export default class PillContainer extends LightningElement {
         return this.items.slice(0, this._visibleItemsCount);
     }
 
+    get wrapperElement() {
+        return this.template.querySelector('[data-element-id="div-wrapper"]');
+    }
+
     /*
      * ------------------------------------------------------------
      *  PUBLIC METHODS
@@ -453,10 +457,9 @@ export default class PillContainer extends LightningElement {
             initialIndex: index,
             lastHoveredIndex: index
         };
-        const wrapper = this.template.querySelector(
-            '[data-element-id="div-wrapper"]'
+        this.wrapperElement.classList.add(
+            'avonni-pill-container__list_dragging'
         );
-        wrapper.classList.add('avonni-pill-container__list_dragging');
         this.updateAssistiveText(index + 1);
     }
 
@@ -466,14 +469,11 @@ export default class PillContainer extends LightningElement {
      * @returns {AvonniResizeObserver} Resize observer.
      */
     initResizeObserver() {
-        const wrapper = this.template.querySelector(
-            '[data-element-id="div-wrapper"]'
-        );
-        if (!wrapper) {
+        if (!this.wrapperElement) {
             return null;
         }
         return new AvonniResizeObserver(
-            wrapper,
+            this.wrapperElement,
             this.updateVisibleItems.bind(this)
         );
     }
@@ -526,10 +526,9 @@ export default class PillContainer extends LightningElement {
         if (!this._dragState) return;
 
         this.clearDragBorder();
-        const wrapper = this.template.querySelector(
-            '[data-element-id="div-wrapper"]'
+        this.wrapperElement.classList.remove(
+            'avonni-pill-container__list_dragging'
         );
-        wrapper.classList.remove('avonni-pill-container__list_dragging');
         this._dragState = null;
         this.altTextElement.textContent = '';
     }
@@ -700,9 +699,10 @@ export default class PillContainer extends LightningElement {
         const yTransform = menuBottom > bottomView ? height * -1 : 0;
         const xTransform = menuRight > rightView ? width * -1 : 0;
 
+        const { top, left } = this.wrapperElement.getBoundingClientRect();
         menu.style.transform = `translate(${xTransform}px, ${yTransform}px)`;
-        menu.style.top = `${y + 10}px`;
-        menu.style.left = `${x + 10}px`;
+        menu.style.top = `${y - top + 10}px`;
+        menu.style.left = `${x - left + 10}px`;
     }
 
     /**
@@ -811,14 +811,12 @@ export default class PillContainer extends LightningElement {
             return;
         }
 
-        const wrapper = this.template.querySelector(
-            '[data-element-id="div-wrapper"]'
-        );
-        if (!wrapper) {
+        if (!this.wrapperElement) {
             return;
         }
 
-        const totalWidth = wrapper.offsetWidth - SHOW_MORE_BUTTON_WIDTH;
+        const totalWidth =
+            this.wrapperElement.offsetWidth - SHOW_MORE_BUTTON_WIDTH;
 
         let fittingCount = 0;
         let width = 0;


### PR DESCRIPTION
### Fixes
**Pill Container**
- Fixed the position of the actions dropdown, when the pill container is inside a parent with a `transform` CSS property.