### PR TITLE
[fix] (ABC-891): Show datatable avatar if it only has text

### DIFF
--- a/src/modules/base/primitiveCellAvatar/primitiveCellAvatar.html
+++ b/src/modules/base/primitiveCellAvatar/primitiveCellAvatar.html
@@ -33,7 +33,7 @@
 -->
 
 <template>
-    <div class="slds-p-around_x-small" if:true={value}>
+    <div class="slds-p-around_x-small" if:true={showAvatar}>
         <c-avatar
             alternative-text={alternativeText}
             entity-icon-name={entityIconName}

--- a/src/modules/base/primitiveCellAvatar/primitiveCellAvatar.js
+++ b/src/modules/base/primitiveCellAvatar/primitiveCellAvatar.js
@@ -83,6 +83,10 @@ export default class PrimitiveCellAvatar extends LightningElement {
         });
     }
 
+    get showAvatar() {
+        return this.value || this.primaryText || this.secondaryText;
+    }
+
     get value() {
         return this.src || this.fallbackIconName;
     }


### PR DESCRIPTION
### Fixes
**Data Table**
- Display avatar type data if it has no value, but has a primary and/or secondary text.