### PR TITLE
[fix] (ABC-884): Remove the single-line border for empty pill container

### DIFF
--- a/src/modules/base/pillContainer/pillContainer.css
+++ b/src/modules/base/pillContainer/pillContainer.css
@@ -58,6 +58,10 @@
     border-color: var(--avonni-pill-container-color-border, #e5e5e5);
 }
 
+.avonni-pill-container__wrapper.avonni-pill-container__no-items {
+    border-color: transparent;
+}
+
 .avonni-pill-container__wrapper .avonni-pill-container__item:first-of-type {
     padding-left: 0.125rem;
 }

--- a/src/modules/base/pillContainer/pillContainer.js
+++ b/src/modules/base/pillContainer/pillContainer.js
@@ -327,7 +327,8 @@ export default class PillContainer extends LightningElement {
     get computedWrapperClass() {
         return classSet('avonni-pill-container__wrapper slds-is-relative').add({
             'slds-pill_container slds-p-top_none slds-p-bottom_none':
-                this.singleLine
+                this.singleLine,
+            'avonni-pill-container__no-items': !this._visibleItemsCount
         });
     }
 


### PR DESCRIPTION
### Fixes
**Pill Container**
- Removed the `single-line` border when no items are set.