### PR TITLE
[feat] (ABC-873): Add attributes to scheduler to customize popover and side panel

### DIFF
--- a/jest-mock/components/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
+++ b/jest-mock/components/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
@@ -10,14 +10,17 @@ export default class PrimitiveSchedulerAgenda extends LightningElement {
     @api events;
     @api eventsLabels;
     @api eventsTheme;
+    @api hideResourcesFilter;
+    @api hideSidePanel;
     @api loadingStateAlternativeText;
     @api newEventTitle;
     @api readOnly;
     @api recurrentEditModes;
     @api resizeColumnDisabled;
     @api resources;
-    @api selectedResources;
     @api selectedDate;
+    @api selectedResources;
+    @api sidePanelPosition;
     @api timeSpan;
     @api zoomToFit;
 

--- a/jest-mock/components/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/jest-mock/components/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -10,14 +10,17 @@ export default class PrimitiveSchedulerCalendar extends LightningElement {
     @api events;
     @api eventsLabels;
     @api eventsTheme;
+    @api hideResourcesFilter;
+    @api hideSidePanel;
     @api loadingStateAlternativeText;
     @api newEventTitle;
     @api readOnly;
     @api recurrentEditModes;
     @api resizeColumnDisabled;
     @api resources;
-    @api selectedResources;
     @api selectedDate;
+    @api selectedResources;
+    @api sidePanelPosition;
     @api timeSpan;
     @api zoomToFit;
 

--- a/jest-mock/components/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
+++ b/jest-mock/components/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
@@ -11,6 +11,8 @@ export default class PrimitiveSchedulerTimeline extends LightningElement {
     @api events;
     @api eventsLabels;
     @api eventsTheme;
+    @api hideResourcesFilter;
+    @api hideSidePanel;
     @api loadingStateAlternativeText;
     @api newEventTitle;
     @api orientation;
@@ -19,6 +21,7 @@ export default class PrimitiveSchedulerTimeline extends LightningElement {
     @api resizeColumnDisabled;
     @api resources;
     @api selectedResources;
+    @api sidePanelPosition;
     @api start;
     @api timeSpan;
     @api zoomToFit;

--- a/lwc.config.json
+++ b/lwc.config.json
@@ -523,6 +523,10 @@
             "path": "src/modules/base/scheduler/scheduler.js"
         },
         {
+            "name": "c/schedulerSharedStyle",
+            "path": "src/modules/base/schedulerSharedStyle/schedulerSharedStyle.css"
+        },
+        {
             "name": "c/schedulerUtils",
             "path": "src/modules/base/schedulerUtils/schedulerUtils.js"
         },

--- a/src/modules/base/primitiveSchedulerAgenda/__tests__/primitiveSchedulerAgenda.test.js
+++ b/src/modules/base/primitiveSchedulerAgenda/__tests__/primitiveSchedulerAgenda.test.js
@@ -456,35 +456,35 @@ describe('Primitive Scheduler Agenda', () => {
     });
 
     // collapse-disabled
-    it('Primitive Scheduler Agenda: collapseDisabled = false', () => {
+    it('Primitive Scheduler Calendar: collapseDisabled = false', () => {
         element.collapseDisabled = false;
 
         return Promise.resolve().then(() => {
-            const leftPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-left"]'
+            const collapseButton = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button-icon-splitter-collapse"]'
             );
-            expect(leftPanel.collapsible).toBeTruthy();
+            const expandButton = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button-icon-splitter-expand"]'
+            );
 
-            const rightPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-right"]'
-            );
-            expect(rightPanel.collapsible).toBeTruthy();
+            expect(collapseButton).toBeTruthy();
+            expect(expandButton).toBeTruthy();
         });
     });
 
-    it('Primitive Scheduler Agenda: collapseDisabled = true', () => {
+    it('Primitive Scheduler Calendar: collapseDisabled = true', () => {
         element.collapseDisabled = true;
 
         return Promise.resolve().then(() => {
-            const leftPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-left"]'
+            const collapseButton = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button-icon-splitter-collapse"]'
             );
-            expect(leftPanel.collapsible).toBeFalsy();
+            const expandButton = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button-icon-splitter-expand"]'
+            );
 
-            const rightPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-right"]'
-            );
-            expect(rightPanel.collapsible).toBeFalsy();
+            expect(collapseButton).toBeFalsy();
+            expect(expandButton).toBeFalsy();
         });
     });
 
@@ -877,33 +877,25 @@ describe('Primitive Scheduler Agenda', () => {
     });
 
     // resize-column-disabled
-    it('Primitive Scheduler Agenda: resizeColumnDisabled = false', () => {
+    it('Primitive Scheduler Calendar: resizeColumnDisabled = false', () => {
         element.resizeColumnDisabled = false;
 
         return Promise.resolve().then(() => {
-            const leftPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-left"]'
+            const resizeHandle = element.shadowRoot.querySelector(
+                '[data-element-id="div-splitter-resize-handle"]'
             );
-            const rightPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-right"]'
-            );
-            expect(leftPanel.resizable).toBeTruthy();
-            expect(rightPanel.resizable).toBeTruthy();
+            expect(resizeHandle).toBeTruthy();
         });
     });
 
-    it('Primitive Scheduler Agenda: resizeColumnDisabled = true', () => {
+    it('Primitive Scheduler Calendar: resizeColumnDisabled = true', () => {
         element.resizeColumnDisabled = true;
 
         return Promise.resolve().then(() => {
-            const leftPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-left"]'
+            const resizeHandle = element.shadowRoot.querySelector(
+                '[data-element-id="div-splitter-resize-handle"]'
             );
-            const rightPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-right"]'
-            );
-            expect(leftPanel.resizable).toBeFalsy();
-            expect(rightPanel.resizable).toBeFalsy();
+            expect(resizeHandle).toBeFalsy();
         });
     });
 
@@ -1473,10 +1465,15 @@ describe('Primitive Scheduler Agenda', () => {
             );
             const event = new CustomEvent('contextmenu');
             event.clientY = 35;
+            const from = Number(dayGroup.dataset.date);
+            const to = from + 24 * 60 * 60 * 1000 - 1;
             dayGroup.dispatchEvent(event);
+
             expect(handler).toHaveBeenCalled();
             const call = handler.mock.calls[0][0];
-            expect(call.detail.selection.y).toBe(35);
+            expect(call.detail.y).toBe(35);
+            expect(new Date(call.detail.from).getTime()).toBe(from);
+            expect(new Date(call.detail.to).getTime()).toBe(to);
             expect(call.bubbles).toBeFalsy();
             expect(call.cancelable).toBeFalsy();
             expect(call.composed).toBeFalsy();
@@ -1500,10 +1497,15 @@ describe('Primitive Scheduler Agenda', () => {
                 'privatedisabledcontextmenu'
             );
             contextMenuEvent.clientY = 35;
+            const from = Number(event.dataset.start);
+            const to = Number(event.dataset.end);
             event.dispatchEvent(contextMenuEvent);
+
             expect(handler).toHaveBeenCalled();
             const call = handler.mock.calls[0][0];
-            expect(call.detail.selection.y).toBe(35);
+            expect(call.detail.y).toBe(35);
+            expect(new Date(call.detail.from).getTime()).toBe(from);
+            expect(new Date(call.detail.to).getTime()).toBe(to);
         });
     });
 
@@ -1599,6 +1601,39 @@ describe('Primitive Scheduler Agenda', () => {
         });
     });
 
+    // eventmouseleave
+    it('Primitive Scheduler Agenda: eventmouseleave', () => {
+        element.resources = RESOURCES;
+        element.selectedResources = ALL_RESOURCES;
+        element.selectedDate = SELECTED_DATE;
+        element.events = EVENTS;
+
+        const handler = jest.fn();
+        element.addEventListener('eventmouseleave', handler);
+
+        return Promise.resolve().then(() => {
+            const event = element.shadowRoot.querySelector(
+                '[data-element-id="avonni-primitive-scheduler-event-occurrence"]'
+            );
+            const detail = {
+                eventName: 'some name',
+                key: 'some key',
+                x: 34,
+                y: 56
+            };
+            event.dispatchEvent(
+                new CustomEvent('privatemouseleave', { detail })
+            );
+
+            expect(handler).toHaveBeenCalledTimes(1);
+            const call = handler.mock.calls[0][0];
+            expect(call.detail).toEqual(detail);
+            expect(call.bubbles).toBeFalsy();
+            expect(call.composed).toBeFalsy();
+            expect(call.cancelable).toBeFalsy();
+        });
+    });
+
     // eventselect
     it('Primitive Scheduler Agenda: eventselect', () => {
         element.resources = RESOURCES;
@@ -1635,35 +1670,6 @@ describe('Primitive Scheduler Agenda', () => {
             expect(call.bubbles).toBeTruthy();
             expect(call.cancelable).toBeFalsy();
             expect(call.composed).toBeFalsy();
-        });
-    });
-
-    // hidepopovers
-    it('Primitive Scheduler Agenda: hidepopovers on event mouse leave and blur', () => {
-        element.resources = RESOURCES;
-        element.selectedResources = ALL_RESOURCES;
-        element.selectedDate = SELECTED_DATE;
-        element.events = EVENTS;
-
-        const handler = jest.fn();
-        element.addEventListener('hidepopovers', handler);
-
-        return Promise.resolve().then(() => {
-            const event = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-primitive-scheduler-event-occurrence"]'
-            );
-            event.dispatchEvent(new CustomEvent('privatemouseleave'));
-
-            expect(handler).toHaveBeenCalledTimes(1);
-            const call = handler.mock.calls[0][0];
-            expect(call.detail.list).toEqual(['detail']);
-            expect(call.bubbles).toBeFalsy();
-            expect(call.composed).toBeFalsy();
-            expect(call.cancelable).toBeFalsy();
-
-            event.dispatchEvent(new CustomEvent('privateblur'));
-            expect(handler).toHaveBeenCalledTimes(2);
-            expect(handler.mock.calls[1][0].detail.list).toEqual(['detail']);
         });
     });
 

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.css
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.css
@@ -71,9 +71,20 @@
 }
 
 .avonni-scheduler__agenda-day_today {
+    color: var(--lwc-colorTextInverse, #fff);
+    position: relative;
+    z-index: 0;
+}
+.avonni-scheduler__agenda-day_today::before {
+    content: '';
     background-color: var(--lwc-brandAccessible, #0176d3);
     border-radius: 50%;
-    color: var(--lwc-colorTextInverse, #fff);
+    position: absolute;
+    z-index: -1;
+    top: -5px;
+    left: -5px;
+    right: -5px;
+    bottom: -5px;
 }
 
 .avonni-scheduler__agenda-time {

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.css
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.css
@@ -30,16 +30,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@import 'c/schedulerSharedStyle';
+
 .avonni-scheduler__wrapper {
     max-height: 100%;
     height: calc(100vh - 70px);
     max-width: 100%;
 }
 
+.avonni-scheduler__panel {
+    width: 310px;
+}
+
 .avonni-primitive-scheduler-calendar__inherit-height {
     height: inherit;
     min-height: inherit;
     max-height: inherit;
+}
+
+.avonni-scheduler__main-section {
+    flex: 1 1 0;
 }
 
 .avonni-scheduler__agenda-month-header {

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.css
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.css
@@ -33,8 +33,6 @@
 @import 'c/schedulerSharedStyle';
 
 .avonni-scheduler__wrapper {
-    max-height: 100%;
-    height: calc(100vh - 70px);
     max-width: 100%;
 }
 

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.css
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.css
@@ -60,6 +60,10 @@
     --avonni-primitive-scheduler-event-occurrence-standalone-chip-size: 0.75rem;
 }
 
+.avonni-scheduler__agenda-day-group:last-of-type {
+    border-bottom: none;
+}
+
 .avonni-scheduler__agenda-day {
     font-size: 2.625rem;
     min-width: 3rem;

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
@@ -55,7 +55,10 @@
                         onchange={handleCalendarChange}
                         onnavigate={handleLeftPanelCalendarNavigate}
                     ></c-calendar>
-                    <div class="slds-m-top_medium">
+                    <div
+                        if:false={selectedResourcesReadOnly}
+                        class="slds-m-top_medium"
+                    >
                         <template
                             for:each={resourceOptions}
                             for:item="resource"
@@ -269,7 +272,10 @@
                         onchange={handleCalendarChange}
                         onnavigate={handleLeftPanelCalendarNavigate}
                     ></c-calendar>
-                    <div class="slds-m-top_medium">
+                    <div
+                        if:false={selectedResourcesReadOnly}
+                        class="slds-m-top_medium"
+                    >
                         <template
                             for:each={resourceOptions}
                             for:item="resource"

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
@@ -156,7 +156,7 @@
                     >
                         <!-- Day heading -->
                         <div
-                            class="slds-m-right_large slds-col slds-size_1-of-5"
+                            class="slds-m-right_large slds-size_1-of-5"
                             data-element-id="div-day-heading"
                         >
                             <div
@@ -184,7 +184,7 @@
                             </div>
                         </div>
                         <!-- Day events -->
-                        <div class="slds-col">
+                        <div class="avonni-scheduler__flex-col">
                             <div
                                 for:each={group.events}
                                 for:item="occurrence"
@@ -193,7 +193,7 @@
                             >
                                 <div
                                     class="
-                                        slds-col
+                                        avonni-scheduler__flex-col
                                         slds-size_1-of-5
                                         slds-has-flexi-truncate
                                         avonni-scheduler__agenda-time
@@ -214,7 +214,8 @@
                                     class="
                                         slds-m-bottom_xx-small
                                         avonni-scheduler__agenda-event
-                                        slds-show slds-col
+                                        slds-show
+                                        avonni-scheduler__flex-col
                                     "
                                     color={occurrence.event.color}
                                     date-format={dateFormat}

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
@@ -56,7 +56,7 @@
                         onnavigate={handleLeftPanelCalendarNavigate}
                     ></c-calendar>
                     <div
-                        if:false={selectedResourcesReadOnly}
+                        if:false={hideResourcesFilter}
                         class="slds-m-top_medium"
                     >
                         <template
@@ -272,7 +272,7 @@
                         onnavigate={handleLeftPanelCalendarNavigate}
                     ></c-calendar>
                     <div
-                        if:false={selectedResourcesReadOnly}
+                        if:false={hideResourcesFilter}
                         class="slds-m-top_medium"
                     >
                         <template

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
@@ -236,14 +236,13 @@
                                         data-element-id="avonni-primitive-scheduler-event-occurrence"
                                         data-event-name={occurrence.event.name}
                                         oncontextmenu={stopPropagation}
-                                        onprivateblur={handleHideDetailPopover}
                                         onprivatecontextmenu={handleEventContextMenu}
                                         onprivatedblclick={handleEventDoubleClick}
                                         onprivatedisabledcontextmenu={handleEmptySpotContextMenu}
                                         onprivatedisableddblclick={handleDoubleClick}
                                         onprivatefocus={handleEventFocus}
                                         onprivatemouseenter={handleEventMouseEnter}
-                                        onprivatemouseleave={handleHideDetailPopover}
+                                        onprivatemouseleave={handleEventMouseLeave}
                                     ></c-primitive-scheduler-event-occurrence>
                                 </div>
                             </div>

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
@@ -138,7 +138,7 @@
                             vertical
                             slds-text-title_caps
                             slds-p-left_large
-                            slds-border_bottom
+                            avonni-scheduler__border_bottom
                             avonni-scheduler__agenda-month-header
                         "
                         data-element-id="div-month-heading"
@@ -150,7 +150,8 @@
                         class="
                             slds-p-around_medium
                             slds-grid
-                            slds-border_bottom
+                            avonni-scheduler__agenda-day-group
+                            avonni-scheduler__border_bottom
                         "
                         data-element-id="div-day-group"
                         data-date={group.date.ts}

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
@@ -78,6 +78,7 @@
                 icon-name="utility:left"
                 size="x-small"
                 variant="bare"
+                data-element-id="lightning-button-icon-splitter-collapse"
                 onclick={handleSplitterCollapse}
                 onmousedown={stopPropagation}
             ></lightning-button-icon>
@@ -87,6 +88,7 @@
                     avonni-scheduler__splitter-resize-handle
                     slds-m-vertical_x-small
                 "
+                data-element-id="div-splitter-resize-handle"
             >
                 <span class="slds-assistive-text">Resize</span>
             </div>
@@ -97,6 +99,7 @@
                 icon-name="utility:right"
                 size="x-small"
                 variant="bare"
+                data-element-id="lightning-button-icon-splitter-expand"
                 onclick={handleSplitterExpand}
                 onmousedown={stopPropagation}
             ></lightning-button-icon>
@@ -236,6 +239,8 @@
                                     variant="agenda"
                                     data-element-id="avonni-primitive-scheduler-event-occurrence"
                                     data-event-name={occurrence.event.name}
+                                    data-start={occurrence.from.ts}
+                                    data-end={occurrence.to.ts}
                                     oncontextmenu={stopPropagation}
                                     onprivatecontextmenu={handleEventContextMenu}
                                     onprivatedblclick={handleEventDoubleClick}

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
@@ -35,9 +35,9 @@
 <template>
     <div class="avonni-scheduler__wrapper">
         <c-splitter class="avonni-primitive-scheduler-calendar__inherit-height">
-            <!-- Left panel -->
+            <!-- Side panel: left position -->
             <c-splitter-pane
-                if:false={hideSidePanel}
+                if:true={showLeftPanel}
                 collapsible={allowCollapse}
                 resizable={allowResizeColumn}
                 scrollable
@@ -246,6 +246,46 @@
                             </div>
                         </div>
                     </template>
+                </div>
+            </c-splitter-pane>
+
+            <!-- Side panel: right position -->
+            <c-splitter-pane
+                if:true={showRightPanel}
+                collapsible={allowCollapse}
+                resizable={allowResizeColumn}
+                scrollable
+                size="310px"
+                data-element-id="avonni-splitter-pane-left"
+            >
+                <div
+                    class="slds-p-around_medium"
+                    data-element-id="div-panel-content"
+                >
+                    <c-calendar
+                        disabled-dates={navCalendarDisabledDates}
+                        value={selectedDate}
+                        data-element-id="avonni-calendar-left-panel"
+                        onchange={handleCalendarChange}
+                        onnavigate={handleLeftPanelCalendarNavigate}
+                    ></c-calendar>
+                    <div class="slds-m-top_medium">
+                        <template
+                            for:each={resourceOptions}
+                            for:item="resource"
+                        >
+                            <lightning-input
+                                key={resource.value}
+                                label={resource.label}
+                                checked={resource.selected}
+                                type="checkbox"
+                                value={resource.value}
+                                style={resource.style}
+                                data-element-id="lightning-input-resource"
+                                onchange={handleResourceToggle}
+                            ></lightning-input>
+                        </template>
+                    </div>
                 </div>
             </c-splitter-pane>
         </c-splitter>

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
@@ -33,266 +33,290 @@
 -->
 
 <template>
-    <div class="avonni-scheduler__wrapper">
-        <c-splitter class="avonni-primitive-scheduler-calendar__inherit-height">
-            <!-- Side panel: left position -->
-            <c-splitter-pane
-                if:true={showLeftPanel}
-                collapsible={allowCollapse}
-                resizable={allowResizeColumn}
-                scrollable
-                size="310px"
-                data-element-id="avonni-splitter-pane-left"
+    <div class="avonni-scheduler__wrapper slds-grid">
+        <!-- Side panel: left position -->
+        <div
+            if:true={showLeftPanel}
+            class={sidePanelClass}
+            data-element-id="div-panel"
+        >
+            <div
+                class="slds-p-around_medium"
+                data-element-id="div-panel-content"
             >
-                <div
-                    class="slds-p-around_medium"
-                    data-element-id="div-panel-content"
-                >
-                    <c-calendar
-                        disabled-dates={navCalendarDisabledDates}
-                        value={selectedDate}
-                        data-element-id="avonni-calendar-left-panel"
-                        onchange={handleCalendarChange}
-                        onnavigate={handleLeftPanelCalendarNavigate}
-                    ></c-calendar>
-                    <div
-                        if:false={hideResourcesFilter}
-                        class="slds-m-top_medium"
-                    >
-                        <template
-                            for:each={resourceOptions}
-                            for:item="resource"
-                        >
-                            <lightning-input
-                                key={resource.value}
-                                label={resource.label}
-                                checked={resource.selected}
-                                type="checkbox"
-                                value={resource.value}
-                                style={resource.style}
-                                data-element-id="lightning-input-resource"
-                                onchange={handleResourceToggle}
-                            ></lightning-input>
-                        </template>
-                    </div>
+                <c-calendar
+                    disabled-dates={navCalendarDisabledDates}
+                    value={selectedDate}
+                    data-element-id="avonni-calendar-left-panel"
+                    onchange={handleCalendarChange}
+                    onnavigate={handleLeftPanelCalendarNavigate}
+                ></c-calendar>
+                <div if:false={hideResourcesFilter} class="slds-m-top_medium">
+                    <template for:each={resourceOptions} for:item="resource">
+                        <lightning-input
+                            key={resource.value}
+                            label={resource.label}
+                            checked={resource.selected}
+                            type="checkbox"
+                            value={resource.value}
+                            style={resource.style}
+                            data-element-id="lightning-input-resource"
+                            onchange={handleResourceToggle}
+                        ></lightning-input>
+                    </template>
                 </div>
-            </c-splitter-pane>
-
-            <!-- Agenda panel -->
-            <c-splitter-pane
-                class={rightPanelClass}
-                collapsible={allowCollapse}
-                resizable={allowResizeColumn}
-                scrollable
-                style="
-                    flex: 1 1 0;
-                    margin: -1px 0;
-                    min-height: calc(100% + 2px);
+            </div>
+        </div>
+        <div
+            if:true={showLeftPanel}
+            class={splitterClass}
+            onmousedown={handleSplitterResizeMouseDown}
+        >
+            <lightning-button-icon
+                if:true={showSplitterCollapse}
+                alternative-text="Expand the right side"
+                icon-name="utility:left"
+                size="x-small"
+                variant="bare"
+                onclick={handleSplitterCollapse}
+                onmousedown={stopPropagation}
+            ></lightning-button-icon>
+            <div
+                if:true={showSplitterResize}
+                class="
+                    avonni-scheduler__splitter-resize-handle
+                    slds-m-vertical_x-small
                 "
-                data-element-id="avonni-splitter-pane-right"
             >
+                <span class="slds-assistive-text">Resize</span>
+            </div>
+            <lightning-button-icon
+                if:true={showSplitterExpand}
+                class="avonni-scheduler__splitter-expand-left-button"
+                alternative-text="Expand the left side"
+                icon-name="utility:right"
+                size="x-small"
+                variant="bare"
+                onclick={handleSplitterExpand}
+                onmousedown={stopPropagation}
+            ></lightning-button-icon>
+        </div>
+
+        <!-- Agenda panel -->
+        <div class={mainSectionClass}>
+            <div
+                class="avonni-primitive-scheduler-calendar__inherit-height"
+                data-element-id="div-schedule-body"
+            >
+                <!-- No result illustration -->
                 <div
-                    class="avonni-primitive-scheduler-calendar__inherit-height"
-                    data-element-id="div-schedule-body"
+                    if:false={computedGroups.length}
+                    class="
+                        avonni-scheduler__agenda-no-event-wrapper
+                        slds-grid_align-center
+                        slds-grid slds-grid_vertical-align-center
+                    "
                 >
-                    <!-- No result illustration -->
+                    <c-illustration
+                        class="slds-p-around_medium"
+                        variant="no-events"
+                        title="No events for the selected date."
+                        data-element-id="avonni-illustration-no-events"
+                    ></c-illustration>
+                </div>
+                <template for:each={computedGroups} for:item="group">
+                    <!-- Month heading -->
                     <div
-                        if:false={computedGroups.length}
+                        if:true={group.isFirstDayOfMonth}
+                        key={uniqueKey}
                         class="
-                            avonni-scheduler__agenda-no-event-wrapper
-                            slds-grid_align-center
-                            slds-grid slds-grid_vertical-align-center
+                            slds-p-vertical_medium
+                            slds-theme_shade
+                            vertical
+                            slds-text-title_caps
+                            slds-p-left_large
+                            slds-border_bottom
+                            avonni-scheduler__agenda-month-header
                         "
+                        data-element-id="div-month-heading"
                     >
-                        <c-illustration
-                            class="slds-p-around_medium"
-                            variant="no-events"
-                            title="No events for the selected date."
-                            data-element-id="avonni-illustration-no-events"
-                        ></c-illustration>
+                        {group.fullMonth}
                     </div>
-                    <template for:each={computedGroups} for:item="group">
-                        <!-- Month heading -->
+                    <div
+                        key={uniqueKey}
+                        class="
+                            slds-p-around_medium
+                            slds-grid
+                            slds-border_bottom
+                        "
+                        data-element-id="div-day-group"
+                        data-date={group.date.ts}
+                        oncontextmenu={handleEmptySpotContextMenu}
+                        ondblclick={handleDoubleClick}
+                    >
+                        <!-- Day heading -->
                         <div
-                            if:true={group.isFirstDayOfMonth}
-                            key={uniqueKey}
-                            class="
-                                slds-p-vertical_medium
-                                slds-theme_shade
-                                vertical
-                                slds-text-title_caps
-                                slds-p-left_large
-                                slds-border_bottom
-                                avonni-scheduler__agenda-month-header
-                            "
-                            data-element-id="div-month-heading"
+                            class="slds-m-right_large slds-col slds-size_1-of-5"
+                            data-element-id="div-day-heading"
                         >
-                            {group.fullMonth}
-                        </div>
-                        <div
-                            key={uniqueKey}
-                            class="
-                                slds-p-around_medium
-                                slds-grid
-                                slds-border_bottom
-                            "
-                            data-element-id="div-day-group"
-                            data-date={group.date.ts}
-                            oncontextmenu={handleEmptySpotContextMenu}
-                            ondblclick={handleDoubleClick}
-                        >
-                            <!-- Day heading -->
                             <div
                                 class="
-                                    slds-m-right_large
-                                    slds-col
-                                    slds-size_1-of-5
+                                    slds-grid slds-grid_vertical-align-center
                                 "
-                                data-element-id="div-day-heading"
+                            >
+                                <div class={group.dayClass} title={group.day}>
+                                    {group.day}
+                                </div>
+                                <div class="slds-text-title_caps slds-truncate">
+                                    <div
+                                        class="slds-truncate"
+                                        title={group.weekday}
+                                    >
+                                        {group.weekday}
+                                    </div>
+                                    <div
+                                        class="slds-truncate"
+                                        title={group.month}
+                                    >
+                                        {group.month} {group.year}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <!-- Day events -->
+                        <div class="slds-col">
+                            <div
+                                for:each={group.events}
+                                for:item="occurrence"
+                                key={occurrence.key}
+                                class="slds-grid slds-m-bottom_x-small"
                             >
                                 <div
                                     class="
-                                        slds-grid
-                                        slds-grid_vertical-align-center
+                                        slds-col
+                                        slds-size_1-of-5
+                                        slds-has-flexi-truncate
+                                        avonni-scheduler__agenda-time
                                     "
+                                    data-element-id="div-event-time"
                                 >
                                     <div
-                                        class={group.dayClass}
-                                        title={group.day}
-                                    >
-                                        {group.day}
-                                    </div>
-                                    <div
                                         class="
-                                            slds-text-title_caps
                                             slds-truncate
+                                            slds-text-color_weak
                                         "
+                                        title={occurrence.time}
                                     >
-                                        <div
-                                            class="slds-truncate"
-                                            title={group.weekday}
-                                        >
-                                            {group.weekday}
-                                        </div>
-                                        <div
-                                            class="slds-truncate"
-                                            title={group.month}
-                                        >
-                                            {group.month} {group.year}
-                                        </div>
+                                        {occurrence.time}
                                     </div>
                                 </div>
-                            </div>
-                            <!-- Day events -->
-                            <div class="slds-col">
-                                <div
-                                    for:each={group.events}
-                                    for:item="occurrence"
-                                    key={occurrence.key}
-                                    class="slds-grid slds-m-bottom_x-small"
-                                >
-                                    <div
-                                        class="
-                                            slds-col
-                                            slds-size_1-of-5
-                                            slds-has-flexi-truncate
-                                            avonni-scheduler__agenda-time
-                                        "
-                                        data-element-id="div-event-time"
-                                    >
-                                        <div
-                                            class="
-                                                slds-truncate
-                                                slds-text-color_weak
-                                            "
-                                            title={occurrence.time}
-                                        >
-                                            {occurrence.time}
-                                        </div>
-                                    </div>
-                                    <c-primitive-scheduler-event-occurrence
-                                        class="
-                                            slds-m-bottom_xx-small
-                                            avonni-scheduler__agenda-event
-                                            slds-show slds-col
-                                        "
-                                        color={occurrence.event.color}
-                                        date-format={dateFormat}
-                                        disabled={occurrence.event.disabled}
-                                        event-data={occurrence.event.data}
-                                        event-name={occurrence.event.name}
-                                        from={occurrence.from}
-                                        icon-name={occurrence.event.iconName}
-                                        labels={occurrence.event.labels}
-                                        occurrence={occurrence}
-                                        occurrence-key={occurrence.key}
-                                        reference-line={occurrence.event.referenceLine}
-                                        resource-key={occurrence.resourceName}
-                                        resources={computedResources}
-                                        title={occurrence.title}
-                                        theme={occurrence.event.theme}
-                                        to={occurrence.to}
-                                        variant="agenda"
-                                        data-element-id="avonni-primitive-scheduler-event-occurrence"
-                                        data-event-name={occurrence.event.name}
-                                        oncontextmenu={stopPropagation}
-                                        onprivatecontextmenu={handleEventContextMenu}
-                                        onprivatedblclick={handleEventDoubleClick}
-                                        onprivatedisabledcontextmenu={handleEmptySpotContextMenu}
-                                        onprivatedisableddblclick={handleDoubleClick}
-                                        onprivatefocus={handleEventFocus}
-                                        onprivatemouseenter={handleEventMouseEnter}
-                                        onprivatemouseleave={handleEventMouseLeave}
-                                    ></c-primitive-scheduler-event-occurrence>
-                                </div>
+                                <c-primitive-scheduler-event-occurrence
+                                    class="
+                                        slds-m-bottom_xx-small
+                                        avonni-scheduler__agenda-event
+                                        slds-show slds-col
+                                    "
+                                    color={occurrence.event.color}
+                                    date-format={dateFormat}
+                                    disabled={occurrence.event.disabled}
+                                    event-data={occurrence.event.data}
+                                    event-name={occurrence.event.name}
+                                    from={occurrence.from}
+                                    icon-name={occurrence.event.iconName}
+                                    labels={occurrence.event.labels}
+                                    occurrence={occurrence}
+                                    occurrence-key={occurrence.key}
+                                    reference-line={occurrence.event.referenceLine}
+                                    resource-key={occurrence.resourceName}
+                                    resources={computedResources}
+                                    title={occurrence.title}
+                                    theme={occurrence.event.theme}
+                                    to={occurrence.to}
+                                    variant="agenda"
+                                    data-element-id="avonni-primitive-scheduler-event-occurrence"
+                                    data-event-name={occurrence.event.name}
+                                    oncontextmenu={stopPropagation}
+                                    onprivatecontextmenu={handleEventContextMenu}
+                                    onprivatedblclick={handleEventDoubleClick}
+                                    onprivatedisabledcontextmenu={handleEmptySpotContextMenu}
+                                    onprivatedisableddblclick={handleDoubleClick}
+                                    onprivatefocus={handleEventFocus}
+                                    onprivatemouseenter={handleEventMouseEnter}
+                                    onprivatemouseleave={handleEventMouseLeave}
+                                ></c-primitive-scheduler-event-occurrence>
                             </div>
                         </div>
+                    </div>
+                </template>
+            </div>
+        </div>
+
+        <!-- Side panel: right position -->
+        <div
+            if:true={showRightPanel}
+            class={splitterClass}
+            onmousedown={handleSplitterResizeMouseDown}
+        >
+            <lightning-button-icon
+                if:true={showSplitterCollapse}
+                alternative-text="Expand the right side"
+                icon-name="utility:left"
+                size="x-small"
+                variant="bare"
+                onclick={handleSplitterCollapse}
+                onmousedown={stopPropagation}
+            ></lightning-button-icon>
+            <div
+                if:true={showSplitterResize}
+                class="
+                    avonni-scheduler__splitter-resize-handle
+                    slds-m-vertical_x-small
+                "
+            >
+                <span class="slds-assistive-text">Resize</span>
+            </div>
+            <lightning-button-icon
+                if:true={showSplitterExpand}
+                class="avonni-scheduler__splitter-expand-left-button"
+                alternative-text="Expand the left side"
+                icon-name="utility:right"
+                size="x-small"
+                variant="bare"
+                onclick={handleSplitterExpand}
+                onmousedown={stopPropagation}
+            ></lightning-button-icon>
+        </div>
+        <div
+            if:true={showRightPanel}
+            class={sidePanelClass}
+            data-element-id="div-panel"
+        >
+            <div
+                class="slds-p-around_medium"
+                data-element-id="div-panel-content"
+            >
+                <c-calendar
+                    disabled-dates={navCalendarDisabledDates}
+                    value={selectedDate}
+                    data-element-id="avonni-calendar-left-panel"
+                    onchange={handleCalendarChange}
+                    onnavigate={handleLeftPanelCalendarNavigate}
+                ></c-calendar>
+                <div if:false={hideResourcesFilter} class="slds-m-top_medium">
+                    <template for:each={resourceOptions} for:item="resource">
+                        <lightning-input
+                            key={resource.value}
+                            label={resource.label}
+                            checked={resource.selected}
+                            type="checkbox"
+                            value={resource.value}
+                            style={resource.style}
+                            data-element-id="lightning-input-resource"
+                            onchange={handleResourceToggle}
+                        ></lightning-input>
                     </template>
                 </div>
-            </c-splitter-pane>
-
-            <!-- Side panel: right position -->
-            <c-splitter-pane
-                if:true={showRightPanel}
-                collapsible={allowCollapse}
-                resizable={allowResizeColumn}
-                scrollable
-                size="310px"
-                data-element-id="avonni-splitter-pane-left"
-            >
-                <div
-                    class="slds-p-around_medium"
-                    data-element-id="div-panel-content"
-                >
-                    <c-calendar
-                        disabled-dates={navCalendarDisabledDates}
-                        value={selectedDate}
-                        data-element-id="avonni-calendar-left-panel"
-                        onchange={handleCalendarChange}
-                        onnavigate={handleLeftPanelCalendarNavigate}
-                    ></c-calendar>
-                    <div
-                        if:false={hideResourcesFilter}
-                        class="slds-m-top_medium"
-                    >
-                        <template
-                            for:each={resourceOptions}
-                            for:item="resource"
-                        >
-                            <lightning-input
-                                key={resource.value}
-                                label={resource.label}
-                                checked={resource.selected}
-                                type="checkbox"
-                                value={resource.value}
-                                style={resource.style}
-                                data-element-id="lightning-input-resource"
-                                onchange={handleResourceToggle}
-                            ></lightning-input>
-                        </template>
-                    </div>
-                </div>
-            </c-splitter-pane>
-        </c-splitter>
+            </div>
+        </div>
     </div>
 </template>

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
@@ -87,6 +87,7 @@
                 class="
                     avonni-scheduler__splitter-resize-handle
                     slds-m-vertical_x-small
+                    slds-m-horizontal_xx-small
                 "
                 data-element-id="div-splitter-resize-handle"
             >
@@ -278,6 +279,7 @@
                 class="
                     avonni-scheduler__splitter-resize-handle
                     slds-m-vertical_x-small
+                    slds-m-horizontal_xx-small
                 "
             >
                 <span class="slds-assistive-text">Resize</span>

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.html
@@ -37,6 +37,7 @@
         <c-splitter class="avonni-primitive-scheduler-calendar__inherit-height">
             <!-- Left panel -->
             <c-splitter-pane
+                if:false={hideSidePanel}
                 collapsible={allowCollapse}
                 resizable={allowResizeColumn}
                 scrollable
@@ -76,7 +77,7 @@
 
             <!-- Agenda panel -->
             <c-splitter-pane
-                class="slds-border_top slds-border_bottom slds-border_right"
+                class={rightPanelClass}
                 collapsible={allowCollapse}
                 resizable={allowResizeColumn}
                 scrollable

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
@@ -237,6 +237,21 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
     }
 
     /**
+     * Computed CSS classes for the right panel.
+     *
+     * @type {string}
+     */
+    get mainSectionClass() {
+        return classSet(
+            'slds-border_top slds-border_bottom slds-border_right avonni-scheduler__main-section slds-scrollable'
+        )
+            .add({
+                'slds-border_left': this.hideSidePanel
+            })
+            .toString();
+    }
+
+    /**
      * Computed resource options, displayed in the left panel as checkboxes.
      *
      * @type {object[]}
@@ -258,15 +273,11 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
         });
     }
 
-    /**
-     * Computed CSS classes for the right panel.
-     *
-     * @type {string}
-     */
-    get rightPanelClass() {
-        return classSet('slds-border_top slds-border_bottom slds-border_right')
+    get sidePanelClass() {
+        return classSet('avonni-scheduler__panel slds-scrollable')
             .add({
-                'slds-border_left': this.hideSidePanel
+                'avonni-scheduler__panel_collapsed': this._isCollapsed,
+                'avonni-scheduler__panel_expanded': this._isExpanded
             })
             .toString();
     }

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
@@ -243,10 +243,13 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
      */
     get mainSectionClass() {
         return classSet(
-            'avonni-scheduler__border_top avonni-scheduler__border_bottom avonni-scheduler__border_right avonni-scheduler__main-section slds-scrollable'
+            'avonni-scheduler__border_top avonni-scheduler__border_bottom avonni-scheduler__main-section slds-scrollable'
         )
             .add({
-                'avonni-scheduler__border_left': this.hideSidePanel
+                'avonni-scheduler__border_left':
+                    this.hideSidePanel || this.sidePanelPosition === 'right',
+                'avonni-scheduler__border_right':
+                    this.hideSidePanel || this.sidePanelPosition === 'left'
             })
             .toString();
     }

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
@@ -66,6 +66,7 @@ const SIDE_PANEL_POSITIONS = {
 export default class PrimitiveSchedulerAgenda extends ScheduleBase {
     _hideSidePanel = false;
     _selectedDate = dateTimeObjectFrom(DEFAULT_SELECTED_DATE);
+    _selectedResourcesReadOnly = false;
     _sidePanelPosition = SIDE_PANEL_POSITIONS.default;
 
     _computedEvents = [];
@@ -160,6 +161,21 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
             this.setStartToBeginningOfUnit();
             this.initLeftPanelCalendarDisabledDates();
         }
+    }
+
+    /**
+     * If present, it is not possible for the user to select or unselect resources.
+     *
+     * @type {boolean}
+     * @public
+     * @default false
+     */
+    @api
+    get selectedResourcesReadOnly() {
+        return this._selectedResourcesReadOnly;
+    }
+    set selectedResourcesReadOnly(value) {
+        this._selectedResourcesReadOnly = normalizeBoolean(value);
     }
 
     /**

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
@@ -243,10 +243,10 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
      */
     get mainSectionClass() {
         return classSet(
-            'slds-border_top slds-border_bottom slds-border_right avonni-scheduler__main-section slds-scrollable'
+            'avonni-scheduler__border_top avonni-scheduler__border_bottom avonni-scheduler__border_right avonni-scheduler__main-section slds-scrollable'
         )
             .add({
-                'slds-border_left': this.hideSidePanel
+                'avonni-scheduler__border_left': this.hideSidePanel
             })
             .toString();
     }
@@ -280,13 +280,15 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
      */
     get sidePanelClass() {
         return classSet(
-            'avonni-scheduler__panel slds-scrollable slds-border_top slds-border_bottom'
+            'avonni-scheduler__panel slds-scrollable avonni-scheduler__border_top avonni-scheduler__border_bottom'
         )
             .add({
                 'avonni-scheduler__panel_collapsed': this._isCollapsed,
                 'avonni-scheduler__panel_expanded': this._isExpanded,
-                'slds-border_left': this.sidePanelPosition === 'left',
-                'slds-border_right': this.sidePanelPosition === 'right'
+                'avonni-scheduler__border_left':
+                    this.sidePanelPosition === 'left',
+                'avonni-scheduler__border_right':
+                    this.sidePanelPosition === 'right'
             })
             .toString();
     }

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
@@ -34,7 +34,8 @@ import { api } from 'lwc';
 import {
     addToDate,
     dateTimeObjectFrom,
-    normalizeBoolean
+    normalizeBoolean,
+    normalizeString
 } from 'c/utilsPrivate';
 import { Interval } from 'c/luxon';
 import {
@@ -50,6 +51,10 @@ import DayGroup from './dayGroup';
 import { classSet } from 'c/utils';
 
 const DEFAULT_SELECTED_DATE = new Date();
+const SIDE_PANEL_POSITIONS = {
+    valid: ['left', 'right'],
+    default: 'left'
+};
 
 /**
  * Main part of the scheduler, when the selected display is "agenda".
@@ -61,6 +66,7 @@ const DEFAULT_SELECTED_DATE = new Date();
 export default class PrimitiveSchedulerAgenda extends ScheduleBase {
     _hideSidePanel = false;
     _selectedDate = dateTimeObjectFrom(DEFAULT_SELECTED_DATE);
+    _sidePanelPosition = SIDE_PANEL_POSITIONS.default;
 
     _computedEvents = [];
     computedGroups = [];
@@ -157,6 +163,24 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
     }
 
     /**
+     * Position of the side panel, relative to the schedule.
+     *
+     * @type {string}
+     * @default left
+     * @public
+     */
+    @api
+    get sidePanelPosition() {
+        return this._sidePanelPosition;
+    }
+    set sidePanelPosition(value) {
+        this._sidePanelPosition = normalizeString(value, {
+            fallbackValue: SIDE_PANEL_POSITIONS.default,
+            validValues: SIDE_PANEL_POSITIONS.valid
+        });
+    }
+
+    /**
      * Object used to set the duration of the timeline. It should have two keys:
      * * unit (minute, hour, day, week, month or year)
      * * span (number).
@@ -229,6 +253,24 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
                 'slds-border_left': this.hideSidePanel
             })
             .toString();
+    }
+
+    /**
+     * True if the left side panel should be visible.
+     *
+     * @type {boolean}
+     */
+    get showLeftPanel() {
+        return !this.hideSidePanel && this.sidePanelPosition === 'left';
+    }
+
+    /**
+     * True if the right side panel should be visible.
+     *
+     * @type {boolean}
+     */
+    get showRightPanel() {
+        return !this.hideSidePanel && this.sidePanelPosition === 'right';
     }
 
     /*

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
@@ -273,11 +273,20 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
         });
     }
 
+    /**
+     * Computed CSS classes for the side panel.
+     *
+     * @type {string}
+     */
     get sidePanelClass() {
-        return classSet('avonni-scheduler__panel slds-scrollable')
+        return classSet(
+            'avonni-scheduler__panel slds-scrollable slds-border_top slds-border_bottom'
+        )
             .add({
                 'avonni-scheduler__panel_collapsed': this._isCollapsed,
-                'avonni-scheduler__panel_expanded': this._isExpanded
+                'avonni-scheduler__panel_expanded': this._isExpanded,
+                'slds-border_left': this.sidePanelPosition === 'left',
+                'slds-border_right': this.sidePanelPosition === 'right'
             })
             .toString();
     }

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
@@ -64,9 +64,9 @@ const SIDE_PANEL_POSITIONS = {
  * @extends ScheduleBase
  */
 export default class PrimitiveSchedulerAgenda extends ScheduleBase {
+    _hideResourcesFilter = false;
     _hideSidePanel = false;
     _selectedDate = dateTimeObjectFrom(DEFAULT_SELECTED_DATE);
-    _selectedResourcesReadOnly = false;
     _sidePanelPosition = SIDE_PANEL_POSITIONS.default;
 
     _computedEvents = [];
@@ -127,6 +127,21 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
     }
 
     /**
+     * If present, the resources filter is hidden.
+     *
+     * @type {boolean}
+     * @public
+     * @default false
+     */
+    @api
+    get hideResourcesFilter() {
+        return this._hideResourcesFilter;
+    }
+    set hideResourcesFilter(value) {
+        this._hideResourcesFilter = normalizeBoolean(value);
+    }
+
+    /**
      * If present, the side panel will be hidden.
      *
      * @type {boolean}
@@ -161,21 +176,6 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
             this.setStartToBeginningOfUnit();
             this.initLeftPanelCalendarDisabledDates();
         }
-    }
-
-    /**
-     * If present, it is not possible for the user to select or unselect resources.
-     *
-     * @type {boolean}
-     * @public
-     * @default false
-     */
-    @api
-    get selectedResourcesReadOnly() {
-        return this._selectedResourcesReadOnly;
-    }
-    set selectedResourcesReadOnly(value) {
-        this._selectedResourcesReadOnly = normalizeBoolean(value);
     }
 
     /**

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
@@ -31,7 +31,11 @@
  */
 
 import { api } from 'lwc';
-import { addToDate, dateTimeObjectFrom } from 'c/utilsPrivate';
+import {
+    addToDate,
+    dateTimeObjectFrom,
+    normalizeBoolean
+} from 'c/utilsPrivate';
 import { Interval } from 'c/luxon';
 import {
     getElementOnYAxis,
@@ -43,6 +47,7 @@ import {
     ScheduleBase
 } from 'c/schedulerUtils';
 import DayGroup from './dayGroup';
+import { classSet } from 'c/utils';
 
 const DEFAULT_SELECTED_DATE = new Date();
 
@@ -54,6 +59,7 @@ const DEFAULT_SELECTED_DATE = new Date();
  * @extends ScheduleBase
  */
 export default class PrimitiveSchedulerAgenda extends ScheduleBase {
+    _hideSidePanel = false;
     _selectedDate = dateTimeObjectFrom(DEFAULT_SELECTED_DATE);
 
     _computedEvents = [];
@@ -111,6 +117,21 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
         if (this._connected) {
             this.setStartToBeginningOfUnit();
         }
+    }
+
+    /**
+     * If present, the side panel will be hidden.
+     *
+     * @type {boolean}
+     * @public
+     * @default false
+     */
+    @api
+    get hideSidePanel() {
+        return this._hideSidePanel;
+    }
+    set hideSidePanel(value) {
+        this._hideSidePanel = normalizeBoolean(value);
     }
 
     /**
@@ -195,6 +216,19 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
                 value: res.name
             };
         });
+    }
+
+    /**
+     * Computed CSS classes for the right panel.
+     *
+     * @type {string}
+     */
+    get rightPanelClass() {
+        return classSet('slds-border_top slds-border_bottom slds-border_right')
+            .add({
+                'slds-border_left': this.hideSidePanel
+            })
+            .toString();
     }
 
     /*

--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js-meta.xml
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js-meta.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>50.0</apiVersion>

--- a/src/modules/base/primitiveSchedulerCalendar/__tests__/primitiveSchedulerCalendar.test.js
+++ b/src/modules/base/primitiveSchedulerCalendar/__tests__/primitiveSchedulerCalendar.test.js
@@ -671,14 +671,15 @@ describe('Primitive Scheduler Calendar', () => {
         element.collapseDisabled = false;
 
         return Promise.resolve().then(() => {
-            const leftPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-left"]'
+            const collapseButton = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button-icon-splitter-collapse"]'
             );
-            const rightPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-right"]'
+            const expandButton = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button-icon-splitter-expand"]'
             );
-            expect(leftPanel.collapsible).toBeTruthy();
-            expect(rightPanel.collapsible).toBeTruthy();
+
+            expect(collapseButton).toBeTruthy();
+            expect(expandButton).toBeTruthy();
         });
     });
 
@@ -686,14 +687,15 @@ describe('Primitive Scheduler Calendar', () => {
         element.collapseDisabled = true;
 
         return Promise.resolve().then(() => {
-            const leftPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-left"]'
+            const collapseButton = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button-icon-splitter-collapse"]'
             );
-            const rightPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-right"]'
+            const expandButton = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button-icon-splitter-expand"]'
             );
-            expect(leftPanel.collapsible).toBeFalsy();
-            expect(rightPanel.collapsible).toBeFalsy();
+
+            expect(collapseButton).toBeFalsy();
+            expect(expandButton).toBeFalsy();
         });
     });
 
@@ -1335,14 +1337,10 @@ describe('Primitive Scheduler Calendar', () => {
         element.resizeColumnDisabled = false;
 
         return Promise.resolve().then(() => {
-            const leftPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-left"]'
+            const resizeHandle = element.shadowRoot.querySelector(
+                '[data-element-id="div-splitter-resize-handle"]'
             );
-            const rightPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-right"]'
-            );
-            expect(leftPanel.resizable).toBeTruthy();
-            expect(rightPanel.resizable).toBeTruthy();
+            expect(resizeHandle).toBeTruthy();
         });
     });
 
@@ -1350,14 +1348,10 @@ describe('Primitive Scheduler Calendar', () => {
         element.resizeColumnDisabled = true;
 
         return Promise.resolve().then(() => {
-            const leftPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-left"]'
+            const resizeHandle = element.shadowRoot.querySelector(
+                '[data-element-id="div-splitter-resize-handle"]'
             );
-            const rightPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-right"]'
-            );
-            expect(leftPanel.resizable).toBeFalsy();
-            expect(rightPanel.resizable).toBeFalsy();
+            expect(resizeHandle).toBeFalsy();
         });
     });
 
@@ -2076,14 +2070,19 @@ describe('Primitive Scheduler Calendar', () => {
                 '[data-element-id="div-column"]'
             );
             const cell = column.querySelector('[data-element-id="div-cell"]');
+            const from = Number(cell.dataset.start);
+            const to = Number(cell.dataset.end);
             const event = new CustomEvent('contextmenu');
             event.clientX = 283;
             event.clientY = 38;
             cell.dispatchEvent(event);
+
             expect(handler).toHaveBeenCalled();
             const call = handler.mock.calls[0][0];
-            expect(call.detail.selection.y).toBe(38);
-            expect(call.detail.selection.x).toBe(283);
+            expect(new Date(call.detail.from).getTime()).toBe(from);
+            expect(new Date(call.detail.to).getTime()).toBe(to);
+            expect(call.detail.y).toBe(38);
+            expect(call.detail.x).toBe(283);
             expect(call.bubbles).toBeFalsy();
             expect(call.cancelable).toBeFalsy();
             expect(call.composed).toBeFalsy();
@@ -2753,6 +2752,44 @@ describe('Primitive Scheduler Calendar', () => {
             });
     });
 
+    it('Primitive Scheduler Calendar: eventmouseleave', () => {
+        element.resources = RESOURCES;
+        element.selectedResources = ALL_RESOURCES;
+        element.selectedDate = SELECTED_DATE;
+        element.events = SELECTED_DATE_EVENTS;
+
+        const handler = jest.fn();
+        element.addEventListener('eventmouseleave', handler);
+
+        return Promise.resolve()
+            .then(() => {
+                // Wait for the visible interval to be set
+            })
+            .then(() => {
+                const event = element.shadowRoot.querySelector(
+                    '[data-element-id="avonni-primitive-scheduler-event-occurrence-main-grid"]'
+                );
+                const detail = {
+                    eventName: 'some name',
+                    key: 'some key',
+                    x: 34,
+                    y: 56
+                };
+                event.dispatchEvent(
+                    new CustomEvent('privatemouseleave', {
+                        detail
+                    })
+                );
+
+                expect(handler).toHaveBeenCalledTimes(1);
+                const call = handler.mock.calls[0][0];
+                expect(call.detail).toEqual(detail);
+                expect(call.bubbles).toBeFalsy();
+                expect(call.composed).toBeFalsy();
+                expect(call.cancelable).toBeFalsy();
+            });
+    });
+
     // eventselect
     it('Primitive Scheduler Calendar: eventselect', () => {
         element.resources = RESOURCES;
@@ -2799,40 +2836,6 @@ describe('Primitive Scheduler Calendar', () => {
     });
 
     // hidepopovers
-    it('Primitive Scheduler Calendar: hidepopovers on event mouse leave and blur', () => {
-        element.resources = RESOURCES;
-        element.selectedResources = ALL_RESOURCES;
-        element.selectedDate = SELECTED_DATE;
-        element.events = SELECTED_DATE_EVENTS;
-
-        const handler = jest.fn();
-        element.addEventListener('hidepopovers', handler);
-
-        return Promise.resolve()
-            .then(() => {
-                // Wait for the visible interval to be set
-            })
-            .then(() => {
-                const event = element.shadowRoot.querySelector(
-                    '[data-element-id="avonni-primitive-scheduler-event-occurrence-main-grid"]'
-                );
-                event.dispatchEvent(new CustomEvent('privatemouseleave'));
-
-                expect(handler).toHaveBeenCalledTimes(1);
-                const call = handler.mock.calls[0][0];
-                expect(call.detail.list).toEqual(['detail']);
-                expect(call.bubbles).toBeFalsy();
-                expect(call.composed).toBeFalsy();
-                expect(call.cancelable).toBeFalsy();
-
-                event.dispatchEvent(new CustomEvent('privateblur'));
-                expect(handler).toHaveBeenCalledTimes(2);
-                expect(handler.mock.calls[1][0].detail.list).toEqual([
-                    'detail'
-                ]);
-            });
-    });
-
     it('Primitive Scheduler Calendar: hidepopovers on event double click', () => {
         element.resources = RESOURCES;
         element.selectedResources = ALL_RESOURCES;

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.css
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.css
@@ -87,6 +87,10 @@
     position: sticky;
     top: 0;
     z-index: 2;
+    --avonni-primitive-scheduler-header-group-cell-text-color-today: var(
+        --lwc-brandAccessible,
+        #0176d3
+    );
 }
 
 .avonni-scheduler__calendar-day-header-wrapper:not(.avonni-scheduler__calendar-day-header-wrapper_month) {

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.css
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.css
@@ -93,13 +93,6 @@
     border-bottom: 2px solid #c9c9c9;
 }
 
-.avonni-scheduler__calendar-time-zone {
-    color: var(--lwc-colorTextPlaceholder, #747474);
-    font-size: 11px;
-    height: 2.5rem;
-    text-transform: uppercase;
-}
-
 .avonni-scheduler__calendar-show-more-popover {
     --slds-c-popover-position-zindex: 5;
     min-width: var(--lwc-sizeXSmall, 12rem);

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.css
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.css
@@ -34,7 +34,7 @@
 
 .avonni-scheduler__wrapper {
     max-height: 100%;
-    height: calc(100vh - 70px);
+    height: calc(100vh - var(--avonni-scheduler-toolbar-height, 70px));
     max-width: 100%;
 }
 

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.css
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.css
@@ -64,7 +64,7 @@
 }
 
 .avonni-scheduler__calendar-cell_outside-of-current-month {
-    color: #adadad;
+    background-color: var(--lwc-colorBackground, #f3f3f3);
 }
 
 .avonni-primitive-scheduler-calendar__inherit-height {
@@ -75,9 +75,8 @@
 
 .avonni-scheduler__calendar-header {
     --avonni-primitive-scheduler-header-group-cell-color-background: #fff;
-    --avonni-primitive-scheduler-header-group-cell-spacing-block-start: 0.5rem;
-    --avonni-primitive-scheduler-header-group-cell-spacing-block-end: 0.5rem;
-    --avonni-primitive-scheduler-header-group-cell-color-border: transparent;
+    --avonni-primitive-scheduler-header-group-cell-height: 2.5rem;
+    --avonni-primitive-scheduler-header-group-cell-border-right-width: 0;
 }
 
 .avonni-scheduler__calendar-day-header-wrapper {
@@ -85,24 +84,16 @@
     top: 0;
     z-index: 2;
 }
-.avonni-scheduler__calendar-day-header-wrapper::before {
-    content: '';
-    background-image: linear-gradient(to right, white, rgba(255, 255, 255, 0));
-    height: 2px;
-    left: 0;
-    bottom: -1px;
-    position: absolute;
-    width: 80px;
-    z-index: 3;
+
+.avonni-scheduler__calendar-day-header-wrapper:not(.avonni-scheduler__calendar-day-header-wrapper_month) {
+    border-bottom: 2px solid #c9c9c9;
 }
-.avonni-scheduler__calendar-day-header-wrapper::after {
-    box-shadow: inset 0 1px 1px 0 rgb(0 0 0 / 14%),
-        inset 0 2px 1px -1px rgb(0 0 0 / 12%);
-    content: '';
-    position: absolute;
-    left: 0;
-    width: 100%;
-    height: 4px;
+
+.avonni-scheduler__calendar-time-zone {
+    color: var(--lwc-colorTextPlaceholder, #747474);
+    font-size: 11px;
+    height: 2.5rem;
+    text-transform: uppercase;
 }
 
 .avonni-scheduler__calendar-show-more-popover {
@@ -117,4 +108,22 @@
 .avonni-scheduler__calendar-show-more-popover-close-button {
     top: 0;
     right: 0;
+}
+
+.avonni-scheduler__calendar-month-grid .avonni-scheduler__calendar-cell {
+    border-right-color: var(--lwc-colorBorder, #e5e5e5);
+    border-bottom-color: #c9c9c9;
+}
+
+.avonni-scheduler__calendar-month-grid .avonni-scheduler__calendar-cell_today {
+    border: 1px solid var(--lwc-colorBorderRowSelected, #0176d3);
+}
+
+.avonni-scheduler__calendar-cell:last-of-type {
+    border-bottom: none;
+}
+
+.avonni-scheduler__calendar-column:nth-child(7)
+    .avonni-scheduler__calendar-cell {
+    border-right: none;
 }

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.css
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.css
@@ -30,10 +30,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@import 'c/schedulerSharedStyle';
+
 .avonni-scheduler__wrapper {
     max-height: 100%;
     height: calc(100vh - 70px);
     max-width: 100%;
+}
+
+.avonni-scheduler__panel {
+    width: 310px;
+}
+
+.avonni-scheduler__main-section {
+    flex: 1 1 0;
 }
 
 .avonni-scheduler__calendar-column {

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.css
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.css
@@ -67,6 +67,10 @@
     background-color: var(--lwc-colorBackground, #f3f3f3);
 }
 
+.avonni-scheduler__calendar-cell-multi-day:last-of-type {
+    border-right: none;
+}
+
 .avonni-primitive-scheduler-calendar__inherit-height {
     height: inherit;
     min-height: inherit;
@@ -124,6 +128,7 @@
 }
 
 .avonni-scheduler__calendar-column:nth-child(7)
-    .avonni-scheduler__calendar-cell {
+    .avonni-scheduler__calendar-cell,
+.avonni-scheduler__calendar-column_day .avonni-scheduler__calendar-cell {
     border-right: none;
 }

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -172,7 +172,7 @@
                                         <div
                                             key={cell.start}
                                             class="
-                                                slds-col
+                                                avonni-scheduler__flex-col
                                                 slds-border_right
                                                 avonni-primitive-scheduler-calendar__inherit-height
                                             "
@@ -238,7 +238,7 @@
                             </div>
                         </div>
                         <div
-                            class="slds-grid slds-col"
+                            class="slds-grid avonni-scheduler__flex-col"
                             data-element-id="div-cells-grid"
                         >
                             <!-- Hours -->
@@ -255,7 +255,7 @@
                                 onprivatecellsizechange={handleHeaderCellSizeChange}
                                 onprivateheaderchange={handleVerticalHeaderChange}
                             ></c-primitive-scheduler-header-group>
-                            <div class="slds-col">
+                            <div class="avonni-scheduler__flex-col">
                                 <div
                                     class="
                                         slds-is-relative slds-grid
@@ -311,7 +311,11 @@
                                                             {cell.day}
                                                         </div>
                                                         <!-- Placeholders used to take space in cells the multi-day events go through -->
-                                                        <div class="slds-col">
+                                                        <div
+                                                            class="
+                                                                avonni-scheduler__flex-col
+                                                            "
+                                                        >
                                                             <template
                                                                 for:each={cell.placeholders}
                                                                 for:item="placeholder"

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -197,6 +197,7 @@
                                                 class="
                                                     avonni-scheduler__flex-col
                                                     avonni-scheduler__border_right
+                                                    avonni-scheduler__calendar-cell-multi-day
                                                     avonni-primitive-scheduler-calendar__inherit-height
                                                 "
                                                 data-element-id="div-cell"
@@ -297,9 +298,7 @@
                                     >
                                         <div
                                             key={column.start.ts}
-                                            class="
-                                                avonni-scheduler__calendar-column
-                                            "
+                                            class={columnClass}
                                             data-element-id="div-column"
                                             data-index={index}
                                         >

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -575,7 +575,7 @@
         <div
             if:true={showMorePopover}
             class="
-                slds-is-fixed slds-dropdown
+                slds-is-absolute slds-dropdown
                 avonni-scheduler__calendar-show-more-popover
             "
             role="tooltip"

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -64,7 +64,10 @@
                         onnavigate={handleLeftPanelCalendarNavigate}
                     ></c-calendar>
 
-                    <div class="slds-m-top_medium">
+                    <div
+                        if:false={selectedResourcesReadOnly}
+                        class="slds-m-top_medium"
+                    >
                         <template
                             for:each={resourceOptions}
                             for:item="resource"
@@ -494,7 +497,10 @@
                         onnavigate={handleLeftPanelCalendarNavigate}
                     ></c-calendar>
 
-                    <div class="slds-m-top_medium">
+                    <div
+                        if:false={selectedResourcesReadOnly}
+                        class="slds-m-top_medium"
+                    >
                         <template
                             for:each={resourceOptions}
                             for:item="resource"

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -96,6 +96,7 @@
                     icon-name="utility:left"
                     size="x-small"
                     variant="bare"
+                    data-element-id="lightning-button-icon-splitter-collapse"
                     onclick={handleSplitterCollapse}
                     onmousedown={stopPropagation}
                 ></lightning-button-icon>
@@ -105,6 +106,7 @@
                         avonni-scheduler__splitter-resize-handle
                         slds-m-vertical_x-small
                     "
+                    data-element-id="div-splitter-resize-handle"
                 >
                     <span class="slds-assistive-text">Resize</span>
                 </div>
@@ -115,6 +117,7 @@
                     icon-name="utility:right"
                     size="x-small"
                     variant="bare"
+                    data-element-id="lightning-button-icon-splitter-expand"
                     onclick={handleSplitterExpand}
                     onmousedown={stopPropagation}
                 ></lightning-button-icon>

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -202,11 +202,10 @@
                                             data-event-name={event.name}
                                             data-key={occurrence.key}
                                             onprivatefocus={handleEventFocus}
-                                            onprivateblur={handleHideDetailPopover}
                                             onprivatecontextmenu={handleEventContextMenu}
                                             onprivatedisabledcontextmenu={handleEmptySpotContextMenu}
                                             onprivatemouseenter={handleEventMouseEnter}
-                                            onprivatemouseleave={handleHideDetailPopover}
+                                            onprivatemouseleave={handleEventMouseLeave}
                                             onprivatedblclick={handleEventDoubleClick}
                                             onprivatedisableddblclick={handleDoubleClick}
                                             onprivatemousedown={handleMultiDayEventMouseDown}
@@ -334,13 +333,12 @@
                                                                     data-month={cell.month}
                                                                     data-week-number={cell.weekNumber}
                                                                     oncontextmenu={stopPropagation}
-                                                                    onprivateblur={handleHideDetailPopover}
                                                                     onprivatecontextmenu={handleEventContextMenu}
                                                                     onprivatedisabledcontextmenu={handleEmptySpotContextMenu}
                                                                     onprivatedblclick={handleEventDoubleClick}
                                                                     onprivatefocus={handleEventFocus}
                                                                     onprivatemouseenter={handleEventMouseEnter}
-                                                                    onprivatemouseleave={handleHideDetailPopover}
+                                                                    onprivatemouseleave={handleEventMouseLeave}
                                                                     onprivatemousedown={handlePlaceholderMouseDown}
                                                                 ></c-primitive-scheduler-event-occurrence>
                                                             </template>
@@ -412,12 +410,11 @@
                                                     data-day={occurrence.firstAllowedDate.day}
                                                     data-month={occurrence.firstAllowedDate.month}
                                                     data-weekday={occurrence.firstAllowedWeekday}
-                                                    onprivateblur={handleHideDetailPopover}
                                                     onprivatefocus={handleEventFocus}
                                                     onprivatecontextmenu={handleEventContextMenu}
                                                     onprivatedisabledcontextmenu={handleEmptySpotContextMenu}
                                                     onprivatemouseenter={handleEventMouseEnter}
-                                                    onprivatemouseleave={handleHideDetailPopover}
+                                                    onprivatemouseleave={handleEventMouseLeave}
                                                     onprivatedblclick={handleEventDoubleClick}
                                                     onprivatedisableddblclick={handleDoubleClick}
                                                     onprivatemousedown={handleEventMouseDown}

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -43,9 +43,9 @@
             data-element-id="avonni-splitter"
             onprivateslotchange={handleSplitterSlotChange}
         >
-            <!-- Left panel -->
+            <!-- Side panel: left position-->
             <c-splitter-pane
-                if:false={hideSidePanel}
+                if:true={showLeftPanel}
                 collapsible={allowCollapse}
                 resizable={allowResizeColumn}
                 scrollable
@@ -470,6 +470,47 @@
                             ></c-calendar>
                         </div>
                     </template>
+                </div>
+            </c-splitter-pane>
+
+            <!-- Side panel: right position-->
+            <c-splitter-pane
+                if:true={showRightPanel}
+                collapsible={allowCollapse}
+                resizable={allowResizeColumn}
+                scrollable
+                size="310px"
+                data-element-id="avonni-splitter-pane-right"
+            >
+                <div
+                    class="slds-p-around_medium"
+                    data-element-id="div-panel-content"
+                >
+                    <c-calendar
+                        disabled-dates={navCalendarDisabledDates}
+                        value={selectedDate}
+                        data-element-id="avonni-calendar-left-panel"
+                        onchange={handleCalendarChange}
+                        onnavigate={handleLeftPanelCalendarNavigate}
+                    ></c-calendar>
+
+                    <div class="slds-m-top_medium">
+                        <template
+                            for:each={resourceOptions}
+                            for:item="resource"
+                        >
+                            <lightning-input
+                                key={resource.value}
+                                label={resource.label}
+                                checked={resource.selected}
+                                type="checkbox"
+                                value={resource.value}
+                                style={resource.style}
+                                data-element-id="lightning-input-resource"
+                                onchange={handleResourceToggle}
+                            ></lightning-input>
+                        </template>
+                    </div>
                 </div>
             </c-splitter-pane>
         </c-splitter>

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -145,7 +145,7 @@
                                         avonni-scheduler__border_bottom
                                         slds-truncate
                                         slds-text-color_weak
-                                        avonni-scheduler__calendar-time-zone
+                                        avonni-scheduler__time-zone
                                         slds-grid
                                         slds-grid_vertical-align-center
                                     "
@@ -155,7 +155,8 @@
                                             avonni-scheduler__flex-col
                                             slds-text-align_center
                                         "
-                                    ></span>
+                                        >{timezoneLabel}</span
+                                    >
                                 </div>
                             </div>
                             <div class="avonni-scheduler__flex-col">
@@ -183,6 +184,7 @@
                                     data-element-id="div-multi-day-events-wrapper"
                                 >
                                     <div
+                                        if:true={multiDayEventsCellGroup.cells}
                                         class="
                                             slds-grid
                                             avonni-primitive-scheduler-calendar__inherit-height

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -45,6 +45,7 @@
         >
             <!-- Left panel -->
             <c-splitter-pane
+                if:false={hideSidePanel}
                 collapsible={allowCollapse}
                 resizable={allowResizeColumn}
                 scrollable
@@ -84,7 +85,7 @@
             </c-splitter-pane>
 
             <c-splitter-pane
-                class="slds-border_top slds-border_bottom"
+                class={rightPanelClass}
                 collapsible={allowCollapse}
                 resizable={allowResizeColumn}
                 scrollable

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -131,123 +131,147 @@
                     <!-- Day, week and month schedule -->
                     <template if:false={isYear}>
                         <div
-                            class="
-                                avonni-scheduler__calendar-day-header-wrapper
-                                slds-theme_default
-                                slds-is-relative
-                            "
+                            class={horizontalHeaderWrapperClass}
                             data-element-id="div-horizontal-header-wrapper"
                         >
-                            <!-- Day(s) header -->
-                            <c-primitive-scheduler-header-group
-                                class={dayHeadersClass}
-                                available-days-of-the-week={availableDaysOfTheWeek}
-                                headers={dayHeaders}
-                                start={start}
-                                time-span={dayHeadersTimeSpan}
-                                visible-width={dayHeadersVisibleWidth}
-                                zoom-to-fit
-                                data-element-id="avonni-primitive-scheduler-header-group-horizontal"
-                                onprivatecellsizechange={handleHeaderCellSizeChange}
-                                onprivateheaderchange={handleHorizontalHeaderChange}
-                            ></c-primitive-scheduler-header-group>
-                            <!-- Day and week multi day events grid -->
+                            <!-- First column -->
                             <div
-                                if:true={showTopMultiDayEvents}
-                                class="
-                                    slds-border_left
-                                    slds-is-relative
-                                    avonni-scheduler__calendar-multi-day-wrapper
-                                "
-                                data-element-id="div-multi-day-events-wrapper"
+                                if:false={isMonth}
+                                data-element-id="div-horizontal-header-first-column"
                             >
                                 <div
                                     class="
+                                        avonni-scheduler__border_bottom
+                                        slds-truncate
+                                        slds-text-color_weak
+                                        avonni-scheduler__calendar-time-zone
                                         slds-grid
-                                        avonni-primitive-scheduler-calendar__inherit-height
+                                        slds-grid_vertical-align-center
                                     "
                                 >
-                                    <!-- Cells -->
-                                    <template
-                                        for:each={multiDayEventsCellGroup.cells}
-                                        for:item="cell"
+                                    <span
+                                        class="
+                                            avonni-scheduler__flex-col
+                                            slds-text-align_center
+                                        "
+                                    ></span>
+                                </div>
+                            </div>
+                            <div class="avonni-scheduler__flex-col">
+                                <!-- Day(s) header -->
+                                <c-primitive-scheduler-header-group
+                                    class="avonni-scheduler__calendar-header"
+                                    available-days-of-the-week={availableDaysOfTheWeek}
+                                    headers={dayHeaders}
+                                    start={start}
+                                    time-span={dayHeadersTimeSpan}
+                                    visible-width={dayHeadersVisibleWidth}
+                                    zoom-to-fit
+                                    data-element-id="avonni-primitive-scheduler-header-group-horizontal"
+                                    onprivatecellsizechange={handleHeaderCellSizeChange}
+                                    onprivateheaderchange={handleHorizontalHeaderChange}
+                                ></c-primitive-scheduler-header-group>
+                                <!-- Day and week multi day events grid -->
+                                <div
+                                    if:false={isMonth}
+                                    class="
+                                        avonni-scheduler__border_left
+                                        slds-is-relative
+                                        avonni-scheduler__calendar-multi-day-wrapper
+                                    "
+                                    data-element-id="div-multi-day-events-wrapper"
+                                >
+                                    <div
+                                        class="
+                                            slds-grid
+                                            avonni-primitive-scheduler-calendar__inherit-height
+                                        "
                                     >
-                                        <div
-                                            key={cell.start}
-                                            class="
-                                                avonni-scheduler__flex-col
-                                                slds-border_right
-                                                avonni-primitive-scheduler-calendar__inherit-height
-                                            "
-                                            data-element-id="div-cell"
-                                            data-end={cell.end}
-                                            data-start={cell.start}
-                                            oncontextmenu={handleEmptySpotContextMenu}
-                                            onmousedown={handleMultiDayEmptyCellMouseDown}
-                                            ondblclick={handleDoubleClick}
-                                        ></div>
+                                        <!-- Cells -->
+                                        <template
+                                            for:each={multiDayEventsCellGroup.cells}
+                                            for:item="cell"
+                                        >
+                                            <div
+                                                key={cell.start}
+                                                class="
+                                                    avonni-scheduler__flex-col
+                                                    avonni-scheduler__border_right
+                                                    avonni-primitive-scheduler-calendar__inherit-height
+                                                "
+                                                data-element-id="div-cell"
+                                                data-end={cell.end}
+                                                data-start={cell.start}
+                                                oncontextmenu={handleEmptySpotContextMenu}
+                                                onmousedown={handleMultiDayEmptyCellMouseDown}
+                                                ondblclick={handleDoubleClick}
+                                            ></div>
+                                        </template>
+                                    </div>
+                                    <!-- Multi day events -->
+                                    <template
+                                        for:each={multiDayEvents}
+                                        for:item="event"
+                                    >
+                                        <template
+                                            for:each={event.occurrences}
+                                            for:item="occurrence"
+                                        >
+                                            <c-primitive-scheduler-event-occurrence
+                                                key={occurrence.key}
+                                                class="slds-is-absolute"
+                                                color={event.color}
+                                                header-cells={multiDayEventHeaderCells}
+                                                cell-duration={dayCellDuration}
+                                                cell-height={multiDayCellHeight}
+                                                cell-width={cellWidth}
+                                                date-format={dateFormat}
+                                                disabled={event.disabled}
+                                                event-data={event.data}
+                                                event-name={event.name}
+                                                from={occurrence.startOfFrom}
+                                                icon-name={event.iconName}
+                                                labels={event.labels}
+                                                occurrence={occurrence}
+                                                occurrence-key={occurrence.key}
+                                                read-only={multiDayEventReadOnly}
+                                                resource-key={occurrence.resourceName}
+                                                resources={computedResources}
+                                                title={occurrence.title}
+                                                theme={event.theme}
+                                                to={occurrence.endOfTo}
+                                                variant="calendar-horizontal"
+                                                zoom-to-fit={zoomToFit}
+                                                data-disabled={event.disabled}
+                                                data-element-id="avonni-primitive-scheduler-event-occurrence-multi-day"
+                                                data-event-name={event.name}
+                                                data-key={occurrence.key}
+                                                onprivatefocus={handleEventFocus}
+                                                onprivatecontextmenu={handleEventContextMenu}
+                                                onprivatedisabledcontextmenu={handleEmptySpotContextMenu}
+                                                onprivatemouseenter={handleEventMouseEnter}
+                                                onprivatemouseleave={handleEventMouseLeave}
+                                                onprivatedblclick={handleEventDoubleClick}
+                                                onprivatedisableddblclick={handleDoubleClick}
+                                                onprivatemousedown={handleMultiDayEventMouseDown}
+                                                onprivatedisabledmousedown={handleMultiDayEmptyCellMouseDown}
+                                            ></c-primitive-scheduler-event-occurrence>
+                                        </template>
                                     </template>
                                 </div>
-                                <!-- Multi day events -->
-                                <template
-                                    for:each={multiDayEvents}
-                                    for:item="event"
-                                >
-                                    <template
-                                        for:each={event.occurrences}
-                                        for:item="occurrence"
-                                    >
-                                        <c-primitive-scheduler-event-occurrence
-                                            key={occurrence.key}
-                                            class="slds-is-absolute"
-                                            color={event.color}
-                                            header-cells={multiDayEventHeaderCells}
-                                            cell-duration={dayCellDuration}
-                                            cell-height={multiDayCellHeight}
-                                            cell-width={cellWidth}
-                                            date-format={dateFormat}
-                                            disabled={event.disabled}
-                                            event-data={event.data}
-                                            event-name={event.name}
-                                            from={occurrence.startOfFrom}
-                                            icon-name={event.iconName}
-                                            labels={event.labels}
-                                            occurrence={occurrence}
-                                            occurrence-key={occurrence.key}
-                                            read-only={multiDayEventReadOnly}
-                                            resource-key={occurrence.resourceName}
-                                            resources={computedResources}
-                                            title={occurrence.title}
-                                            theme={event.theme}
-                                            to={occurrence.endOfTo}
-                                            variant="calendar-horizontal"
-                                            zoom-to-fit={zoomToFit}
-                                            data-disabled={event.disabled}
-                                            data-element-id="avonni-primitive-scheduler-event-occurrence-multi-day"
-                                            data-event-name={event.name}
-                                            data-key={occurrence.key}
-                                            onprivatefocus={handleEventFocus}
-                                            onprivatecontextmenu={handleEventContextMenu}
-                                            onprivatedisabledcontextmenu={handleEmptySpotContextMenu}
-                                            onprivatemouseenter={handleEventMouseEnter}
-                                            onprivatemouseleave={handleEventMouseLeave}
-                                            onprivatedblclick={handleEventDoubleClick}
-                                            onprivatedisableddblclick={handleDoubleClick}
-                                            onprivatemousedown={handleMultiDayEventMouseDown}
-                                            onprivatedisabledmousedown={handleMultiDayEmptyCellMouseDown}
-                                        ></c-primitive-scheduler-event-occurrence>
-                                    </template>
-                                </template>
                             </div>
                         </div>
                         <div
-                            class="slds-grid avonni-scheduler__flex-col"
+                            class={cellsGridClass}
                             data-element-id="div-cells-grid"
                         >
                             <!-- Hours -->
                             <c-primitive-scheduler-header-group
                                 if:true={showHourHeaders}
-                                class="avonni-scheduler__calendar-header"
+                                class="
+                                    avonni-scheduler__calendar-header
+                                    avonni-scheduler__border_right
+                                "
                                 available-time-frames={availableTimeFrames}
                                 headers={hourHeaders}
                                 start={start}

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -65,7 +65,7 @@
                     ></c-calendar>
 
                     <div
-                        if:false={selectedResourcesReadOnly}
+                        if:false={hideResourcesFilter}
                         class="slds-m-top_medium"
                     >
                         <template
@@ -495,7 +495,7 @@
                     ></c-calendar>
 
                     <div
-                        if:false={selectedResourcesReadOnly}
+                        if:false={hideResourcesFilter}
                         class="slds-m-top_medium"
                     >
                         <template

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -38,19 +38,18 @@
         data-element-id="div-wrapper"
         onmousemove={handleMouseMove}
     >
-        <c-splitter
-            class="avonni-primitive-scheduler-calendar__inherit-height"
-            data-element-id="avonni-splitter"
-            onprivateslotchange={handleSplitterSlotChange}
+        <div
+            class="
+                avonni-primitive-scheduler-calendar__inherit-height
+                slds-grid
+            "
+            data-element-id="div-main-wrapper"
         >
             <!-- Side panel: left position-->
-            <c-splitter-pane
+            <div
                 if:true={showLeftPanel}
-                collapsible={allowCollapse}
-                resizable={allowResizeColumn}
-                scrollable
-                size="310px"
-                data-element-id="avonni-splitter-pane-left"
+                class={sidePanelClass}
+                data-element-id="div-panel"
             >
                 <div
                     class="slds-p-around_medium"
@@ -85,20 +84,43 @@
                         </template>
                     </div>
                 </div>
-            </c-splitter-pane>
-
-            <c-splitter-pane
-                class={rightPanelClass}
-                collapsible={allowCollapse}
-                resizable={allowResizeColumn}
-                scrollable
-                style="
-                    flex: 1 1 0;
-                    margin: -1px 0;
-                    min-height: calc(100% + 2px);
-                "
-                data-element-id="avonni-splitter-pane-right"
+            </div>
+            <div
+                if:true={showLeftPanel}
+                class={splitterClass}
+                onmousedown={handleSplitterResizeMouseDown}
             >
+                <lightning-button-icon
+                    if:true={showSplitterCollapse}
+                    alternative-text="Expand the right side"
+                    icon-name="utility:left"
+                    size="x-small"
+                    variant="bare"
+                    onclick={handleSplitterCollapse}
+                    onmousedown={stopPropagation}
+                ></lightning-button-icon>
+                <div
+                    if:true={showSplitterResize}
+                    class="
+                        avonni-scheduler__splitter-resize-handle
+                        slds-m-vertical_x-small
+                    "
+                >
+                    <span class="slds-assistive-text">Resize</span>
+                </div>
+                <lightning-button-icon
+                    if:true={showSplitterExpand}
+                    class="avonni-scheduler__splitter-expand-left-button"
+                    alternative-text="Expand the left side"
+                    icon-name="utility:right"
+                    size="x-small"
+                    variant="bare"
+                    onclick={handleSplitterExpand}
+                    onmousedown={stopPropagation}
+                ></lightning-button-icon>
+            </div>
+
+            <div class={mainPanelClass} data-element-id="div-main-panel">
                 <div
                     class={scheduleWrapperClass}
                     data-element-id="div-schedule-wrapper"
@@ -471,16 +493,47 @@
                         </div>
                     </template>
                 </div>
-            </c-splitter-pane>
+            </div>
 
             <!-- Side panel: right position-->
-            <c-splitter-pane
+            <div
                 if:true={showRightPanel}
-                collapsible={allowCollapse}
-                resizable={allowResizeColumn}
-                scrollable
-                size="310px"
-                data-element-id="avonni-splitter-pane-right"
+                class={splitterClass}
+                onmousedown={handleSplitterResizeMouseDown}
+            >
+                <lightning-button-icon
+                    if:true={showSplitterCollapse}
+                    alternative-text="Expand the right side"
+                    icon-name="utility:left"
+                    size="x-small"
+                    variant="bare"
+                    onclick={handleSplitterCollapse}
+                    onmousedown={stopPropagation}
+                ></lightning-button-icon>
+                <div
+                    if:true={showSplitterResize}
+                    class="
+                        avonni-scheduler__splitter-resize-handle
+                        slds-m-vertical_x-small
+                    "
+                >
+                    <span class="slds-assistive-text">Resize</span>
+                </div>
+                <lightning-button-icon
+                    if:true={showSplitterExpand}
+                    class="avonni-scheduler__splitter-expand-left-button"
+                    alternative-text="Expand the left side"
+                    icon-name="utility:right"
+                    size="x-small"
+                    variant="bare"
+                    onclick={handleSplitterExpand}
+                    onmousedown={stopPropagation}
+                ></lightning-button-icon>
+            </div>
+            <div
+                if:true={showRightPanel}
+                class={sidePanelClass}
+                data-element-id="div-panel"
             >
                 <div
                     class="slds-p-around_medium"
@@ -515,8 +568,8 @@
                         </template>
                     </div>
                 </div>
-            </c-splitter-pane>
-        </c-splitter>
+            </div>
+        </div>
 
         <!-- Show more popover -->
         <div

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -105,6 +105,7 @@
                     class="
                         avonni-scheduler__splitter-resize-handle
                         slds-m-vertical_x-small
+                        slds-m-horizontal_xx-small
                     "
                     data-element-id="div-splitter-resize-handle"
                 >
@@ -545,6 +546,7 @@
                     class="
                         avonni-scheduler__splitter-resize-handle
                         slds-m-vertical_x-small
+                        slds-m-horizontal_xx-small
                     "
                 >
                     <span class="slds-assistive-text">Resize</span>

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -94,6 +94,7 @@ const SPLITTER_BAR_WIDTH = 12;
 export default class PrimitiveSchedulerCalendar extends ScheduleBase {
     _hideSidePanel = false;
     _selectedDate = dateTimeObjectFrom(DEFAULT_SELECTED_DATE);
+    _selectedResourcesReadOnly = false;
     _sidePanelPosition = SIDE_PANEL_POSITIONS.default;
 
     _centerDraggedEvent = false;
@@ -223,6 +224,21 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
                 this.initLeftPanelCalendarDisabledDates();
             }
         }
+    }
+
+    /**
+     * If present, it is not possible for the user to select or unselect resources.
+     *
+     * @type {boolean}
+     * @public
+     * @default false
+     */
+    @api
+    get selectedResourcesReadOnly() {
+        return this._selectedResourcesReadOnly;
+    }
+    set selectedResourcesReadOnly(value) {
+        this._selectedResourcesReadOnly = normalizeBoolean(value);
     }
 
     /**

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -370,6 +370,14 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
             .toString();
     }
 
+    get columnClass() {
+        return classSet('avonni-scheduler__calendar-column')
+            .add({
+                'avonni-scheduler__calendar-column_day': this.isDay
+            })
+            .toString();
+    }
+
     /**
      * Formatted available months, used to generate the calendars in the year view.
      *
@@ -571,10 +579,13 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
      */
     get mainPanelClass() {
         return classSet(
-            'avonni-scheduler__border_top avonni-scheduler__border_bottom avonni-scheduler__main-section slds-scrollable avonni-scheduler__border_right'
+            'avonni-scheduler__border_top avonni-scheduler__border_bottom avonni-scheduler__main-section slds-scrollable'
         )
             .add({
-                'avonni-scheduler__border_left': this.hideSidePanel
+                'avonni-scheduler__border_left':
+                    this.hideSidePanel || this.sidePanelPosition === 'right',
+                'avonni-scheduler__border_right':
+                    this.hideSidePanel || this.sidePanelPosition === 'left'
             })
             .toString();
     }

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -1493,13 +1493,12 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
         const schedule = this.template.querySelector(
             '[data-element-id="div-main-panel"]'
         );
-        if (wrapper && sidePanel && schedule) {
+        if (wrapper && schedule) {
             const hourHeader = this.template.querySelector(
                 '[data-element-id="avonni-primitive-scheduler-header-group-vertical"]'
             );
-            const sidePanelWidth = this.hideSidePanel
-                ? 0
-                : sidePanel.offsetWidth;
+            const sidePanelWidth =
+                this.hideSidePanel || !sidePanel ? 0 : sidePanel.offsetWidth;
             const scrollBarWidth = schedule.offsetWidth - schedule.clientWidth;
             const verticalHeaderWidth = hourHeader ? hourHeader.offsetWidth : 0;
             const splitterBarWidth =

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -37,7 +37,6 @@ import {
     dateTimeObjectFrom,
     deepCopy,
     getWeekNumber,
-    normalizeArray,
     normalizeBoolean,
     normalizeString
 } from 'c/utilsPrivate';
@@ -103,7 +102,6 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
     _hourHeadersLoading = true;
     _mouseInShowMorePopover = false;
     _mouseIsDown = false;
-    _splitterPanes = [];
     _resizeObserver;
     _showMorePopoverContextMenuIsOpened = false;
     _showMorePopoverIsFocused = false;
@@ -492,8 +490,10 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
      *
      * @type {string}
      */
-    get rightPanelClass() {
-        return classSet('slds-border_top slds-border_bottom')
+    get mainPanelClass() {
+        return classSet(
+            'slds-border_top slds-border_bottom avonni-scheduler__main-section slds-scrollable'
+        )
             .add({
                 'slds-border_left': this.hideSidePanel
             })
@@ -554,6 +554,15 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
             this.multiDayEvents.length &&
             this.multiDayEventsCellGroup.cells
         );
+    }
+
+    get sidePanelClass() {
+        return classSet('slds-scrollable avonni-scheduler__panel')
+            .add({
+                'avonni-scheduler__panel_collapsed': this._isCollapsed,
+                'avonni-scheduler__panel_expanded': this._isExpanded
+            })
+            .toString();
     }
 
     /**
@@ -1266,15 +1275,15 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
      */
     updateCellHeight() {
         const numberOfRows = this.columns[0].referenceCells.length;
-        const splitter = this.template.querySelector(
-            '[data-element-id="avonni-splitter"]'
+        const wrapper = this.template.querySelector(
+            '[data-element-id="div-main-wrapper"]'
         );
-        const splitterHeight = splitter.getBoundingClientRect().height - 2;
+        const wrapperHeight = wrapper.getBoundingClientRect().height - 2;
         const dayHeaders = this.template.querySelector(
             '[data-element-id="avonni-primitive-scheduler-header-group-horizontal"]'
         );
         const dayHeadersHeight = dayHeaders.getBoundingClientRect().height;
-        const availableHeight = splitterHeight - dayHeadersHeight;
+        const availableHeight = wrapperHeight - dayHeadersHeight;
         this.cellHeight = availableHeight / numberOfRows;
         this.template.host.style = `
             --avonni-scheduler-cell-height: ${this.cellHeight}px;
@@ -1470,22 +1479,19 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
         const wrapper = this.template.querySelector(
             '[data-element-id="div-wrapper"]'
         );
-        const hourHeader = this.template.querySelector(
-            '[data-element-id="avonni-primitive-scheduler-header-group-vertical"]'
+        const sidePanel = this.template.querySelector(
+            '[data-element-id="div-panel"]'
         );
-
-        if (wrapper && this._splitterPanes.length) {
-            const sidePanel =
-                this._sidePanelPosition === 'left'
-                    ? this._splitterPanes[0]
-                    : this._splitterPanes[1];
+        const schedule = this.template.querySelector(
+            '[data-element-id="div-main-panel"]'
+        );
+        if (wrapper && sidePanel && schedule) {
+            const hourHeader = this.template.querySelector(
+                '[data-element-id="avonni-primitive-scheduler-header-group-vertical"]'
+            );
             const sidePanelWidth = this.hideSidePanel
                 ? 0
                 : sidePanel.offsetWidth;
-            const schedule =
-                this._sidePanelPosition === 'left'
-                    ? this._splitterPanes[1]
-                    : this._splitterPanes[0];
             const scrollBarWidth = schedule.offsetWidth - schedule.clientWidth;
             const verticalHeaderWidth = hourHeader ? hourHeader.offsetWidth : 0;
             const splitterBarWidth =
@@ -1844,15 +1850,6 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
         }
         this._showPlaceholderOccurrence = true;
         this.handleHiddenEventMouseDown(event);
-    }
-
-    /**
-     * Handle a change in the splitter slots. Save the pane elements in a property, to be able to get their width in the future.
-     *
-     * @param {Event} event `privateslotchange` event fired by the splitter.
-     */
-    handleSplitterSlotChange(event) {
-        this._splitterPanes = normalizeArray(event.detail.paneElements);
     }
 
     /**

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -92,9 +92,9 @@ const SPLITTER_BAR_WIDTH = 12;
  * @extends ScheduleBase
  */
 export default class PrimitiveSchedulerCalendar extends ScheduleBase {
+    _hideResourcesFilter = false;
     _hideSidePanel = false;
     _selectedDate = dateTimeObjectFrom(DEFAULT_SELECTED_DATE);
-    _selectedResourcesReadOnly = false;
     _sidePanelPosition = SIDE_PANEL_POSITIONS.default;
 
     _centerDraggedEvent = false;
@@ -185,6 +185,21 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
      */
 
     /**
+     * If present, the resources filter is hidden.
+     *
+     * @type {boolean}
+     * @public
+     * @default false
+     */
+    @api
+    get hideResourcesFilter() {
+        return this._hideResourcesFilter;
+    }
+    set hideResourcesFilter(value) {
+        this._hideResourcesFilter = normalizeBoolean(value);
+    }
+
+    /**
      * If present, the side panel will be hidden.
      *
      * @type {boolean}
@@ -224,21 +239,6 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
                 this.initLeftPanelCalendarDisabledDates();
             }
         }
-    }
-
-    /**
-     * If present, it is not possible for the user to select or unselect resources.
-     *
-     * @type {boolean}
-     * @public
-     * @default false
-     */
-    @api
-    get selectedResourcesReadOnly() {
-        return this._selectedResourcesReadOnly;
-    }
-    set selectedResourcesReadOnly(value) {
-        this._selectedResourcesReadOnly = normalizeBoolean(value);
     }
 
     /**

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -627,11 +627,20 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
         );
     }
 
+    /**
+     * Computed CSS classes for the side panel.
+     *
+     * @type {string}
+     */
     get sidePanelClass() {
-        return classSet('slds-scrollable avonni-scheduler__panel')
+        return classSet(
+            'slds-scrollable avonni-scheduler__panel slds-border_top slds-border_bottom'
+        )
             .add({
                 'avonni-scheduler__panel_collapsed': this._isCollapsed,
-                'avonni-scheduler__panel_expanded': this._isExpanded
+                'avonni-scheduler__panel_expanded': this._isExpanded,
+                'slds-border_left': this.sidePanelPosition === 'left',
+                'slds-border_right': this.sidePanelPosition === 'right'
             })
             .toString();
     }

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -361,6 +361,15 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
      * -------------------------------------------------------------
      */
 
+    get cellsGridClass() {
+        return classSet('slds-grid avonni-scheduler__flex-col')
+            .add({
+                'slds-border_top': !this.isMonth,
+                'avonni-scheduler__calendar-month-grid': this.isMonth
+            })
+            .toString();
+    }
+
     /**
      * Formatted available months, used to generate the calendars in the year view.
      *
@@ -403,19 +412,6 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
     }
 
     /**
-     * Computed CSS classes for the horizontal primitive headers visible in the day, week and month view.
-     *
-     * @type {string}
-     */
-    get dayHeadersClass() {
-        return classSet('avonni-scheduler__calendar-header')
-            .add({
-                'slds-border_left': !this.isMonth
-            })
-            .toString();
-    }
-
-    /**
      * Computed visible time span, used by the horizontal primitive headers visible in the day, week and month view.
      *
      * @type {object}
@@ -445,6 +441,18 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
         return this.isMonth
             ? this._dayHeadersLoading
             : this._dayHeadersLoading || this._hourHeadersLoading;
+    }
+
+    get horizontalHeaderWrapperClass() {
+        return classSet(
+            'avonni-scheduler__calendar-day-header-wrapper slds-theme_default slds-is-relative slds-grid'
+        )
+            .add({
+                'avonni-scheduler__calendar-day-header-wrapper_month':
+                    this.isMonth,
+                'slds-m-bottom_medium': !this.isMonth
+            })
+            .toString();
     }
 
     /**
@@ -563,10 +571,10 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
      */
     get mainPanelClass() {
         return classSet(
-            'slds-border_top slds-border_bottom avonni-scheduler__main-section slds-scrollable'
+            'avonni-scheduler__border_top avonni-scheduler__border_bottom avonni-scheduler__main-section slds-scrollable avonni-scheduler__border_right'
         )
             .add({
-                'slds-border_left': this.hideSidePanel
+                'avonni-scheduler__border_left': this.hideSidePanel
             })
             .toString();
     }
@@ -634,13 +642,15 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
      */
     get sidePanelClass() {
         return classSet(
-            'slds-scrollable avonni-scheduler__panel slds-border_top slds-border_bottom'
+            'slds-scrollable avonni-scheduler__panel avonni-scheduler__border_top avonni-scheduler__border_bottom'
         )
             .add({
                 'avonni-scheduler__panel_collapsed': this._isCollapsed,
                 'avonni-scheduler__panel_expanded': this._isExpanded,
-                'slds-border_left': this.sidePanelPosition === 'left',
-                'slds-border_right': this.sidePanelPosition === 'right'
+                'avonni-scheduler__border_left':
+                    this.sidePanelPosition === 'left',
+                'avonni-scheduler__border_right':
+                    this.sidePanelPosition === 'right'
             })
             .toString();
     }
@@ -1283,10 +1293,10 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
      * Align the horizontal headers with the end of the vertical headers.
      */
     setHorizontalHeadersSideSpacing() {
-        const horizontalHeaders = this.template.querySelector(
-            '[data-element-id="div-horizontal-header-wrapper"]'
+        const firstColumn = this.template.querySelector(
+            '[data-element-id="div-horizontal-header-first-column"]'
         );
-        if (!horizontalHeaders) {
+        if (!firstColumn) {
             return;
         }
 
@@ -1296,9 +1306,9 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
         if (verticalHeaders) {
             // Align the horizontal headers with the vertical headers
             const width = verticalHeaders.getBoundingClientRect().width;
-            horizontalHeaders.style.paddingLeft = `${width - 1}px`;
+            firstColumn.style.width = `${width - 1}px`;
         } else {
-            horizontalHeaders.style.paddingLeft = null;
+            firstColumn.style.width = null;
         }
     }
 
@@ -1511,7 +1521,7 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
             const selector = `[data-element-id="avonni-primitive-scheduler-event-occurrence-main-grid"][data-weekday="${column.weekday}"]`;
             this.updateOccurrencesOffset(column, selector, true);
 
-            if (this.multiDayEvents.length && this.multiDayWrapper) {
+            if (this.multiDayEvents.length) {
                 // Update the multi-day occurrences offset
                 const multiDaySelector =
                     '[data-element-id="avonni-primitive-scheduler-event-occurrence-multi-day"]';
@@ -1522,6 +1532,8 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
                 const height = rowHeight || this.cellHeight;
                 this.multiDayCellHeight = height;
                 this.multiDayWrapper.style.height = `${height}px`;
+            } else {
+                this.multiDayWrapper.style.height = `15px`;
             }
         });
     }

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -675,6 +675,16 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
         return this.isMonth ? 'calendar-month' : 'calendar-vertical';
     }
 
+    /**
+     * Timezone label, in the format GMT+0.
+     *
+     * @type {string}
+     */
+    get timezoneLabel() {
+        const timezone = this.selectedDate.toFormat('Z');
+        return timezone === '+0' ? 'GMT' : `GMT${timezone}`;
+    }
+
     /*
      * ------------------------------------------------------------
      *  PUBLIC METHODS

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -191,6 +191,69 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
      */
 
     /**
+     * Array of available days of the week. If present, the scheduler will only show the available days of the week. Defaults to all days being available.
+     * The days are represented by a number, starting from 0 for Sunday, and ending with 6 for Saturday.
+     * For example, if the available days are Monday to Friday, the value would be: `[1, 2, 3, 4, 5]`
+     *
+     * @type {number[]}
+     * @public
+     * @default [0, 1, ... , 5, 6]
+     */
+    @api
+    get availableDaysOfTheWeek() {
+        return super.availableDaysOfTheWeek;
+    }
+    set availableDaysOfTheWeek(value) {
+        super.availableDaysOfTheWeek = value;
+
+        if (this._connected) {
+            this.initHeaders();
+        }
+    }
+
+    /**
+     * Array of available months. If present, the scheduler will only show the available months. Defaults to all months being available.
+     * The months are represented by a number, starting from 0 for January, and ending with 11 for December.
+     * For example, if the available months are January, February, June, July, August and December, the value would be: `[0, 1, 5, 6, 7, 11]`
+     *
+     * @type {number[]}
+     * @public
+     * @default [0, 1, … , 10, 11]
+     */
+    @api
+    get availableMonths() {
+        return super.availableMonths;
+    }
+    set availableMonths(value) {
+        super.availableMonths = value;
+
+        if (this._connected) {
+            this.initHeaders();
+        }
+    }
+
+    /**
+     * Array of available time frames. If present, the scheduler will only show the available time frames. Defaults to the full day being available.
+     * Each time frame string must follow the pattern ‘start-end’, with start and end being ISO8601 formatted time strings.
+     * For example, if the available times are from 10am to 12pm, and 2:30pm to 6:45pm, the value would be: `['10:00-11:59', '14:30-18:44']`
+     *
+     * @type {string[]}
+     * @public
+     * @default ['00:00-23:59']
+     */
+    @api
+    get availableTimeFrames() {
+        return super.availableTimeFrames;
+    }
+    set availableTimeFrames(value) {
+        super.availableTimeFrames = value;
+
+        if (this._connected) {
+            this.initHeaders();
+        }
+    }
+
+    /**
      * If present, the resources filter is hidden.
      *
      * @type {boolean}

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -162,7 +162,15 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
             const popover = this.template.querySelector(
                 '[data-element-id="div-popover"]'
             );
-            positionPopover(popover, this.showMorePopover.position, true);
+            const wrapper = this.template.querySelector(
+                '[data-element-id="div-wrapper"]'
+            );
+            positionPopover(
+                wrapper.getBoundingClientRect(),
+                popover,
+                this.showMorePopover.position,
+                true
+            );
             this.focusPopoverClose();
         }
 

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js-meta.xml
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js-meta.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>50.0</apiVersion>

--- a/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceAgenda.test.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceAgenda.test.js
@@ -90,7 +90,7 @@ describe('Primitive Scheduler Event Occurrence: agenda variant', () => {
                 'slds-truncate slds-grid avonni-scheduler__event-label_center slds-grid_vertical-align-center'
             );
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate slds-col slds-p-horizontal_x-small avonni-scheduler__event_display-as-dot'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small avonni-scheduler__event_display-as-dot'
             );
             expect(eventContent.style.cssText).toBeFalsy();
         });
@@ -126,7 +126,7 @@ describe('Primitive Scheduler Event Occurrence: agenda variant', () => {
                 'slds-truncate slds-grid avonni-scheduler__event-label_center slds-p-horizontal_x-small'
             );
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate slds-col slds-p-horizontal_x-small slds-text-color_inverse slds-current-color avonni-scheduler__event_standalone-multi-day-starts-in-previous-cell avonni-scheduler__event_standalone-multi-day-ends-in-later-cell avonni-scheduler__event_default'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small slds-text-color_inverse slds-current-color avonni-scheduler__event_standalone-multi-day-starts-in-previous-cell avonni-scheduler__event_standalone-multi-day-ends-in-later-cell avonni-scheduler__event_default'
             );
             expect(eventContent.style.cssText).toBe(
                 'background-color: rgb(51, 51, 51); --avonni-primitive-scheduler-event-occurrence-background-color: rgb(51, 51, 51);'

--- a/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceCalendar.test.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceCalendar.test.js
@@ -185,7 +185,7 @@ describe('Primitive Scheduler Event Occurrence: calendar variants', () => {
                 'slds-grid slds-grid_vertical-align-center slds-p-vertical_xx-small'
             );
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate slds-col slds-p-horizontal_x-small slds-text-color_inverse slds-current-color avonni-scheduler__event_default'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small slds-text-color_inverse slds-current-color avonni-scheduler__event_default'
             );
         });
     });
@@ -264,7 +264,7 @@ describe('Primitive Scheduler Event Occurrence: calendar variants', () => {
             );
             expect(wrapper.className).toBe('slds-grid');
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate slds-col slds-p-horizontal_x-small avonni-scheduler__event_display-as-dot'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small avonni-scheduler__event_display-as-dot'
             );
         });
     });
@@ -370,7 +370,7 @@ describe('Primitive Scheduler Event Occurrence: calendar variants', () => {
                 'slds-grid slds-grid_vertical-align-center slds-p-bottom_xx-small'
             );
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate slds-col slds-p-horizontal_x-small slds-text-color_inverse slds-current-color avonni-scheduler__event_default avonni-scheduler__event_standalone-multi-day-starts-in-previous-cell avonni-scheduler__event_standalone-multi-day-ends-in-later-cell'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small slds-text-color_inverse slds-current-color avonni-scheduler__event_default avonni-scheduler__event_standalone-multi-day-starts-in-previous-cell avonni-scheduler__event_standalone-multi-day-ends-in-later-cell'
             );
             expect(centerLabel.className).toBe(
                 'slds-truncate slds-grid avonni-scheduler__event-label_center slds-p-horizontal_x-small'
@@ -448,7 +448,7 @@ describe('Primitive Scheduler Event Occurrence: calendar variants', () => {
                 'slds-grid avonni-scheduler__event-wrapper_vertical'
             );
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate slds-col slds-text-color_inverse slds-current-color avonni-scheduler__event_default avonni-scheduler__event_vertical'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-text-color_inverse slds-current-color avonni-scheduler__event_default avonni-scheduler__event_vertical'
             );
         });
     });

--- a/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceTimeline.test.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceTimeline.test.js
@@ -114,7 +114,7 @@ describe('Primitive Scheduler Event Occurrence: timeline variants', () => {
                 'slds-truncate slds-grid avonni-scheduler__event-label_center slds-p-horizontal_x-small'
             );
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate slds-col slds-p-horizontal_x-small slds-text-color_inverse slds-current-color avonni-scheduler__event_default'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small slds-text-color_inverse slds-current-color avonni-scheduler__event_default'
             );
             expect(eventContent.style.cssText).toBe(
                 'background-color: rgb(3, 56, 7); --avonni-primitive-scheduler-event-occurrence-background-color: rgb(3, 56, 7);'
@@ -187,7 +187,7 @@ describe('Primitive Scheduler Event Occurrence: timeline variants', () => {
                 'slds-truncate slds-grid avonni-scheduler__event-label_center'
             );
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate slds-col slds-p-horizontal_x-small slds-text-color_inverse slds-current-color avonni-scheduler__event_default avonni-scheduler__event_vertical'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small slds-text-color_inverse slds-current-color avonni-scheduler__event_default avonni-scheduler__event_vertical'
             );
             expect(eventContent.style.cssText).toBe(
                 'background-color: rgb(3, 56, 7); --avonni-primitive-scheduler-event-occurrence-background-color: rgb(3, 56, 7);'

--- a/src/modules/base/primitiveSchedulerEventOccurrence/disabled.html
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/disabled.html
@@ -57,7 +57,10 @@
             </span>
             <span
                 if:true={title}
-                class="slds-truncate slds-col"
+                class="
+                    slds-truncate
+                    avonni-primitive-scheduler-event-occurrence__flex-col
+                "
                 title={title}
                 data-element-id="div-disabled-title"
                 >{title}</span

--- a/src/modules/base/primitiveSchedulerEventOccurrence/disabled.html
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/disabled.html
@@ -36,6 +36,7 @@
     <div
         class={disabledClass}
         style={disabledStyle}
+        title={title}
         data-element-id="div-disabled-wrapper"
         oncontextmenu={handleDisabledContextMenu}
         ondblclick={handleDisabledDoubleClick}
@@ -44,7 +45,6 @@
         <div
             if:false={isStandalone}
             class={disabledTitleClass}
-            title={title}
             data-element-id="div-disabled-title-wrapper"
         >
             <span>
@@ -61,7 +61,6 @@
                     slds-truncate
                     avonni-primitive-scheduler-event-occurrence__flex-col
                 "
-                title={title}
                 data-element-id="div-disabled-title"
                 >{title}</span
             >
@@ -88,7 +87,6 @@
             <span
                 if:true={title}
                 class="slds-truncate avonni-scheduler__event-label-span_center"
-                title={title}
             >
                 <span
                     if:true={isMonthCalendarSingleDay}

--- a/src/modules/base/primitiveSchedulerEventOccurrence/eventOccurrence.css
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/eventOccurrence.css
@@ -163,7 +163,8 @@
 .avonni-scheduler__event:hover .avonni-scheduler__event-resize-icon {
     visibility: visible;
 }
-.avonni-scheduler__event_vertical:hover .avonni-scheduler__event-label_center {
+.avonni-scheduler__event_vertical-animated:hover
+    .avonni-scheduler__event-label_center {
     transform: translateY(0.75rem);
 }
 

--- a/src/modules/base/primitiveSchedulerEventOccurrence/eventOccurrence.css
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/eventOccurrence.css
@@ -42,19 +42,20 @@
     cursor: pointer;
     position: relative;
     z-index: 2;
+    border-radius: var(--lwc-borderRadiusMedium, 0.25rem);
 }
 
 .avonni-scheduler__event_past {
     opacity: 0.6;
 }
 
-.avonni-scheduler__event-wrapper:focus {
-    outline: none;
+.avonni-scheduler__event-wrapper {
+    padding: 1px;
 }
-.avonni-scheduler__event-wrapper_focused {
+.avonni-scheduler__event_focused {
     box-shadow: inset 0 0 0 1px var(--lwc-colorBorderRowSelectedHover, #1b96ff);
 }
-:host.avonni-scheduler__event-dragged .avonni-scheduler__event-wrapper_focused {
+:host.avonni-scheduler__event-dragged .avonni-scheduler__event_focused {
     box-shadow: none;
 }
 

--- a/src/modules/base/primitiveSchedulerEventOccurrence/eventOccurrence.css
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/eventOccurrence.css
@@ -44,8 +44,8 @@
     z-index: 2;
 }
 
-.avonni-scheduler__event:not(.avonni-scheduler__event_display-as-dot) {
-    opacity: 0.8;
+.avonni-scheduler__event_past {
+    opacity: 0.6;
 }
 
 .avonni-scheduler__event-wrapper:focus {

--- a/src/modules/base/primitiveSchedulerEventOccurrence/eventOccurrence.html
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/eventOccurrence.html
@@ -73,7 +73,12 @@
             </span>
         </div>
 
-        <div class="slds-col slds-has-flexi-truncate">
+        <div
+            class="
+                avonni-primitive-scheduler-event-occurrence__flex-col
+                slds-has-flexi-truncate
+            "
+        >
             <!-- Top label -->
             <div
                 if:true={computedLabels.top}

--- a/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
@@ -734,8 +734,8 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
                         (this._focused && theme === 'transparent')),
                 'avonni-scheduler__event_focused': this._focused,
                 'slds-p-vertical_xx-small': centerLabel.iconName,
-                'avonni-scheduler__event_vertical':
-                    theme !== 'line' && this.isVertical,
+                'avonni-scheduler__event_vertical-animated':
+                    theme !== 'line' && this.isVertical && !this.readOnly,
                 'slds-p-bottom_xx-small': theme === 'line',
                 'avonni-scheduler__event_display-as-dot': this.displayAsDot,
                 'slds-theme_shade slds-theme_alert-texture slds-text-color_weak':

--- a/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
@@ -732,7 +732,7 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
                     (theme === 'default' ||
                         theme === 'rounded' ||
                         (this._focused && theme === 'transparent')),
-                'avonni-scheduler__event-wrapper_focused': this._focused,
+                'avonni-scheduler__event_focused': this._focused,
                 'slds-p-vertical_xx-small': centerLabel.iconName,
                 'avonni-scheduler__event_vertical':
                     theme !== 'line' && this.isVertical,
@@ -854,14 +854,8 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
                     !this.isVerticalTimeline &&
                     !this.isVerticalCalendar &&
                     !this.displayAsDot,
-                'slds-p-vertical_xx-small':
-                    !this.isVerticalTimeline &&
-                    !this.isVerticalCalendar &&
-                    !this.isMonthCalendar &&
-                    !this.isAgenda,
-                'slds-p-bottom_xx-small':
-                    this.isStandalone && this.spansOnMoreThanOneDay,
-                'avonni-scheduler__event-wrapper_vertical': this.isVertical
+                'avonni-scheduler__event-wrapper_vertical': this.isVertical,
+                'avonni-scheduler__event-wrapper': !this.isVertical
             })
             .toString();
     }

--- a/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
@@ -743,7 +743,8 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
                 'avonni-scheduler__event_standalone-multi-day-starts-in-previous-cell':
                     !this.displayAsDot && this.occurrence.startsInPreviousCell,
                 'avonni-scheduler__event_standalone-multi-day-ends-in-later-cell':
-                    !this.displayAsDot && this.occurrence.endsInLaterCell
+                    !this.displayAsDot && this.occurrence.endsInLaterCell,
+                'avonni-scheduler__event_past': this.from < Date.now()
             })
             .toString();
 

--- a/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
@@ -723,7 +723,7 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
         const theme = this.theme;
         const centerLabel = normalizeObject(this.labels.center);
         let classes = classSet(
-            'avonni-scheduler__event slds-grid slds-has-flexi-truncate slds-col'
+            'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col'
         )
             .add({
                 'slds-p-horizontal_x-small': !this.isVerticalCalendar,

--- a/src/modules/base/primitiveSchedulerEventOccurrence/shared.css
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/shared.css
@@ -36,9 +36,19 @@
     user-select: none;
 }
 
+.avonni-primitive-scheduler-event-occurrence__flex-col {
+    flex: 1 1 auto;
+}
+
 .avonni-scheduler__event-dot-chip {
-    min-height: var(--avonni-primitive-scheduler-event-occurrence-standalone-chip-size, 8px);
-    min-width: var(--avonni-primitive-scheduler-event-occurrence-standalone-chip-size, 8px);
+    min-height: var(
+        --avonni-primitive-scheduler-event-occurrence-standalone-chip-size,
+        8px
+    );
+    min-width: var(
+        --avonni-primitive-scheduler-event-occurrence-standalone-chip-size,
+        8px
+    );
     border-radius: 50%;
 }
 

--- a/src/modules/base/primitiveSchedulerHeaderGroup/__tests__/primitiveSchedulerHeaderGroup.test.js
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/__tests__/primitiveSchedulerHeaderGroup.test.js
@@ -692,7 +692,10 @@ describe('Primitive Scheduler Header Group', () => {
 
     // visible-width and zoom-to-fit
     it('Scheduler header group: zoomToFit', () => {
-        element.shadowRoot.host.getBoundingClientRect = jest.fn(() => {
+        const wrapper = element.shadowRoot.querySelector(
+            '[data-element-id="div-wrapper"]'
+        );
+        wrapper.getBoundingClientRect = jest.fn(() => {
             return { width: 120 };
         });
         const handler = jest.fn();

--- a/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.css
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.css
@@ -30,6 +30,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@import 'c/schedulerSharedStyle';
+
 :host {
     display: block;
 }
@@ -52,18 +54,9 @@
         --avonni-primitive-scheduler-header-group-cell-color-background,
         #f3f3f3
     );
-    font-weight: 700;
-    padding-top: var(
-        --avonni-primitive-scheduler-header-group-cell-spacing-block-start
-    );
-    padding-bottom: var(
-        --avonni-primitive-scheduler-header-group-cell-spacing-block-end
-    );
-    border-bottom-style: solid;
-    border-bottom-width: 1px;
-    border-bottom-color: var(
-        --avonni-primitive-scheduler-header-group-cell-color-border,
-        #e5e5e5
+    height: var(--avonni-primitive-scheduler-header-group-cell-height);
+    border-right-width: var(
+        --avonni-primitive-scheduler-header-group-cell-border-right-width
     );
 }
 
@@ -90,11 +83,23 @@
     padding: 0 0.75rem;
 }
 
+.avonni-scheduler-header-group__header-label_horizontal {
+    text-transform: uppercase;
+}
+
 .avonni-scheduler-header-group__header-label_sticky {
     position: sticky;
     left: 0;
     top: var(
         --avonni-primitive-scheduler-header-group-label-position-top,
         10px
+    );
+}
+
+.avonni-scheduler-header-group__header-label_vertical-non-sticky {
+    top: calc(var(--avonni-scheduler-cell-height) / -2);
+    background-color: var(
+        --avonni-primitive-scheduler-header-group-cell-color-background,
+        #f3f3f3
     );
 }

--- a/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.css
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.css
@@ -60,6 +60,10 @@
     );
 }
 
+.avonni-scheduler-header-group__header-label[data-today='true'] {
+    color: var(--avonni-primitive-scheduler-header-group-cell-text-color-today);
+}
+
 .avonni-scheduler-header-group__header_vertical
     .avonni-scheduler-header-group__header-cell {
     width: auto;

--- a/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.css
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.css
@@ -44,6 +44,7 @@
 }
 
 .avonni-scheduler-header-group__header-cell {
+    flex: 1 1 auto;
     width: var(--avonni-scheduler-cell-size);
     min-width: var(--avonni-scheduler-cell-size);
     color: #514f4d;

--- a/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.html
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.html
@@ -59,6 +59,7 @@
                                 class={stickyCellLabelClass}
                                 title={cell.label}
                                 data-element-id="span-label-sticky"
+                                data-today={cell.isToday}
                                 >{cell.label}
                             </span>
                         </template>
@@ -67,6 +68,7 @@
                                 class={nonStickyCellLabelClass}
                                 title={cell.label}
                                 data-element-id="span-label-non-sticky"
+                                data-today={cell.isToday}
                                 >{cell.label}
                             </span>
                         </template>

--- a/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.html
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.html
@@ -49,26 +49,14 @@
                 >
                     <div
                         key={cell.start}
-                        class="
-                            slds-border_right
-                            slds-grid
-                            slds-grid_vertical-align-center
-                            slds-grid_align-center
-                            slds-grow
-                            avonni-scheduler-header-group__header-cell
-                        "
+                        class={cellClass}
                         data-element-id="div-cell"
                         data-end={cell.end}
                         data-start={cell.start}
                     >
                         <template if:false={header.last}>
                             <span
-                                class="
-                                    slds-truncate
-                                    slds-text-body_small
-                                    slds-p-horizontal_x-small
-                                    avonni-scheduler-header-group__header-label_sticky
-                                "
+                                class={stickyCellLabelClass}
                                 title={cell.label}
                                 data-element-id="span-label-sticky"
                                 >{cell.label}
@@ -76,7 +64,7 @@
                         </template>
                         <template if:true={header.last}>
                             <span
-                                class="slds-truncate slds-text-body_small"
+                                class={nonStickyCellLabelClass}
                                 title={cell.label}
                                 data-element-id="span-label-non-sticky"
                                 >{cell.label}

--- a/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.html
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.html
@@ -51,7 +51,6 @@
                         key={cell.start}
                         class="
                             slds-border_right
-                            slds-col
                             slds-grid
                             slds-grid_vertical-align-center
                             slds-grid_align-center

--- a/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
@@ -383,6 +383,18 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
      * -------------------------------------------------------------
      */
 
+    get cellClass() {
+        return classSet(
+            'avonni-scheduler__border_right slds-grid slds-grid_vertical-align-center slds-grid_align-center slds-grow avonni-scheduler-header-group__header-cell'
+        )
+            .add({
+                'avonni-scheduler-header-group__header-cell_vertical slds-border_bottom':
+                    this.isVertical,
+                'avonni-scheduler__border_bottom': !this.isVertical
+            })
+            .toString();
+    }
+
     /**
      * Computed end date of the headers.
      *
@@ -450,6 +462,17 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
         return this.variant === 'vertical';
     }
 
+    get nonStickyCellLabelClass() {
+        return classSet('slds-truncate slds-text-color_weak')
+            .add({
+                'avonni-scheduler-header-group__header-label_horizontal':
+                    !this.isVertical,
+                'slds-is-relative avonni-scheduler-header-group__header-label_vertical-non-sticky slds-p-around_xx-small':
+                    this.isVertical
+            })
+            .toString();
+    }
+
     /**
      * Header with the smallest unit.
      *
@@ -462,6 +485,17 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
 
         const lastIndex = this.computedHeaders.length - 1;
         return this.computedHeaders[lastIndex];
+    }
+
+    get stickyCellLabelClass() {
+        return classSet(
+            'slds-truncate slds-p-horizontal_x-small avonni-scheduler-header-group__header-label_sticky'
+        )
+            .add({
+                'avonni-scheduler-header-group__header-label_horizontal':
+                    !this.isVertical
+            })
+            .toString();
     }
 
     /**

--- a/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
@@ -617,9 +617,13 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
         if (!this.smallestHeader) {
             return;
         }
-        const hostWidth = this.template.host.getBoundingClientRect().width;
+        const wrapper = this.template.querySelector(
+            '[data-element-id="div-wrapper"]'
+        );
+        const wrapperWidth = wrapper.getBoundingClientRect().width;
+
         // Remove 1 for the border
-        const totalWidth = (this.visibleWidth || hostWidth) - 1;
+        const totalWidth = (this.visibleWidth || wrapperWidth) - 1;
         const totalNumberOfCells = this.smallestHeader.numberOfCells;
         let cellSize = 0;
 

--- a/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
@@ -463,7 +463,9 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
     }
 
     get nonStickyCellLabelClass() {
-        return classSet('slds-truncate slds-text-color_weak')
+        return classSet(
+            'slds-truncate slds-text-color_weak avonni-scheduler-header-group__header-label'
+        )
             .add({
                 'avonni-scheduler-header-group__header-label_horizontal':
                     !this.isVertical,
@@ -489,7 +491,7 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
 
     get stickyCellLabelClass() {
         return classSet(
-            'slds-truncate slds-p-horizontal_x-small avonni-scheduler-header-group__header-label_sticky'
+            'slds-truncate slds-p-horizontal_x-small avonni-scheduler-header-group__header-label avonni-scheduler-header-group__header-label_sticky'
         )
             .add({
                 'avonni-scheduler-header-group__header-label_horizontal':

--- a/src/modules/base/primitiveSchedulerHeaderGroup/schedulerHeader.js
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/schedulerHeader.js
@@ -185,7 +185,13 @@ export default class SchedulerHeader {
                 break;
             }
 
+            // Used to color the text of the current day in the calendar display
+            const isToday =
+                new Date().getTime() >= date.ts &&
+                new Date().getTime() <= cellEnd.ts;
+
             this.cells.push({
+                isToday,
                 label: date.startOf(unit).toFormat(label),
                 start: date.ts,
                 end: cellEnd.ts

--- a/src/modules/base/primitiveSchedulerTimeline/__tests__/primitiveSchedulerTimeline.test.js
+++ b/src/modules/base/primitiveSchedulerTimeline/__tests__/primitiveSchedulerTimeline.test.js
@@ -354,33 +354,35 @@ describe('Primitive Scheduler Timeline', () => {
     });
 
     // collapse-disabled
-    it('Primitive Scheduler Timeline: collapseDisabled = false', () => {
+    it('Primitive Scheduler Calendar: collapseDisabled = false', () => {
         element.collapseDisabled = false;
 
         return Promise.resolve().then(() => {
-            const leftPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-left"]'
+            const collapseButton = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button-icon-splitter-collapse"]'
             );
-            const rightPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-right"]'
+            const expandButton = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button-icon-splitter-expand"]'
             );
-            expect(leftPanel.collapsible).toBeTruthy();
-            expect(rightPanel.collapsible).toBeTruthy();
+
+            expect(collapseButton).toBeTruthy();
+            expect(expandButton).toBeTruthy();
         });
     });
 
-    it('Primitive Scheduler Timeline: collapseDisabled = true', () => {
+    it('Primitive Scheduler Calendar: collapseDisabled = true', () => {
         element.collapseDisabled = true;
 
         return Promise.resolve().then(() => {
-            const leftPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-left"]'
+            const collapseButton = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button-icon-splitter-collapse"]'
             );
-            const rightPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-right"]'
+            const expandButton = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button-icon-splitter-expand"]'
             );
-            expect(leftPanel.collapsible).toBeFalsy();
-            expect(rightPanel.collapsible).toBeFalsy();
+
+            expect(collapseButton).toBeFalsy();
+            expect(expandButton).toBeFalsy();
         });
     });
 
@@ -806,33 +808,25 @@ describe('Primitive Scheduler Timeline', () => {
     });
 
     // resize-column-disabled
-    it('Primitive Scheduler Timeline: resizeColumnDisabled = false', () => {
+    it('Primitive Scheduler Calendar: resizeColumnDisabled = false', () => {
         element.resizeColumnDisabled = false;
 
         return Promise.resolve().then(() => {
-            const leftPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-left"]'
+            const resizeHandle = element.shadowRoot.querySelector(
+                '[data-element-id="div-splitter-resize-handle"]'
             );
-            const rightPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-right"]'
-            );
-            expect(leftPanel.resizable).toBeTruthy();
-            expect(rightPanel.resizable).toBeTruthy();
+            expect(resizeHandle).toBeTruthy();
         });
     });
 
-    it('Primitive Scheduler Timeline: resizeColumnDisabled = true', () => {
+    it('Primitive Scheduler Calendar: resizeColumnDisabled = true', () => {
         element.resizeColumnDisabled = true;
 
         return Promise.resolve().then(() => {
-            const leftPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-left"]'
+            const resizeHandle = element.shadowRoot.querySelector(
+                '[data-element-id="div-splitter-resize-handle"]'
             );
-            const rightPanel = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-splitter-pane-right"]'
-            );
-            expect(leftPanel.resizable).toBeFalsy();
-            expect(rightPanel.resizable).toBeFalsy();
+            expect(resizeHandle).toBeFalsy();
         });
     });
 
@@ -1158,11 +1152,8 @@ describe('Primitive Scheduler Timeline', () => {
                 const resourceRow = element.shadowRoot.querySelector(
                     '[data-element-id="div-resource"]'
                 );
-                const leftPanel = element.shadowRoot.querySelector(
-                    '[data-element-id="avonni-splitter-pane-left"]'
-                );
                 const firstCol = element.shadowRoot.querySelector(
-                    '[data-element-id="div-first-column"]'
+                    '[data-element-id="div-panel"]'
                 );
                 const scheduleBody = element.shadowRoot.querySelector(
                     '[data-element-id="div-schedule-body"]'
@@ -1177,12 +1168,11 @@ describe('Primitive Scheduler Timeline', () => {
                 expect(resourceRow.className).toBe(
                     'slds-grid slds-is-relative'
                 );
-                expect(leftPanel.size).toBe('300px');
                 expect(firstCol.className).toBe(
-                    'avonni-scheduler__first-col slds-grid'
+                    'avonni-scheduler__first-col slds-grid slds-scrollable avonni-scheduler__first-col_horizontal'
                 );
                 expect(scheduleWrapper.className).toBe(
-                    'slds-grid slds-is-relative avonni-scheduler__wrapper'
+                    'slds-grid slds-is-relative avonni-scheduler__schedule-wrapper'
                 );
                 expect(scheduleBody.className).toBe('slds-is-relative');
                 expect(cell.classList).toContain('avonni-scheduler__flex-col');
@@ -1226,11 +1216,8 @@ describe('Primitive Scheduler Timeline', () => {
                 const resourceRow = element.shadowRoot.querySelector(
                     '[data-element-id="div-resource"]'
                 );
-                const leftPanel = element.shadowRoot.querySelector(
-                    '[data-element-id="avonni-splitter-pane-left"]'
-                );
                 const firstCol = element.shadowRoot.querySelector(
-                    '[data-element-id="div-first-column"]'
+                    '[data-element-id="div-panel"]'
                 );
                 const scheduleBody = element.shadowRoot.querySelector(
                     '[data-element-id="div-schedule-body"]'
@@ -1245,12 +1232,11 @@ describe('Primitive Scheduler Timeline', () => {
                 expect(resourceRow.className).toBe(
                     'slds-grid slds-is-relative slds-grid_vertical avonni-scheduler__flex-col'
                 );
-                expect(leftPanel.size).toBe('110px');
                 expect(firstCol.className).toBe(
-                    'avonni-scheduler__first-col slds-grid avonni-scheduler__first-col_vertical avonni-scheduler__grid_align-end'
+                    'avonni-scheduler__first-col slds-grid slds-scrollable avonni-scheduler__grid_align-end avonni-scheduler__first-col_vertical'
                 );
                 expect(scheduleWrapper.className).toBe(
-                    'slds-grid slds-is-relative avonni-scheduler__wrapper avonni-scheduler__wrapper_vertical'
+                    'slds-grid slds-is-relative avonni-scheduler__schedule-wrapper avonni-scheduler__schedule-wrapper_vertical'
                 );
                 expect(scheduleBody.className).toBe(
                     'slds-is-relative slds-grid avonni-scheduler__schedule-body_vertical'
@@ -1519,11 +1505,16 @@ describe('Primitive Scheduler Timeline', () => {
             const contextMenuEvent = new CustomEvent('contextmenu');
             contextMenuEvent.clientY = 100;
             contextMenuEvent.clientX = 120;
+            const from = Number(cell.dataset.start);
+            const to = Number(cell.dataset.end);
             cell.dispatchEvent(contextMenuEvent);
+
             expect(handler).toHaveBeenCalled();
             const call = handler.mock.calls[0][0];
-            expect(call.detail.selection.y).toBe(100);
-            expect(call.detail.selection.x).toBe(120);
+            expect(call.detail.y).toBe(100);
+            expect(call.detail.x).toBe(120);
+            expect(new Date(call.detail.from).getTime()).toBe(from);
+            expect(new Date(call.detail.to).getTime()).toBe(to);
             expect(call.bubbles).toBeFalsy();
             expect(call.cancelable).toBeFalsy();
             expect(call.composed).toBeFalsy();
@@ -1552,11 +1543,16 @@ describe('Primitive Scheduler Timeline', () => {
                 );
                 contextMenuEvent.clientY = 12;
                 contextMenuEvent.clientX = 5;
+                const from = Number(event.dataset.start);
+                const to = Number(event.dataset.end);
                 event.dispatchEvent(contextMenuEvent);
+
                 expect(handler).toHaveBeenCalled();
                 const detail = handler.mock.calls[0][0].detail;
-                expect(detail.selection.y).toBe(12);
-                expect(detail.selection.x).toBe(5);
+                expect(detail.y).toBe(12);
+                expect(detail.x).toBe(5);
+                expect(new Date(detail.from).getTime()).toBe(from);
+                expect(new Date(detail.to).getTime()).toBe(to);
             });
     });
 
@@ -2079,6 +2075,42 @@ describe('Primitive Scheduler Timeline', () => {
             });
     });
 
+    it('Primitive Scheduler Timeline: eventmouseleave on event mouse leave and blur', () => {
+        element.resources = RESOURCES;
+        element.selectedResources = ALL_RESOURCES;
+        element.start = START;
+        element.events = EVENTS;
+
+        const handler = jest.fn();
+        element.addEventListener('eventmouseleave', handler);
+
+        return Promise.resolve()
+            .then(() => {
+                // Wait for the visible interval to be set
+            })
+            .then(() => {
+                const event = element.shadowRoot.querySelector(
+                    '[data-element-id="avonni-primitive-scheduler-event-occurrence"]'
+                );
+                const detail = {
+                    eventName: 'some name',
+                    key: 'some key',
+                    x: 34,
+                    y: 56
+                };
+                event.dispatchEvent(
+                    new CustomEvent('privatemouseleave', { detail })
+                );
+
+                expect(handler).toHaveBeenCalledTimes(1);
+                const call = handler.mock.calls[0][0];
+                expect(call.detail).toEqual(detail);
+                expect(call.bubbles).toBeFalsy();
+                expect(call.composed).toBeFalsy();
+                expect(call.cancelable).toBeFalsy();
+            });
+    });
+
     // eventselect
     it('Primitive Scheduler Timeline: eventselect', () => {
         element.resources = RESOURCES;
@@ -2125,40 +2157,6 @@ describe('Primitive Scheduler Timeline', () => {
     });
 
     // hidepopovers
-    it('Primitive Scheduler Timeline: hidepopovers on event mouse leave and blur', () => {
-        element.resources = RESOURCES;
-        element.selectedResources = ALL_RESOURCES;
-        element.start = START;
-        element.events = EVENTS;
-
-        const handler = jest.fn();
-        element.addEventListener('hidepopovers', handler);
-
-        return Promise.resolve()
-            .then(() => {
-                // Wait for the visible interval to be set
-            })
-            .then(() => {
-                const event = element.shadowRoot.querySelector(
-                    '[data-element-id="avonni-primitive-scheduler-event-occurrence"]'
-                );
-                event.dispatchEvent(new CustomEvent('privatemouseleave'));
-
-                expect(handler).toHaveBeenCalledTimes(1);
-                const call = handler.mock.calls[0][0];
-                expect(call.detail.list).toEqual(['detail']);
-                expect(call.bubbles).toBeFalsy();
-                expect(call.composed).toBeFalsy();
-                expect(call.cancelable).toBeFalsy();
-
-                event.dispatchEvent(new CustomEvent('privateblur'));
-                expect(handler).toHaveBeenCalledTimes(2);
-                expect(handler.mock.calls[1][0].detail.list).toEqual([
-                    'detail'
-                ]);
-            });
-    });
-
     it('Primitive Scheduler Timeline: hidepopovers on event double click', () => {
         element.resources = RESOURCES;
         element.selectedResources = ALL_RESOURCES;
@@ -2229,7 +2227,7 @@ describe('Primitive Scheduler Timeline', () => {
                     'set'
                 );
                 const rightPanel = element.shadowRoot.querySelector(
-                    '[data-element-id="avonni-splitter-pane-right"]'
+                    '[data-element-id="div-schedule-wrapper"]'
                 );
                 jest.spyOn(event, 'getBoundingClientRect').mockReturnValue({
                     right: -10

--- a/src/modules/base/primitiveSchedulerTimeline/__tests__/primitiveSchedulerTimeline.test.js
+++ b/src/modules/base/primitiveSchedulerTimeline/__tests__/primitiveSchedulerTimeline.test.js
@@ -1185,7 +1185,7 @@ describe('Primitive Scheduler Timeline', () => {
                     'slds-grid slds-is-relative avonni-scheduler__wrapper'
                 );
                 expect(scheduleBody.className).toBe('slds-is-relative');
-                expect(cell.classList).toContain('slds-col');
+                expect(cell.classList).toContain('avonni-scheduler__flex-col');
                 expect(cell.classList).not.toContain(
                     'avonni-scheduler__cell_vertical'
                 );
@@ -1243,7 +1243,7 @@ describe('Primitive Scheduler Timeline', () => {
                 expect(verticalHeaders).toBeTruthy();
                 expect(resourceHeaders).toBeTruthy();
                 expect(resourceRow.className).toBe(
-                    'slds-grid slds-is-relative slds-grid_vertical slds-col'
+                    'slds-grid slds-is-relative slds-grid_vertical avonni-scheduler__flex-col'
                 );
                 expect(leftPanel.size).toBe('110px');
                 expect(firstCol.className).toBe(
@@ -1255,7 +1255,9 @@ describe('Primitive Scheduler Timeline', () => {
                 expect(scheduleBody.className).toBe(
                     'slds-is-relative slds-grid avonni-scheduler__schedule-body_vertical'
                 );
-                expect(cell.classList).not.toContain('slds-col');
+                expect(cell.classList).not.toContain(
+                    'avonni-scheduler__flex-col'
+                );
                 expect(cell.classList).toContain(
                     'avonni-scheduler__cell_vertical'
                 );
@@ -1291,9 +1293,9 @@ describe('Primitive Scheduler Timeline', () => {
                     'avonni-scheduler__cell_zoom-to-fit'
                 );
                 expect(col.className).toBe(
-                    'slds-col slds-grid avonni-scheduler__schedule-col slds-theme_default'
+                    'avonni-scheduler__flex-col slds-grid avonni-scheduler__schedule-col slds-theme_default'
                 );
-                expect(nestedCol.className).toBe('slds-col');
+                expect(nestedCol.className).toBe('avonni-scheduler__flex-col');
 
                 element.orientation = 'vertical';
             })
@@ -1329,10 +1331,10 @@ describe('Primitive Scheduler Timeline', () => {
                     'avonni-scheduler__cell_zoom-to-fit'
                 );
                 expect(col.className).toBe(
-                    'slds-col slds-grid avonni-scheduler__schedule-col slds-theme_default avonni-scheduler__schedule-col_zoom-to-fit'
+                    'avonni-scheduler__flex-col slds-grid avonni-scheduler__schedule-col slds-theme_default avonni-scheduler__schedule-col_zoom-to-fit'
                 );
                 expect(nestedCol.className).toBe(
-                    'slds-col avonni-scheduler__schedule-col_zoom-to-fit'
+                    'avonni-scheduler__flex-col avonni-scheduler__schedule-col_zoom-to-fit'
                 );
 
                 element.orientation = 'vertical';

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.css
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.css
@@ -51,7 +51,7 @@
     max-height: calc(
         100vh - var(--toolbar-height) - var(--vertical-resources-row-height)
     );
-    height: calc(100% - var(--vertical-resources-row-height) - 1px);
+    height: calc(100% - var(--vertical-resources-row-height) - 1rem - 1px);
 }
 
 .avonni-scheduler__first-col {

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.css
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.css
@@ -51,6 +51,7 @@
     max-height: calc(
         100vh - var(--toolbar-height) - var(--vertical-resources-row-height)
     );
+    height: calc(100% - var(--vertical-resources-row-height) - 1px);
 }
 
 .avonni-scheduler__first-col {
@@ -131,6 +132,7 @@
 
 .avonni-scheduler__cell_vertical:not(.avonni-scheduler__cell_zoom-to-fit) {
     min-width: 75px;
+    width: 100%;
 }
 
 .avonni-scheduler__schedule-body_vertical .avonni-scheduler__cell {

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.css
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.css
@@ -107,13 +107,16 @@
 .avonni-scheduler__vertical-resource-header-cell,
 .avonni-scheduler__vertical-resource-header-first-cell {
     background-color: #f3f3f3;
-    color: #514f4d;
-    font-weight: 700;
     min-height: var(--vertical-resources-row-height);
     height: var(--vertical-resources-row-height);
     position: sticky;
     top: 0;
     z-index: 4;
+}
+
+.avonni-scheduler__vertical-resource-header-cell {
+    color: #514f4d;
+    font-weight: 700;
 }
 
 .avonni-scheduler__schedule-col {

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.css
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.css
@@ -33,30 +33,30 @@
 @import 'c/schedulerSharedStyle';
 
 :host {
-    --toolbar-height: 70px;
     --vertical-resources-row-height: 3rem;
 }
 
 .avonni-scheduler__wrapper {
-    max-height: calc(100vh - var(--toolbar-height));
+    max-height: calc(100vh - var(--avonni-scheduler-toolbar-height, 70px));
 }
 
 .avonni-scheduler__schedule-wrapper {
     min-height: 5rem;
-    max-height: calc(100vh - var(--toolbar-height));
+    max-height: calc(100vh - var(--avonni-scheduler-toolbar-height, 70px));
     overflow: auto;
 }
 
 .avonni-scheduler__schedule-wrapper.avonni-scheduler__schedule-wrapper_vertical {
     max-height: calc(
-        100vh - var(--toolbar-height) - var(--vertical-resources-row-height)
+        100vh - var(--avonni-scheduler-toolbar-height, 70px) -
+            var(--vertical-resources-row-height)
     );
     height: calc(100% - var(--vertical-resources-row-height) - 1rem - 1px);
 }
 
 .avonni-scheduler__first-col {
     background-color: #f3f3f3;
-    max-height: calc(100vh - var(--toolbar-height));
+    max-height: calc(100vh - var(--avonni-scheduler-toolbar-height, 70px));
 }
 .avonni-scheduler__first-col_vertical {
     width: 110px;

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.css
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.css
@@ -30,22 +30,24 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@import 'c/schedulerSharedStyle';
+
 :host {
     --toolbar-height: 70px;
     --vertical-resources-row-height: 3rem;
 }
 
 .avonni-scheduler__wrapper {
+    max-height: calc(100vh - var(--toolbar-height));
+}
+
+.avonni-scheduler__schedule-wrapper {
     min-height: 5rem;
     max-height: calc(100vh - var(--toolbar-height));
     overflow: auto;
 }
 
-.avonni-scheduler__splitter {
-    max-height: calc(100vh - var(--toolbar-height));
-}
-
-.avonni-scheduler__wrapper.avonni-scheduler__wrapper_vertical {
+.avonni-scheduler__schedule-wrapper.avonni-scheduler__schedule-wrapper_vertical {
     max-height: calc(
         100vh - var(--toolbar-height) - var(--vertical-resources-row-height)
     );
@@ -54,6 +56,12 @@
 .avonni-scheduler__first-col {
     background-color: #f3f3f3;
     max-height: calc(100vh - var(--toolbar-height));
+}
+.avonni-scheduler__first-col_vertical {
+    width: 110px;
+}
+.avonni-scheduler__first-col_horizontal {
+    width: 300px;
 }
 
 .avonni-scheduler__grid_align-end {

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.css
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.css
@@ -63,6 +63,7 @@
 }
 .avonni-scheduler__first-col_horizontal {
     width: 300px;
+    margin-right: -3px;
 }
 
 .avonni-scheduler__grid_align-end {
@@ -88,6 +89,10 @@
 .avonni-scheduler__vertical-header-wrapper {
     width: 100%;
     overflow: hidden;
+}
+
+.avonni-scheduler__vertical-splitter {
+    border-left: none;
 }
 
 .avonni-scheduler__vertical-resource-header-cell {
@@ -128,6 +133,10 @@
 .avonni-scheduler__cell {
     width: var(--avonni-scheduler-cell-width);
     min-width: var(--avonni-scheduler-cell-width);
+}
+
+.avonni-scheduler__cell:last-of-type {
+    border-right: 1px solid #c9c9c9;
 }
 
 .avonni-scheduler__cell_vertical:not(.avonni-scheduler__cell_zoom-to-fit) {

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
@@ -99,6 +99,7 @@
                 class="
                     avonni-scheduler__splitter-resize-handle
                     slds-m-vertical_x-small
+                    slds-m-horizontal_xx-small
                 "
                 data-element-id="div-splitter-resize-handle"
             >

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
@@ -125,7 +125,11 @@
                 data-element-id="div-vertical-resource-headers"
             >
                 <div
-                    class="slds-grid slds-col slds-scrollable_none"
+                    class="
+                        slds-grid
+                        avonni-scheduler__flex-col
+                        slds-scrollable_none
+                    "
                     data-element-id="div-resource-header-cells"
                 >
                     <template
@@ -148,7 +152,7 @@
                                 data-element-id="avonni-primitive-avatar"
                             ></c-primitive-avatar>
                             <div
-                                class="slds-truncate slds-col"
+                                class="slds-truncate avonni-scheduler__flex-col"
                                 data-element-id="div-vertical-resource-header-label"
                             >
                                 {resource.label}

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
@@ -85,6 +85,7 @@
                 icon-name="utility:left"
                 size="x-small"
                 variant="bare"
+                data-element-id="lightning-button-icon-splitter-collapse"
                 onclick={handleSplitterCollapse}
                 onmousedown={stopPropagation}
             ></lightning-button-icon>
@@ -94,6 +95,7 @@
                     avonni-scheduler__splitter-resize-handle
                     slds-m-vertical_x-small
                 "
+                data-element-id="div-splitter-resize-handle"
             >
                 <span class="slds-assistive-text">Resize</span>
             </div>
@@ -104,6 +106,7 @@
                 icon-name="utility:right"
                 size="x-small"
                 variant="bare"
+                data-element-id="lightning-button-icon-splitter-expand"
                 onclick={handleSplitterExpand}
                 onmousedown={stopPropagation}
             ></lightning-button-icon>
@@ -291,6 +294,8 @@
                                                 data-event-name={event.name}
                                                 data-key={occurrence.key}
                                                 data-resource-name={occurrence.resourceName}
+                                                data-start={occurrence.from.ts}
+                                                data-end={occurrence.to.ts}
                                                 onprivatefocus={handleEventFocus}
                                                 onprivatecontextmenu={handleEventContextMenu}
                                                 onprivatedisabledcontextmenu={handleEmptySpotContextMenu}

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
@@ -59,8 +59,14 @@
                         avonni-scheduler__border_bottom
                         avonni-scheduler__border_right
                         slds-m-bottom_medium
+                        slds-grid
+                        slds-grid_vertical-align-center
+                        slds-grid_align-center
+                        avonni-scheduler__time-zone
                     "
-                ></div>
+                >
+                    {timezoneLabel}
+                </div>
                 <c-primitive-scheduler-header-group
                     class="
                         avonni-scheduler__header_vertical

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
@@ -33,66 +33,87 @@
 -->
 
 <template>
-    <c-splitter class="avonni-scheduler__splitter slds-show">
-        <c-splitter-pane
-            collapsible={allowCollapse}
-            resizable={allowResizeColumn}
-            size={firstColInitialWidth}
-            data-element-id="avonni-splitter-pane-left"
-        >
-            <!-- Datatable or vertical headers -->
-            <div class={firstColClass} data-element-id="div-first-column">
-                <c-datatable
-                    if:false={isVertical}
-                    class="slds-show avonni-scheduler__datatable"
-                    max-column-width="9999999999"
-                    columns={columns}
-                    records={selectedDatatableRecords}
-                    hide-checkbox-column
-                    key-field="name"
-                    resize-column-disabled={resizeColumnDisabled}
-                    data-element-id="avonni-datatable"
-                    onresize={handleDatatableResize}
-                ></c-datatable>
-
+    <div class="slds-grid avonni-scheduler__wrapper">
+        <!-- Datatable or vertical headers -->
+        <div class={firstColClass} data-element-id="div-panel">
+            <c-datatable
+                if:false={isVertical}
+                class="slds-show avonni-scheduler__datatable"
+                max-column-width="9999999999"
+                columns={columns}
+                records={selectedDatatableRecords}
+                hide-checkbox-column
+                key-field="name"
+                resize-column-disabled={resizeColumnDisabled}
+                data-element-id="avonni-datatable"
+                onresize={handleDatatableResize}
+            ></c-datatable>
+            <div
+                if:true={isVertical}
+                class="avonni-scheduler__vertical-header-wrapper"
+                data-element-id="div-vertical-header-wrapper"
+            >
                 <div
-                    if:true={isVertical}
-                    class="avonni-scheduler__vertical-header-wrapper"
-                    data-element-id="div-vertical-header-wrapper"
-                >
-                    <div
-                        class="
-                            avonni-scheduler__vertical-resource-header-first-cell
-                            slds-border_bottom
-                        "
-                    ></div>
-                    <c-primitive-scheduler-header-group
-                        class="avonni-scheduler__header_vertical"
-                        available-days-of-the-week={availableDaysOfTheWeek}
-                        available-months={availableMonths}
-                        available-time-frames={availableTimeFrames}
-                        available-time-spans={availableTimeSpans}
-                        headers={computedHeaders}
-                        start={start}
-                        time-span={timeSpan}
-                        variant="vertical"
-                        zoom-to-fit={zoomToFit}
-                        data-element-id="avonni-primitive-scheduler-header-group"
-                        onprivatecellsizechange={handleHeaderCellSizeChange}
-                        onprivateheaderchange={handleHeaderChange}
-                    ></c-primitive-scheduler-header-group>
-                </div>
+                    class="
+                        avonni-scheduler__vertical-resource-header-first-cell
+                        slds-border_bottom
+                    "
+                ></div>
+                <c-primitive-scheduler-header-group
+                    class="avonni-scheduler__header_vertical"
+                    available-days-of-the-week={availableDaysOfTheWeek}
+                    available-months={availableMonths}
+                    available-time-frames={availableTimeFrames}
+                    available-time-spans={availableTimeSpans}
+                    headers={computedHeaders}
+                    start={start}
+                    time-span={timeSpan}
+                    variant="vertical"
+                    zoom-to-fit={zoomToFit}
+                    data-element-id="avonni-primitive-scheduler-header-group"
+                    onprivatecellsizechange={handleHeaderCellSizeChange}
+                    onprivateheaderchange={handleHeaderChange}
+                ></c-primitive-scheduler-header-group>
             </div>
-        </c-splitter-pane>
+        </div>
 
-        <c-splitter-pane
-            collapsible={allowCollapse}
-            resizable={allowResizeColumn}
-            style="flex: 1 1 0"
-            data-element-id="avonni-splitter-pane-right"
+        <!-- Splitter -->
+        <div class={splitterClass} onmousedown={handleSplitterResizeMouseDown}>
+            <lightning-button-icon
+                if:true={showSplitterCollapse}
+                alternative-text="Expand the right side"
+                icon-name="utility:left"
+                size="x-small"
+                variant="bare"
+                onclick={handleSplitterCollapse}
+                onmousedown={stopPropagation}
+            ></lightning-button-icon>
+            <div
+                if:true={showSplitterResize}
+                class="
+                    avonni-scheduler__splitter-resize-handle
+                    slds-m-vertical_x-small
+                "
+            >
+                <span class="slds-assistive-text">Resize</span>
+            </div>
+            <lightning-button-icon
+                if:true={showSplitterExpand}
+                class="avonni-scheduler__splitter-expand-left-button"
+                alternative-text="Expand the left side"
+                icon-name="utility:right"
+                size="x-small"
+                variant="bare"
+                onclick={handleSplitterExpand}
+                onmousedown={stopPropagation}
+            ></lightning-button-icon>
+        </div>
+
+        <!-- Resource headers as columns -->
+        <div
+            class="avonni-scheduler__second-col slds-scrollable"
             onscroll={handleScroll}
         >
-            <!-- Resource headers as columns -->
             <div
                 if:true={isVertical}
                 class="
@@ -284,6 +305,6 @@
                     </div>
                 </div>
             </div>
-        </c-splitter-pane>
-    </c-splitter>
+        </div>
+    </div>
 </template>

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
@@ -267,11 +267,10 @@
                                                 data-key={occurrence.key}
                                                 data-resource-name={occurrence.resourceName}
                                                 onprivatefocus={handleEventFocus}
-                                                onprivateblur={handleHideDetailPopover}
                                                 onprivatecontextmenu={handleEventContextMenu}
                                                 onprivatedisabledcontextmenu={handleEmptySpotContextMenu}
                                                 onprivatemouseenter={handleEventMouseEnter}
-                                                onprivatemouseleave={handleHideDetailPopover}
+                                                onprivatemouseleave={handleEventMouseLeave}
                                                 onprivatedblclick={handleEventDoubleClick}
                                                 onprivatedisableddblclick={handleDoubleClick}
                                                 onprivatemousedown={handleEventMouseDown}

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.html
@@ -56,11 +56,16 @@
                 <div
                     class="
                         avonni-scheduler__vertical-resource-header-first-cell
-                        slds-border_bottom
+                        avonni-scheduler__border_bottom
+                        avonni-scheduler__border_right
+                        slds-m-bottom_medium
                     "
                 ></div>
                 <c-primitive-scheduler-header-group
-                    class="avonni-scheduler__header_vertical"
+                    class="
+                        avonni-scheduler__header_vertical
+                        avonni-scheduler__border_top
+                    "
                     available-days-of-the-week={availableDaysOfTheWeek}
                     available-months={availableMonths}
                     available-time-frames={availableTimeFrames}
@@ -114,7 +119,11 @@
 
         <!-- Resource headers as columns -->
         <div
-            class="avonni-scheduler__second-col slds-scrollable"
+            class="
+                avonni-scheduler__second-col
+                slds-scrollable
+                avonni-scheduler__border_top
+            "
             onscroll={handleScroll}
         >
             <div
@@ -122,8 +131,9 @@
                 class="
                     slds-grid
                     slds-theme_shade
-                    slds-border_bottom
+                    avonni-scheduler__border_bottom
                     slds-scrollable_none
+                    slds-m-bottom_medium
                 "
                 data-element-id="div-vertical-resource-headers"
             >

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
@@ -483,6 +483,16 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
     }
 
     /**
+     * Timezone label, in the format GMT+0.
+     *
+     * @type {string}
+     */
+    get timezoneLabel() {
+        const timezone = this.start.toFormat('Z');
+        return timezone === '+0' ? 'GMT' : `GMT${timezone}`;
+    }
+
+    /**
      * Computed CSS classes for the vertical resource header cells.
      *
      * @type {string}

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
@@ -256,7 +256,7 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
             'slds-border_right slds-border_bottom slds-p-around_none slds-wrap avonni-scheduler__cell'
         )
             .add({
-                'slds-col': !this.isVertical,
+                'avonni-scheduler__flex-col': !this.isVertical,
                 'avonni-scheduler__cell_vertical': this.isVertical,
                 'avonni-scheduler__cell_zoom-to-fit': this.zoomToFit
             })
@@ -353,7 +353,7 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
     get resourceClass() {
         return classSet('slds-grid slds-is-relative')
             .add({
-                'slds-grid_vertical slds-col': this.isVertical
+                'slds-grid_vertical avonni-scheduler__flex-col': this.isVertical
             })
             .toString();
     }
@@ -390,7 +390,7 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
      */
     get scheduleColClass() {
         return classSet(
-            'slds-col slds-grid avonni-scheduler__schedule-col slds-theme_default'
+            'avonni-scheduler__flex-col slds-grid avonni-scheduler__schedule-col slds-theme_default'
         )
             .add({
                 'avonni-scheduler__schedule-col_zoom-to-fit': this.zoomToFit
@@ -420,7 +420,7 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
      * @type {string}
      */
     get scheduleNestedColClass() {
-        return classSet('slds-col')
+        return classSet('avonni-scheduler__flex-col')
             .add({
                 'avonni-scheduler__schedule-col_zoom-to-fit': this.zoomToFit
             })

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
@@ -978,6 +978,7 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
         } else {
             this.cellWidth = cellSize;
         }
+        this.updateResourcesStyle();
     }
 
     /**

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
@@ -252,12 +252,12 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
      * @type {string}
      */
     get cellClass() {
-        return classSet(
-            'slds-border_right slds-border_bottom slds-p-around_none slds-wrap avonni-scheduler__cell'
-        )
+        return classSet('slds-p-around_none slds-wrap avonni-scheduler__cell')
             .add({
-                'avonni-scheduler__flex-col': !this.isVertical,
-                'avonni-scheduler__cell_vertical': this.isVertical,
+                'avonni-scheduler__flex-col slds-border_right avonni-scheduler__border_bottom':
+                    !this.isVertical,
+                'avonni-scheduler__cell_vertical avonni-scheduler__border_right slds-border_bottom':
+                    this.isVertical,
                 'avonni-scheduler__cell_zoom-to-fit': this.zoomToFit
             })
             .toString();
@@ -302,7 +302,7 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
      */
     get firstColClass() {
         return classSet(
-            'avonni-scheduler__first-col slds-grid slds-scrollable slds-border_left slds-border_top'
+            'avonni-scheduler__first-col slds-grid slds-scrollable avonni-scheduler__border_left avonni-scheduler__border_top avonni-scheduler__border_bottom'
         )
             .add({
                 'avonni-scheduler__grid_align-end avonni-scheduler__first-col_vertical':
@@ -439,7 +439,8 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
             'slds-grid slds-is-relative avonni-scheduler__schedule-wrapper'
         )
             .add({
-                'avonni-scheduler__schedule-wrapper_vertical': this.isVertical
+                'avonni-scheduler__schedule-wrapper_vertical slds-border_top':
+                    this.isVertical
             })
             .toString();
     }
@@ -473,6 +474,14 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
             .milliseconds;
     }
 
+    get splitterClass() {
+        return classSet(super.splitterClass)
+            .add({
+                'avonni-scheduler__vertical-splitter': this.isVertical
+            })
+            .toString();
+    }
+
     /**
      * Computed CSS classes for the vertical resource header cells.
      *
@@ -480,7 +489,7 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
      */
     get verticalResourceHeaderCellClass() {
         return classSet(
-            'slds-border_right slds-p-horizontal_x-small avonni-scheduler__vertical-resource-header-cell slds-grid slds-grid_vertical-align-center'
+            'avonni-scheduler__border_right slds-p-horizontal_x-small avonni-scheduler__vertical-resource-header-cell slds-grid slds-grid_vertical-align-center'
         )
             .add({
                 'avonni-scheduler__vertical-resource-header-cell_zoom-to-fit':

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
@@ -296,37 +296,20 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
     }
 
     /**
-     * First column HTML Element.
-     *
-     * @type {HTMLElement}
-     */
-    get firstCol() {
-        return this.template.querySelector(
-            '[data-element-id="div-first-column"]'
-        );
-    }
-
-    /**
      * Computed CSS classes for the first column.
      *
      * @type {string}
      */
     get firstColClass() {
-        return classSet('avonni-scheduler__first-col slds-grid')
+        return classSet('avonni-scheduler__first-col slds-grid slds-scrollable')
             .add({
-                'avonni-scheduler__first-col_vertical avonni-scheduler__grid_align-end':
-                    this.isVertical
+                'avonni-scheduler__grid_align-end avonni-scheduler__first-col_vertical':
+                    this.isVertical,
+                'avonni-scheduler__first-col_horizontal': !this.isVertical,
+                'avonni-scheduler__panel_collapsed': this._isCollapsed,
+                'avonni-scheduler__panel_expanded': this._isExpanded
             })
             .toString();
-    }
-
-    /**
-     * Initial valid string CSS width of the first column. It is used to set the left panel width, before resize.
-     *
-     * @type {string}
-     */
-    get firstColInitialWidth() {
-        return this.isVertical ? '110px' : '300px';
     }
 
     /**
@@ -335,7 +318,9 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
      * @type {number}
      */
     get firstColWidth() {
-        return this.firstCol ? this.firstCol.getBoundingClientRect().width : 0;
+        return this.panelElement
+            ? this.panelElement.getBoundingClientRect().width
+            : 0;
     }
 
     /**
@@ -448,9 +433,11 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
      * @type {string}
      */
     get scheduleWrapperClass() {
-        return classSet('slds-grid slds-is-relative avonni-scheduler__wrapper')
+        return classSet(
+            'slds-grid slds-is-relative avonni-scheduler__schedule-wrapper'
+        )
             .add({
-                'avonni-scheduler__wrapper_vertical': this.isVertical
+                'avonni-scheduler__schedule-wrapper_vertical': this.isVertical
             })
             .toString();
     }
@@ -780,7 +767,7 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
             );
             const height = this.isVertical
                 ? 80
-                : this.firstCol.offsetHeight - headers.offsetHeight;
+                : this.panelElement.offsetHeight - headers.offsetHeight;
             loader.style.height = `${height}px`;
         }
     }
@@ -951,13 +938,10 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
      */
     handleDatatableResize(event) {
         if (event.detail.isUserTriggered) {
-            this.datatable.style.width = null;
             this._rowsHeight = [];
             this.computedResources.forEach((resource) => {
                 resource.minHeight = undefined;
             });
-            this.firstCol.style.width = null;
-            this.firstCol.style.minWidth = null;
             this.computedResources = [...this.computedResources];
         } else {
             this.updateRowsHeight();

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
@@ -873,16 +873,17 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
                 const computedResource = this.getResourceFromName(name);
                 const rowHeight = computedResource.height;
 
-                const dataRow = this._rowsHeight.find((row) => {
-                    return row.resourceName === name;
-                });
-                const dataRowHeight = dataRow.height;
-
-                const style = `
-                    min-height: ${dataRowHeight}px;
+                let style = `
                     height: ${rowHeight}px;
                     --avonni-scheduler-cell-width: ${this.cellWidth}px;
                 `;
+                const dataRow = this._rowsHeight.find((row) => {
+                    return row.resourceName === name;
+                });
+                if (dataRow) {
+                    const dataRowHeight = dataRow.height;
+                    style += `min-height: ${dataRowHeight}px;`;
+                }
 
                 // Patch inconsistency in the datatable row heights
                 const normalizedHeight =

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
@@ -301,7 +301,9 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
      * @type {string}
      */
     get firstColClass() {
-        return classSet('avonni-scheduler__first-col slds-grid slds-scrollable')
+        return classSet(
+            'avonni-scheduler__first-col slds-grid slds-scrollable slds-border_left slds-border_top'
+        )
             .add({
                 'avonni-scheduler__grid_align-end avonni-scheduler__first-col_vertical':
                     this.isVertical,

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js-meta.xml
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js-meta.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>50.0</apiVersion>

--- a/src/modules/base/scheduler/__docs__/data.js
+++ b/src/modules/base/scheduler/__docs__/data.js
@@ -435,6 +435,139 @@ const events = [
     }
 ];
 
+const eventsWithExtraKeys = [
+    {
+        resourceNames: ['Jung'],
+        name: 'research',
+        title: 'Research',
+        from: new Date(2021, 11, 13, 9),
+        to: new Date(2021, 11, 14, 12),
+        office: 'Montreal, QC',
+        cost: 650
+    },
+    {
+        resourceNames: ['Nina'],
+        name: 'code-review',
+        title: 'Code review',
+        from: new Date(2021, 11, 13, 13),
+        to: new Date(2021, 11, 13, 15),
+        recurrence: 'daily',
+        office: 'Montreal, QC'
+    },
+    {
+        resourceNames: ['Jung'],
+        name: 'seminar',
+        title: 'Online seminar',
+        from: new Date(2021, 11, 14, 8),
+        to: new Date(2021, 11, 16),
+        office: 'Montreal, QC',
+        cost: 1304.5
+    },
+    {
+        resourceNames: ['Nina', 'Jung'],
+        name: 'write-spec',
+        title: 'Write specifications',
+        from: new Date(2021, 11, 15),
+        allDay: true,
+        office: 'Montreal, QC'
+    },
+    {
+        resourceNames: ['Dave'],
+        name: 'create-wireframe',
+        title: 'Create wireframe',
+        from: new Date(2021, 11, 13, 10, 15),
+        to: new Date(2021, 11, 16, 12),
+        office: 'Trois-Rivières, QC'
+    },
+    {
+        resourceNames: ['Lily'],
+        name: 'create-mockup',
+        title: 'Create mockup',
+        from: new Date(2021, 11, 20, 7),
+        to: new Date(2021, 11, 22, 10, 30),
+        office: 'Vancouver, BC'
+    },
+    {
+        resourceNames: ['Dave'],
+        name: 'test-new-ui',
+        title: 'Test new UI',
+        from: new Date(2021, 11, 17, 15),
+        to: new Date(2021, 11, 21),
+        office: 'Trois-Rivières, QC'
+    },
+    {
+        resourceNames: ['Reginald'],
+        name: 'implement-feature',
+        title: 'Implement feature',
+        from: new Date(2021, 11, 13, 14),
+        to: new Date(2021, 11, 15, 16),
+        office: 'Trois-Rivières, QC'
+    },
+    {
+        resourceNames: ['Nina'],
+        name: 'push-to-prod',
+        title: 'Push to production',
+        from: new Date(2021, 11, 16, 11),
+        to: new Date(2021, 11, 16, 12),
+        office: 'Montreal, QC'
+    },
+    {
+        resourceNames: ['Nina'],
+        name: 'phone-meeting',
+        title: 'Phone meeting',
+        from: new Date(2021, 11, 21, 10),
+        to: new Date(2021, 11, 21, 12),
+        office: 'Montreal, QC'
+    },
+    {
+        resourceNames: ['Jung'],
+        name: 'update-documentation',
+        title: 'Update documentation',
+        from: new Date(2021, 11, 17, 11),
+        to: new Date(2021, 11, 17, 18),
+        office: 'Montreal, QC'
+    },
+    {
+        resourceNames: ['Jung'],
+        name: 'presentation',
+        title: 'Presentation at the conference',
+        from: new Date(2021, 11, 16, 11),
+        to: new Date(2021, 11, 16, 18),
+        office: 'Montreal, QC',
+        cost: 346.8
+    },
+    {
+        resourceNames: ['Dave', 'Lily'],
+        name: 'ux-ui-team-meeting',
+        title: 'UI/UX team meeting',
+        from: new Date(2021, 11, 17, 11),
+        to: new Date(2021, 11, 17, 12),
+        recurrence: 'weekly',
+        office: 'Vancouver, BC'
+    },
+    {
+        resourceNames: ['Nina', 'Dave', 'Jung', 'Lily', 'Reginald'],
+        name: 'office-party',
+        title: 'Office party',
+        from: new Date(2021, 11, 24, 12),
+        to: new Date(2021, 11, 25),
+        office: 'Montreal, QC',
+        cost: 5670.6
+    },
+    {
+        resourceNames: ['Nina', 'Reginald'],
+        name: 'standup',
+        title: 'Stand-up meeting',
+        from: new Date(2021, 11, 13, 9, 30),
+        to: new Date(2021, 11, 14, 10),
+        recurrence: 'weekly',
+        recurrenceAttributes: {
+            weekdays: [1, 3, 5]
+        },
+        office: 'Montreal, QC'
+    }
+];
+
 const eventsWithLabels = [
     {
         resourceNames: ['Jung'],
@@ -614,6 +747,7 @@ export {
     basicEvents,
     events,
     eventsThemed,
+    eventsWithExtraKeys,
     eventsWithLabels,
     longEvents,
     lotsOfEvents,

--- a/src/modules/base/scheduler/__docs__/scheduler.jsdoc.js
+++ b/src/modules/base/scheduler/__docs__/scheduler.jsdoc.js
@@ -108,13 +108,3 @@
  * @property {number} span The number of unit the scheduler will show. Defaults to 1.
  * @property {string} unit Unit of this time span. Valid values include minute, hour, day, week, month and year. Defaults to day.
  */
-
-/**
- * @namespace stylingHooks
- */
-/**
- * @memberof stylingHooks
- * @name --avonni-scheduler-toolbar-color-background
- * @default #ffffff
- * @type color
- */

--- a/src/modules/base/scheduler/__docs__/scheduler.jsdoc.js
+++ b/src/modules/base/scheduler/__docs__/scheduler.jsdoc.js
@@ -108,3 +108,13 @@
  * @property {number} span The number of unit the scheduler will show. Defaults to 1.
  * @property {string} unit Unit of this time span. Valid values include minute, hour, day, week, month and year. Defaults to day.
  */
+
+/**
+ * @namespace stylingHooks
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-scheduler-toolbar-color-background
+ * @default #ffffff
+ * @type color
+ */

--- a/src/modules/base/scheduler/__docs__/scheduler.stories.js
+++ b/src/modules/base/scheduler/__docs__/scheduler.stories.js
@@ -36,6 +36,7 @@ import {
     resources,
     headers,
     events,
+    eventsWithExtraKeys,
     eventsThemed,
     eventsWithLabels,
     disabledDatesTimes,
@@ -260,6 +261,17 @@ export default {
                 type: { summary: 'string' },
                 defaultValue: { summary: 'aurora' },
                 category: 'Events'
+            }
+        },
+        eventsDisplayFields: {
+            name: 'events-display-fields',
+            control: {
+                type: 'object'
+            },
+            description:
+                'Array of data objects, displayed in the popover visible on hover on an event. See Output Data for valid keys. The value of each field should be a key of the selected event object.',
+            table: {
+                type: { summary: 'object[]' }
             }
         },
         eventsTheme: {
@@ -616,12 +628,38 @@ export const Calendar = Template.bind({});
 Calendar.args = {
     resources,
     start,
-    events,
+    events: eventsWithExtraKeys,
     selectedDisplay: 'calendar',
     selectedResources: ['Dave', 'Jung', 'Reginald'],
     selectedTimeSpan: 'Standard.Scheduler.WeekTimeSpan',
     disabledDatesTimes,
-    referenceLines
+    referenceLines,
+    eventsDisplayFields: [
+        {
+            label: 'Start',
+            value: 'from',
+            type: 'date'
+        },
+        {
+            label: 'End',
+            value: 'to',
+            type: 'date'
+        },
+        {
+            label: 'Office',
+            value: 'office'
+        },
+        {
+            label: 'Cost',
+            value: 'cost',
+            type: 'currency',
+            typeAttributes: {
+                currencyCode: 'CAD',
+                currencyDisplayAs: 'name',
+                minimumFractionDigits: 2
+            }
+        }
+    ]
 };
 
 export const Agenda = Template.bind({});

--- a/src/modules/base/scheduler/__docs__/scheduler.stories.js
+++ b/src/modules/base/scheduler/__docs__/scheduler.stories.js
@@ -416,6 +416,18 @@ export default {
                 type: { summary: 'string[]' }
             }
         },
+        selectedResourcesReadOnly: {
+            name: 'selected-resources-read-only',
+            control: {
+                type: 'boolean'
+            },
+            description:
+                'If present, it is not possible for the user to select or unselect resources.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' }
+            }
+        },
         selectedTimeSpan: {
             name: 'selected-time-span',
             control: {
@@ -550,6 +562,7 @@ export default {
         readOnly: false,
         resizeColumnDisabled: false,
         selectedDisplay: 'timeline',
+        selectedResourcesReadOnly: false,
         selectedTimeSpan: 'Standard.Scheduler.DayTimeSpan',
         sidePanelPosition: 'left',
         start: new Date(),

--- a/src/modules/base/scheduler/__docs__/scheduler.stories.js
+++ b/src/modules/base/scheduler/__docs__/scheduler.stories.js
@@ -428,6 +428,18 @@ export default {
                 defaultValue: { summary: 'Standard.Scheduler.DayTimeSpan' }
             }
         },
+        sidePanelPosition: {
+            name: 'side-panel-position',
+            control: {
+                type: 'text'
+            },
+            description:
+                'Position of the side panel, relative to the schedule. This attribute only affects the agenda and calendar displays.',
+            table: {
+                type: { summary: 'string' },
+                defaultValue: { summary: 'left' }
+            }
+        },
         start: {
             control: {
                 type: 'date'
@@ -539,6 +551,7 @@ export default {
         resizeColumnDisabled: false,
         selectedDisplay: 'timeline',
         selectedTimeSpan: 'Standard.Scheduler.DayTimeSpan',
+        sidePanelPosition: 'left',
         start: new Date(),
         timeSpans: [
             {

--- a/src/modules/base/scheduler/__docs__/scheduler.stories.js
+++ b/src/modules/base/scheduler/__docs__/scheduler.stories.js
@@ -271,7 +271,8 @@ export default {
             description:
                 'Array of data objects, displayed in the popover visible on hover on an event. See Output Data for valid keys. The value of each field should be a key of the selected event object.',
             table: {
-                type: { summary: 'object[]' }
+                type: { summary: 'object[]' },
+                category: 'Events'
             }
         },
         eventsTheme: {
@@ -308,7 +309,8 @@ export default {
             description: 'If present, the resources filter is hidden.',
             table: {
                 type: { summary: 'boolean' },
-                defaultValue: { summary: 'false' }
+                defaultValue: { summary: 'false' },
+                category: 'Panels and Toolbar'
             }
         },
         hideSidePanel: {
@@ -448,19 +450,22 @@ export default {
                 'Unique name of the selected time span. The selected time span will determine the visible duration of the scheduler.',
             table: {
                 type: { summary: 'string' },
-                defaultValue: { summary: 'Standard.Scheduler.DayTimeSpan' }
+                defaultValue: { summary: 'Standard.Scheduler.DayTimeSpan' },
+                category: 'Panels and Toolbar'
             }
         },
         sidePanelPosition: {
             name: 'side-panel-position',
             control: {
-                type: 'text'
+                type: 'select'
             },
+            options: ['left', 'right'],
             description:
                 'Position of the side panel, relative to the schedule. This attribute only affects the agenda and calendar displays.',
             table: {
                 type: { summary: 'string' },
-                defaultValue: { summary: 'left' }
+                defaultValue: { summary: 'left' },
+                category: 'Panels and Toolbar'
             }
         },
         start: {

--- a/src/modules/base/scheduler/__docs__/scheduler.stories.js
+++ b/src/modules/base/scheduler/__docs__/scheduler.stories.js
@@ -300,6 +300,17 @@ export default {
                 category: 'Panels and Toolbar'
             }
         },
+        hideResourcesFilter: {
+            name: 'hide-resources-filter',
+            control: {
+                type: 'boolean'
+            },
+            description: 'If present, the resources filter is hidden.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' }
+            }
+        },
         hideSidePanel: {
             name: 'hide-side-panel',
             control: {
@@ -428,18 +439,6 @@ export default {
                 type: { summary: 'string[]' }
             }
         },
-        selectedResourcesReadOnly: {
-            name: 'selected-resources-read-only',
-            control: {
-                type: 'boolean'
-            },
-            description:
-                'If present, it is not possible for the user to select or unselect resources.',
-            table: {
-                type: { summary: 'boolean' },
-                defaultValue: { summary: 'false' }
-            }
-        },
         selectedTimeSpan: {
             name: 'selected-time-span',
             control: {
@@ -566,6 +565,7 @@ export default {
         },
         eventsPalette: 'aurora',
         eventsTheme: 'default',
+        hideResourcesFilter: false,
         hideSidePanel: false,
         hideToolbar: false,
         isLoading: false,
@@ -574,7 +574,6 @@ export default {
         readOnly: false,
         resizeColumnDisabled: false,
         selectedDisplay: 'timeline',
-        selectedResourcesReadOnly: false,
         selectedTimeSpan: 'Standard.Scheduler.DayTimeSpan',
         sidePanelPosition: 'left',
         start: new Date(),

--- a/src/modules/base/scheduler/__docs__/scheduler.stories.js
+++ b/src/modules/base/scheduler/__docs__/scheduler.stories.js
@@ -289,18 +289,6 @@ export default {
                 category: 'Events'
             }
         },
-        headerActions: {
-            name: 'header-actions',
-            control: {
-                type: 'object'
-            },
-            description:
-                'Array of action objects. If present, the actions will be shown in the toolbar.',
-            table: {
-                type: { summary: 'object[]' },
-                category: 'Panels and Toolbar'
-            }
-        },
         hiddenDisplays: {
             name: 'hidden-displays',
             control: {
@@ -490,6 +478,18 @@ export default {
                 type: { summary: 'object' },
                 defaultValue: { summary: 'Date()' },
                 category: 'Available dates'
+            }
+        },
+        toolbarActions: {
+            name: 'toolbar-actions',
+            control: {
+                type: 'object'
+            },
+            description:
+                'Array of action objects. If present, the actions will be shown in the toolbar.',
+            table: {
+                type: { summary: 'object[]' },
+                category: 'Panels and Toolbar'
             }
         },
         timeSpans: {
@@ -854,7 +854,7 @@ ThemesAndColors.args = {
     events: eventsThemed,
     eventsPalette: 'wildflowers',
     selectedResources: ['Dave', 'Reginald', 'Nina', 'Jung', 'Lily'],
-    headerActions: [
+    toolbarActions: [
         {
             label: 'Action 1',
             name: 'actionOne'

--- a/src/modules/base/scheduler/__docs__/scheduler.stories.js
+++ b/src/modules/base/scheduler/__docs__/scheduler.stories.js
@@ -289,6 +289,18 @@ export default {
                 category: 'Events'
             }
         },
+        headerActions: {
+            name: 'header-actions',
+            control: {
+                type: 'object'
+            },
+            description:
+                'Array of action objects. If present, the actions will be shown in the toolbar.',
+            table: {
+                type: { summary: 'object[]' },
+                category: 'Panels and Toolbar'
+            }
+        },
         hiddenDisplays: {
             name: 'hidden-displays',
             control: {
@@ -841,5 +853,15 @@ ThemesAndColors.args = {
     start,
     events: eventsThemed,
     eventsPalette: 'wildflowers',
-    selectedResources: ['Dave', 'Reginald', 'Nina', 'Jung', 'Lily']
+    selectedResources: ['Dave', 'Reginald', 'Nina', 'Jung', 'Lily'],
+    headerActions: [
+        {
+            label: 'Action 1',
+            name: 'actionOne'
+        },
+        {
+            label: 'Action 2',
+            name: 'actionTwo'
+        }
+    ]
 };

--- a/src/modules/base/scheduler/__docs__/scheduler.stories.js
+++ b/src/modules/base/scheduler/__docs__/scheduler.stories.js
@@ -288,6 +288,19 @@ export default {
                 category: 'Panels and Toolbar'
             }
         },
+        hideSidePanel: {
+            name: 'hide-side-panel',
+            control: {
+                type: 'boolean'
+            },
+            description:
+                'If present, the side panel will be hidden. This attribute only affects the agenda and calendar displays.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' },
+                category: 'Panels and Toolbar'
+            }
+        },
         hideToolbar: {
             name: 'hide-toolbar',
             control: {
@@ -517,6 +530,7 @@ export default {
         },
         eventsPalette: 'aurora',
         eventsTheme: 'default',
+        hideSidePanel: false,
         hideToolbar: false,
         isLoading: false,
         loadingStateAlternativeText: 'Loading',

--- a/src/modules/base/scheduler/__examples__/scheduler.js
+++ b/src/modules/base/scheduler/__examples__/scheduler.js
@@ -51,6 +51,7 @@ export const Scheduler = ({
     eventsPalette,
     eventsDisplayFields,
     eventsTheme,
+    headerActions,
     hiddenDisplays,
     hideResourcesFilter,
     hideSidePanel,
@@ -87,6 +88,7 @@ export const Scheduler = ({
     element.eventsPalette = eventsPalette;
     element.eventsDisplayFields = eventsDisplayFields;
     element.eventsTheme = eventsTheme;
+    element.headerActions = headerActions;
     element.hiddenDisplays = hiddenDisplays;
     element.hideResourcesFilter = hideResourcesFilter;
     element.hideSidePanel = hideSidePanel;

--- a/src/modules/base/scheduler/__examples__/scheduler.js
+++ b/src/modules/base/scheduler/__examples__/scheduler.js
@@ -61,6 +61,7 @@ export const Scheduler = ({
     resources,
     selectedDisplay,
     selectedResources,
+    selectedResourcesReadOnly,
     selectedTimeSpan,
     sidePanelPosition,
     start,
@@ -95,6 +96,7 @@ export const Scheduler = ({
     element.resources = resources;
     element.selectedDisplay = selectedDisplay;
     element.selectedResources = selectedResources;
+    element.selectedResourcesReadOnly = selectedResourcesReadOnly;
     element.selectedTimeSpan = selectedTimeSpan;
     element.sidePanelPosition = sidePanelPosition;
     element.start = start;

--- a/src/modules/base/scheduler/__examples__/scheduler.js
+++ b/src/modules/base/scheduler/__examples__/scheduler.js
@@ -49,6 +49,7 @@ export const Scheduler = ({
     events,
     eventsLabels,
     eventsPalette,
+    eventsDisplayFields,
     eventsTheme,
     hiddenDisplays,
     hideSidePanel,
@@ -84,6 +85,7 @@ export const Scheduler = ({
     element.events = events;
     element.eventsLabels = eventsLabels;
     element.eventsPalette = eventsPalette;
+    element.eventsDisplayFields = eventsDisplayFields;
     element.eventsTheme = eventsTheme;
     element.hiddenDisplays = hiddenDisplays;
     element.hideSidePanel = hideSidePanel;

--- a/src/modules/base/scheduler/__examples__/scheduler.js
+++ b/src/modules/base/scheduler/__examples__/scheduler.js
@@ -51,6 +51,7 @@ export const Scheduler = ({
     eventsPalette,
     eventsTheme,
     hiddenDisplays,
+    hideSidePanel,
     hideToolbar,
     isLoading,
     readOnly,
@@ -83,6 +84,7 @@ export const Scheduler = ({
     element.eventsPalette = eventsPalette;
     element.eventsTheme = eventsTheme;
     element.hiddenDisplays = hiddenDisplays;
+    element.hideSidePanel = hideSidePanel;
     element.hideToolbar = hideToolbar;
     element.isLoading = isLoading;
     element.readOnly = readOnly;

--- a/src/modules/base/scheduler/__examples__/scheduler.js
+++ b/src/modules/base/scheduler/__examples__/scheduler.js
@@ -62,6 +62,7 @@ export const Scheduler = ({
     selectedDisplay,
     selectedResources,
     selectedTimeSpan,
+    sidePanelPosition,
     start,
     timeSpans,
     variant,
@@ -95,6 +96,7 @@ export const Scheduler = ({
     element.selectedDisplay = selectedDisplay;
     element.selectedResources = selectedResources;
     element.selectedTimeSpan = selectedTimeSpan;
+    element.sidePanelPosition = sidePanelPosition;
     element.start = start;
     element.timeSpans = timeSpans;
     element.variant = variant;

--- a/src/modules/base/scheduler/__examples__/scheduler.js
+++ b/src/modules/base/scheduler/__examples__/scheduler.js
@@ -52,6 +52,7 @@ export const Scheduler = ({
     eventsDisplayFields,
     eventsTheme,
     hiddenDisplays,
+    hideResourcesFilter,
     hideSidePanel,
     hideToolbar,
     isLoading,
@@ -62,7 +63,6 @@ export const Scheduler = ({
     resources,
     selectedDisplay,
     selectedResources,
-    selectedResourcesReadOnly,
     selectedTimeSpan,
     sidePanelPosition,
     start,
@@ -88,6 +88,7 @@ export const Scheduler = ({
     element.eventsDisplayFields = eventsDisplayFields;
     element.eventsTheme = eventsTheme;
     element.hiddenDisplays = hiddenDisplays;
+    element.hideResourcesFilter = hideResourcesFilter;
     element.hideSidePanel = hideSidePanel;
     element.hideToolbar = hideToolbar;
     element.isLoading = isLoading;
@@ -98,7 +99,6 @@ export const Scheduler = ({
     element.resources = resources;
     element.selectedDisplay = selectedDisplay;
     element.selectedResources = selectedResources;
-    element.selectedResourcesReadOnly = selectedResourcesReadOnly;
     element.selectedTimeSpan = selectedTimeSpan;
     element.sidePanelPosition = sidePanelPosition;
     element.start = start;

--- a/src/modules/base/scheduler/__examples__/scheduler.js
+++ b/src/modules/base/scheduler/__examples__/scheduler.js
@@ -51,7 +51,7 @@ export const Scheduler = ({
     eventsPalette,
     eventsDisplayFields,
     eventsTheme,
-    headerActions,
+    toolbarActions,
     hiddenDisplays,
     hideResourcesFilter,
     hideSidePanel,
@@ -88,7 +88,7 @@ export const Scheduler = ({
     element.eventsPalette = eventsPalette;
     element.eventsDisplayFields = eventsDisplayFields;
     element.eventsTheme = eventsTheme;
-    element.headerActions = headerActions;
+    element.toolbarActions = toolbarActions;
     element.hiddenDisplays = hiddenDisplays;
     element.hideResourcesFilter = hideResourcesFilter;
     element.hideSidePanel = hideSidePanel;

--- a/src/modules/base/scheduler/defaults.js
+++ b/src/modules/base/scheduler/defaults.js
@@ -85,6 +85,16 @@ const DEFAULT_EVENTS_LABELS = {
         fieldName: 'title'
     }
 };
+const DEFAULT_EVENTS_DISPLAY_FIELDS = [
+    {
+        type: 'date',
+        value: 'from'
+    },
+    {
+        type: 'date',
+        value: 'to'
+    }
+];
 const DEFAULT_LOADING_STATE_ALTERNATIVE_TEXT = 'Loading';
 const DEFAULT_SELECTED_TIME_SPAN = 'Standard.Scheduler.DayTimeSpan';
 const DEFAULT_START_DATE = new Date();
@@ -264,6 +274,7 @@ export {
     DEFAULT_DATE_FORMAT,
     DEFAULT_DIALOG_LABELS,
     DEFAULT_EVENTS_LABELS,
+    DEFAULT_EVENTS_DISPLAY_FIELDS,
     DEFAULT_LOADING_STATE_ALTERNATIVE_TEXT,
     DEFAULT_SELECTED_TIME_SPAN,
     DEFAULT_START_DATE,

--- a/src/modules/base/scheduler/defaults.js
+++ b/src/modules/base/scheduler/defaults.js
@@ -244,6 +244,11 @@ const REFERENCE_LINE_VARIANTS = {
     default: 'default'
 };
 
+const SIDE_PANEL_POSITIONS = {
+    valid: ['left', 'right'],
+    default: 'left'
+};
+
 const VARIANTS = {
     valid: ['horizontal', 'vertical'],
     default: 'horizontal'
@@ -269,6 +274,7 @@ export {
     PALETTES,
     RECURRENCES,
     REFERENCE_LINE_VARIANTS,
+    SIDE_PANEL_POSITIONS,
     TIME_SPANS,
     VARIANTS
 };

--- a/src/modules/base/scheduler/scheduler.css
+++ b/src/modules/base/scheduler/scheduler.css
@@ -55,3 +55,16 @@
 .avonni-scheduler__toolbar-date-range {
     --slds-c-button-text-color: #444444;
 }
+
+.avonni-scheduler__toolbar-nav-button_first {
+    --slds-c-button-radius-border: 0.25rem 0 0 0.25rem;
+}
+
+.avonni-scheduler__toolbar-nav-button_middle {
+    --slds-c-button-radius-border: 0;
+    --slds-c-button-sizing-border: 1px 0 1px 0;
+}
+
+.avonni-scheduler__toolbar-nav-button_last {
+    --slds-c-button-radius-border: 0 0.25rem 0.25rem 0;
+}

--- a/src/modules/base/scheduler/scheduler.css
+++ b/src/modules/base/scheduler/scheduler.css
@@ -35,7 +35,7 @@
 }
 
 .avonni-scheduler__schedule {
-    height: calc(100% - 70px);
+    height: calc(100% - var(--avonni-scheduler-toolbar-height, 70px));
 }
 
 .avonni-scheduler__detail-popover-close-button {

--- a/src/modules/base/scheduler/scheduler.css
+++ b/src/modules/base/scheduler/scheduler.css
@@ -30,6 +30,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+.avonni-scheduler__flex-col {
+    flex: 1 1 auto;
+}
+
 .avonni-scheduler__detail-popover-close-button {
     z-index: 1;
     top: 0;

--- a/src/modules/base/scheduler/scheduler.css
+++ b/src/modules/base/scheduler/scheduler.css
@@ -60,15 +60,19 @@
     --slds-c-button-text-color: #444444;
 }
 
-.avonni-scheduler__toolbar-nav-button_first {
+.avonni-scheduler__toolbar-button-group_first {
     --slds-c-button-radius-border: 0.25rem 0 0 0.25rem;
 }
 
-.avonni-scheduler__toolbar-nav-button_middle {
+.avonni-scheduler__toolbar-button-group_middle {
     --slds-c-button-radius-border: 0;
     --slds-c-button-sizing-border: 1px 0 1px 0;
 }
 
-.avonni-scheduler__toolbar-nav-button_last {
+.avonni-scheduler__toolbar-button-group_last {
     --slds-c-button-radius-border: 0 0.25rem 0.25rem 0;
+}
+
+.avonni-scheduler__display-menu.avonni-scheduler__toolbar-button-group_first {
+    --slds-c-button-sizing-border: 1px 0 1px 1px;
 }

--- a/src/modules/base/scheduler/scheduler.css
+++ b/src/modules/base/scheduler/scheduler.css
@@ -38,6 +38,10 @@
     height: calc(100% - 70px);
 }
 
+.avonni-scheduler__toolbar {
+    background-color: var(--avonni-scheduler-toolbar-color-background, #ffffff);
+}
+
 .avonni-scheduler__detail-popover-close-button {
     z-index: 1;
     top: 0;

--- a/src/modules/base/scheduler/scheduler.css
+++ b/src/modules/base/scheduler/scheduler.css
@@ -42,6 +42,10 @@
 
 .avonni-scheduler__context-menu {
     z-index: 1;
+
+    /* Needed to prevent a scroll jump when the menu appears */
+    top: 0;
+    left: 0;
 }
 
 .avonni-scheduler__display-menu {

--- a/src/modules/base/scheduler/scheduler.css
+++ b/src/modules/base/scheduler/scheduler.css
@@ -30,10 +30,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-:host {
-    --avonni-splitter-horizontal-color-border-around: transparent;
-}
-
 .avonni-scheduler__detail-popover-close-button {
     z-index: 1;
     top: 0;

--- a/src/modules/base/scheduler/scheduler.css
+++ b/src/modules/base/scheduler/scheduler.css
@@ -50,10 +50,6 @@
 
 .avonni-scheduler__context-menu {
     z-index: 1;
-
-    /* Needed to prevent a scroll jump when the menu appears */
-    top: 0;
-    left: 0;
 }
 
 .avonni-scheduler__display-menu {

--- a/src/modules/base/scheduler/scheduler.css
+++ b/src/modules/base/scheduler/scheduler.css
@@ -34,8 +34,9 @@
     --avonni-splitter-horizontal-color-border-around: transparent;
 }
 
-.avonni-scheduler__event-detail-popover {
-    width: auto;
+.avonni-scheduler__detail-popover-close-button {
+    top: 0;
+    right: 2px;
 }
 
 .avonni-scheduler__calendar {

--- a/src/modules/base/scheduler/scheduler.css
+++ b/src/modules/base/scheduler/scheduler.css
@@ -38,10 +38,6 @@
     height: calc(100% - 70px);
 }
 
-.avonni-scheduler__toolbar {
-    background-color: var(--avonni-scheduler-toolbar-color-background, #ffffff);
-}
-
 .avonni-scheduler__detail-popover-close-button {
     z-index: 1;
     top: 0;

--- a/src/modules/base/scheduler/scheduler.css
+++ b/src/modules/base/scheduler/scheduler.css
@@ -34,6 +34,10 @@
     flex: 1 1 auto;
 }
 
+.avonni-scheduler__schedule {
+    height: calc(100% - 70px);
+}
+
 .avonni-scheduler__detail-popover-close-button {
     z-index: 1;
     top: 0;

--- a/src/modules/base/scheduler/scheduler.css
+++ b/src/modules/base/scheduler/scheduler.css
@@ -35,6 +35,7 @@
 }
 
 .avonni-scheduler__detail-popover-close-button {
+    z-index: 1;
     top: 0;
     right: 2px;
 }

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -156,7 +156,7 @@
             ></lightning-button-icon>
         </div>
 
-        <div class="slds-m-left_small slds-grid">
+        <div class="slds-m-left_x-small slds-grid">
             <!-- Displays -->
             <c-button-menu
                 if:true={moreThanOneDisplay}
@@ -217,7 +217,7 @@
         <!-- Resources filter -->
         <c-filter-menu
             if:true={showResourceFilter}
-            class="slds-m-left_small"
+            class="slds-m-left_x-small"
             alternative-text="Select resources"
             dropdown-alignment="right"
             hide-apply-reset-buttons
@@ -229,6 +229,15 @@
             data-element-id="avonni-filter-menu-resources"
             onselect={handleToolbarResourceSelect}
         ></c-filter-menu>
+
+        <lightning-button-icon-stateful
+            if:true={showSidePanelToggle}
+            class="slds-m-left_x-small"
+            icon-name="utility:rows"
+            selected={sidePanelIsExpanded}
+            variant="border-filled"
+            onclick={handleToolbarSidePanelToggle}
+        ></lightning-button-icon-stateful>
     </div>
 
     <template if:false={isLoading}>
@@ -252,6 +261,7 @@
             resize-column-disabled={resizeColumnDisabled}
             resources={computedResources}
             selected-resources={selectedResources}
+            side-panel-is-expanded={sidePanelIsExpanded}
             start={start}
             time-span={currentTimeSpan}
             orientation={variant}
@@ -267,6 +277,7 @@
             oneventselect={handleEventSelect}
             onopeneditdialog={handleOpenEditDialog}
             onopenrecurrencedialog={handleOpenRecurrenceDialog}
+            ontogglesidepanel={handleToggleSidePanel}
             onvisibleintervalchange={handleVisibleIntervalChange}
         ></c-primitive-scheduler-timeline>
 
@@ -301,6 +312,7 @@
             resources={computedResources}
             selected-date={selectedDate}
             selected-resources={selectedResources}
+            side-panel-is-expanded={sidePanelIsExpanded}
             side-panel-position={sidePanelPosition}
             time-span={currentTimeSpan}
             zoom-to-fit={zoomToFit}
@@ -317,6 +329,7 @@
             onopeneditdialog={handleOpenEditDialog}
             onopenrecurrencedialog={handleOpenRecurrenceDialog}
             onresourceselect={handleResourceSelect}
+            ontogglesidepanel={handleToggleSidePanel}
             onvisibleintervalchange={handleVisibleIntervalChange}
         ></c-primitive-scheduler-calendar>
 
@@ -337,6 +350,7 @@
             resources={computedResources}
             selected-date={selectedDate}
             selected-resources={selectedResources}
+            side-panel-is-expanded={sidePanelIsExpanded}
             side-panel-position={sidePanelPosition}
             time-span={currentTimeSpan}
             data-element-id="avonni-primitive-scheduler-agenda"
@@ -352,6 +366,7 @@
             onopeneditdialog={handleOpenEditDialog}
             onopenrecurrencedialog={handleOpenRecurrenceDialog}
             onresourceselect={handleResourceSelect}
+            ontogglesidepanel={handleToggleSidePanel}
             onvisibleintervalchange={handleVisibleIntervalChange}
         ></c-primitive-scheduler-agenda>
     </template>

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -124,26 +124,29 @@
         </div>
 
         <!-- Toolbar next/today/previous navigation -->
-        <lightning-button-group>
+        <div class="slds-grid">
             <lightning-button-icon
+                class="avonni-scheduler__toolbar-nav-button_first"
                 disabled={showEmptyTimelineMessage}
                 icon-name="utility:chevronleft"
                 data-element-id="lightning-button-icon-toolbar-prev"
                 onclick={handleToolbarPrevClick}
             ></lightning-button-icon>
             <lightning-button
+                class="avonni-scheduler__toolbar-nav-button_middle"
                 disabled={showEmptyTimelineMessage}
                 label="Today"
                 data-element-id="lightning-button-icon-toolbar-today"
                 onclick={handleToolbarTodayClick}
             ></lightning-button>
             <lightning-button-icon
+                class="avonni-scheduler__toolbar-nav-button_last"
                 disabled={showEmptyTimelineMessage}
                 icon-name="utility:chevronright"
                 data-element-id="lightning-button-icon-toolbar-next"
                 onclick={handleToolbarNextClick}
             ></lightning-button-icon>
-        </lightning-button-group>
+        </div>
 
         <c-button-menu
             if:true={moreThanOneDisplay}

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -213,6 +213,7 @@
             oneventcontextmenu={handleEventContextMenu}
             oneventcreate={handleEventCreate}
             oneventmouseenter={handleEventMouseEnter}
+            oneventmouseleave={handleEventMouseLeave}
             onhidepopovers={handleHidePopovers}
             oneventselect={handleEventSelect}
             onopeneditdialog={handleOpenEditDialog}
@@ -259,6 +260,7 @@
             oneventcreate={handleEventCreate}
             oneventselect={handleEventSelect}
             oneventmouseenter={handleEventMouseEnter}
+            oneventmouseleave={handleEventMouseLeave}
             onhidepopovers={handleHidePopovers}
             onopeneditdialog={handleOpenEditDialog}
             onopenrecurrencedialog={handleOpenRecurrenceDialog}
@@ -292,6 +294,7 @@
             oneventcontextmenu={handleEventContextMenu}
             oneventcreate={handleEventCreate}
             oneventmouseenter={handleEventMouseEnter}
+            oneventmouseleave={handleEventMouseLeave}
             onhidepopovers={handleHidePopovers}
             onopeneditdialog={handleOpenEditDialog}
             onopenrecurrencedialog={handleOpenRecurrenceDialog}
@@ -315,6 +318,9 @@
         role="tooltip"
         aria-live="polite"
         data-element-id="div-detail-popover"
+        onkeyup={handleDetailPopoverKeyUp}
+        onmouseenter={handleDetailPopoverMouseEnter}
+        onmouseleave={handleDetailPopoverMouseLeave}
     >
         <lightning-focus-trap>
             <lightning-button-icon
@@ -326,6 +332,8 @@
                 icon-name="utility:close"
                 size="small"
                 variant="bare"
+                data-element-id="lightning-button-icon-detail-popover-close-button"
+                onclick={hideDetailPopover}
             ></lightning-button-icon>
 
             <div class="slds-popover__body">
@@ -359,15 +367,18 @@
                     <template for:each={firstEventActions} for:item="action">
                         <lightning-button
                             key={action.name}
-                            name={action.name}
                             label={action.label}
                             icon-name={action.iconName}
+                            name={action.name}
+                            onclick={handleActionSelect}
                         ></lightning-button>
                     </template>
                     <lightning-button-menu
                         if:true={lastEventActions.length}
                         alternative-text="More actions"
+                        menu-alignment="right"
                         variant="border-filled"
+                        onselect={handleActionSelect}
                     >
                         <template for:each={lastEventActions} for:item="action">
                             <lightning-menu-item

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -241,6 +241,7 @@
             events={computedEvents}
             events-labels={eventsLabels}
             events-theme={eventsTheme}
+            hide-resources-filter={hideResourcesFilter}
             hide-side-panel={hideSidePanel}
             loading-state-alternative-text={loadingStateAlternativeText}
             read-only={readOnly}
@@ -248,7 +249,6 @@
             resources={computedResources}
             selected-date={selectedDate}
             selected-resources={selectedResources}
-            selected-resources-read-only={selectedResourcesReadOnly}
             side-panel-position={sidePanelPosition}
             time-span={currentTimeSpan}
             zoom-to-fit={zoomToFit}
@@ -277,13 +277,13 @@
             date-format={dateFormat}
             events={computedEvents}
             events-labels={eventsLabels}
+            hide-resources-filter={hideResourcesFilter}
             hide-side-panel={hideSidePanel}
             read-only={readOnly}
             resize-column-disabled={resizeColumnDisabled}
             resources={computedResources}
             selected-date={selectedDate}
             selected-resources={selectedResources}
-            selected-resources-read-only={selectedResourcesReadOnly}
             side-panel-position={sidePanelPosition}
             time-span={currentTimeSpan}
             data-element-id="avonni-primitive-scheduler-agenda"

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -187,6 +187,7 @@
     <template if:false={isLoading}>
         <c-primitive-scheduler-timeline
             if:true={showTimeline}
+            class="avonni-scheduler__schedule slds-show"
             available-days-of-the-week={availableDaysOfTheWeek}
             available-months={availableMonths}
             available-time-frames={availableTimeFrames}
@@ -232,7 +233,10 @@
 
         <c-primitive-scheduler-calendar
             if:true={isCalendar}
-            class="avonni-scheduler__calendar slds-is-relative"
+            class="
+                avonni-scheduler__calendar avonni-scheduler__schedule
+                slds-is-relative slds-show
+            "
             available-days-of-the-week={availableDaysOfTheWeek}
             available-months={availableMonths}
             available-time-frames={availableTimeFrames}
@@ -271,6 +275,7 @@
 
         <c-primitive-scheduler-agenda
             if:true={isAgenda}
+            class="avonni-scheduler__schedule slds-show"
             available-days-of-the-week={availableDaysOfTheWeek}
             available-months={availableMonths}
             available-time-frames={availableTimeFrames}

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -172,11 +172,9 @@
             dropdown-alignment="right"
             hide-apply-reset-buttons
             hide-selected-items
-            is-multi-select
             icon-name="utility:filterList"
-            items={resourceOptions}
-            show-search-box
             title="Select resources"
+            type-attributes={resourceFilterTypeAttributes}
             value={selectedResources}
             data-element-id="avonni-filter-menu-resources"
             onselect={handleToolbarResourceSelect}

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -312,7 +312,7 @@
     <!-- Event detail popover -->
     <div
         if:true={showDetailPopover}
-        class="slds-is-fixed slds-popover slds-popover_medium"
+        class="slds-is-absolute slds-popover slds-popover_medium"
         role="tooltip"
         aria-live="polite"
         data-element-id="div-detail-popover"
@@ -398,7 +398,7 @@
     <!-- Event context menu -->
     <c-primitive-dropdown-menu
         if:true={contextMenuActions.length}
-        class="slds-is-fixed avonni-scheduler__context-menu"
+        class="slds-is-absolute avonni-scheduler__context-menu"
         show={showContextMenu}
         items={contextMenuActions}
         data-element-id="avonni-primitive-dropdown-menu"

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -240,6 +240,7 @@
             events={computedEvents}
             events-labels={eventsLabels}
             events-theme={eventsTheme}
+            hide-side-panel={hideSidePanel}
             loading-state-alternative-text={loadingStateAlternativeText}
             read-only={readOnly}
             resize-column-disabled={resizeColumnDisabled}
@@ -272,6 +273,7 @@
             date-format={dateFormat}
             events={computedEvents}
             events-labels={eventsLabels}
+            hide-side-panel={hideSidePanel}
             read-only={readOnly}
             resize-column-disabled={resizeColumnDisabled}
             resources={computedResources}

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -247,6 +247,7 @@
             resources={computedResources}
             selected-date={selectedDate}
             selected-resources={selectedResources}
+            side-panel-position={sidePanelPosition}
             time-span={currentTimeSpan}
             zoom-to-fit={zoomToFit}
             data-element-id="avonni-primitive-scheduler-calendar"
@@ -279,6 +280,7 @@
             resources={computedResources}
             selected-date={selectedDate}
             selected-resources={selectedResources}
+            side-panel-position={sidePanelPosition}
             time-span={currentTimeSpan}
             data-element-id="avonni-primitive-scheduler-agenda"
             ondatechange={handleSelectedDateChange}

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -166,7 +166,7 @@
         </c-button-menu>
 
         <c-filter-menu
-            if:true={isTimeline}
+            if:true={showResourceFilter}
             class="slds-m-left_small"
             alternative-text="Select resources"
             dropdown-alignment="right"
@@ -247,6 +247,7 @@
             resources={computedResources}
             selected-date={selectedDate}
             selected-resources={selectedResources}
+            selected-resources-read-only={selectedResourcesReadOnly}
             side-panel-position={sidePanelPosition}
             time-span={currentTimeSpan}
             zoom-to-fit={zoomToFit}
@@ -280,6 +281,7 @@
             resources={computedResources}
             selected-date={selectedDate}
             selected-resources={selectedResources}
+            selected-resources-read-only={selectedResourcesReadOnly}
             side-panel-position={sidePanelPosition}
             time-span={currentTimeSpan}
             data-element-id="avonni-primitive-scheduler-agenda"

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -36,12 +36,7 @@
     <!-- Toolbar -->
     <div
         if:false={hideToolbar}
-        class="
-            slds-grid
-            slds-p-bottom_medium
-            slds-grid_vertical-align-center
-            avonni-scheduler__toolbar
-        "
+        class="slds-grid slds-p-bottom_medium slds-grid_vertical-align-center"
         data-element-id="div-toolbar"
     >
         <!-- Toolbar time spans -->

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -126,21 +126,21 @@
         <!-- Toolbar next/today/previous navigation -->
         <div class="slds-grid">
             <lightning-button-icon
-                class="avonni-scheduler__toolbar-nav-button_first"
+                class="avonni-scheduler__toolbar-button-group_first"
                 disabled={showEmptyTimelineMessage}
                 icon-name="utility:chevronleft"
                 data-element-id="lightning-button-icon-toolbar-prev"
                 onclick={handleToolbarPrevClick}
             ></lightning-button-icon>
             <lightning-button
-                class="avonni-scheduler__toolbar-nav-button_middle"
+                class="avonni-scheduler__toolbar-button-group_middle"
                 disabled={showEmptyTimelineMessage}
                 label="Today"
                 data-element-id="lightning-button-icon-toolbar-today"
                 onclick={handleToolbarTodayClick}
             ></lightning-button>
             <lightning-button-icon
-                class="avonni-scheduler__toolbar-nav-button_last"
+                class="avonni-scheduler__toolbar-button-group_last"
                 disabled={showEmptyTimelineMessage}
                 icon-name="utility:chevronright"
                 data-element-id="lightning-button-icon-toolbar-next"
@@ -148,26 +148,63 @@
             ></lightning-button-icon>
         </div>
 
-        <c-button-menu
-            if:true={moreThanOneDisplay}
-            class="slds-m-left_small avonni-scheduler__display-menu"
-            label={computedSelectedDisplay.label}
-            menu-alignment="right"
-            data-element-id="avonni-button-menu-toolbar-display"
-            onselect={handleDisplaySelect}
-        >
-            <template for:each={displayOptions} for:item="displayOption">
-                <lightning-menu-item
-                    key={displayOption.value}
-                    checked={displayOption.checked}
-                    icon-name={displayOption.iconName}
-                    label={displayOption.label}
-                    value={displayOption.value}
-                    data-element-id="lightning-menu-item-display"
-                ></lightning-menu-item>
-            </template>
-        </c-button-menu>
+        <div class="slds-m-left_small slds-grid">
+            <!-- Displays -->
+            <c-button-menu
+                if:true={moreThanOneDisplay}
+                class={displayButtonClass}
+                label={computedSelectedDisplay.label}
+                menu-alignment="right"
+                data-element-id="avonni-button-menu-toolbar-display"
+                onselect={handleDisplaySelect}
+            >
+                <template for:each={displayOptions} for:item="displayOption">
+                    <lightning-menu-item
+                        key={displayOption.value}
+                        checked={displayOption.checked}
+                        icon-name={displayOption.iconName}
+                        label={displayOption.label}
+                        value={displayOption.value}
+                        data-element-id="lightning-menu-item-display"
+                    ></lightning-menu-item>
+                </template>
+            </c-button-menu>
 
+            <!-- Actions -->
+            <lightning-button
+                if:true={oneHeaderActionButton}
+                class={headerActionButtonClass}
+                icon-name={oneHeaderActionButton.iconName}
+                label={oneHeaderActionButton.label}
+                value={oneHeaderActionButton.name}
+            ></lightning-button>
+            <lightning-button-icon
+                if:true={oneHeaderActionButtonIcon}
+                class={headerActionButtonClass}
+                alternative-text={oneHeaderActionButtonIcon.name}
+                icon-name={oneHeaderActionButtonIcon.iconName}
+                value={oneHeaderActionButtonIcon.name}
+                variant="border-filled"
+            ></lightning-button-icon>
+            <c-button-menu
+                if:true={moreThanOneHeaderAction}
+                class={headerActionButtonClass}
+                alternative-text="Actions"
+                menu-alignment="right"
+                onselect={handleHeaderActionSelect}
+            >
+                <template for:each={headerActions} for:item="action">
+                    <lightning-menu-item
+                        key={action.name}
+                        icon-name={action.iconName}
+                        label={action.label}
+                        value={action.name}
+                    ></lightning-menu-item>
+                </template>
+            </c-button-menu>
+        </div>
+
+        <!-- Resources filter -->
         <c-filter-menu
             if:true={showResourceFilter}
             class="slds-m-left_small"

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -36,7 +36,12 @@
     <!-- Toolbar -->
     <div
         if:false={hideToolbar}
-        class="slds-grid slds-m-bottom_medium slds-grid_vertical-align-center"
+        class="
+            slds-grid
+            slds-p-bottom_medium
+            slds-grid_vertical-align-center
+            avonni-scheduler__toolbar
+        "
         data-element-id="div-toolbar"
     >
         <!-- Toolbar time spans -->
@@ -58,6 +63,7 @@
                 if:true={toolbarTimeSpanMenuItems.length}
                 disabled={showEmptyTimelineMessage}
                 icon-name="utility:down"
+                variant="border-filled"
                 data-element-id="avonni-button-menu-toolbar-spans"
             >
                 <template
@@ -129,6 +135,7 @@
                 class="avonni-scheduler__toolbar-button-group_first"
                 disabled={showEmptyTimelineMessage}
                 icon-name="utility:chevronleft"
+                variant="border-filled"
                 data-element-id="lightning-button-icon-toolbar-prev"
                 onclick={handleToolbarPrevClick}
             ></lightning-button-icon>
@@ -143,6 +150,7 @@
                 class="avonni-scheduler__toolbar-button-group_last"
                 disabled={showEmptyTimelineMessage}
                 icon-name="utility:chevronright"
+                variant="border-filled"
                 data-element-id="lightning-button-icon-toolbar-next"
                 onclick={handleToolbarNextClick}
             ></lightning-button-icon>

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -406,7 +406,7 @@
     <!-- Event context menu -->
     <c-primitive-dropdown-menu
         if:true={contextMenuActions.length}
-        class="slds-is-absolute avonni-scheduler__context-menu"
+        class="slds-is-fixed avonni-scheduler__context-menu"
         show={showContextMenu}
         items={contextMenuActions}
         data-element-id="avonni-primitive-dropdown-menu"

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -311,41 +311,76 @@
     <!-- Event detail popover -->
     <div
         if:true={showDetailPopover}
-        class="
-            avonni-scheduler__event-detail-popover
-            slds-is-fixed slds-popover slds-dropdown slds-dropdown_left
-        "
+        class="slds-is-fixed slds-popover slds-popover_medium"
         role="tooltip"
         aria-live="polite"
         data-element-id="div-detail-popover"
     >
-        <div class="slds-popover__body">
-            <div class="slds-m-bottom_x-small">
-                <strong>{selection.occurrence.title}</strong>
+        <lightning-focus-trap>
+            <lightning-button-icon
+                class="
+                    slds-is-absolute
+                    avonni-scheduler__detail-popover-close-button
+                "
+                alternative-text="Close popover"
+                icon-name="utility:close"
+                size="small"
+                variant="bare"
+            ></lightning-button-icon>
+
+            <div class="slds-popover__body">
+                <div class="slds-m-bottom_small slds-text-heading_small">
+                    {selection.occurrence.title}
+                </div>
+                <div class="slds-grid slds-wrap slds-gutters_x-small">
+                    <template for:each={detailPopoverFields} for:item="field">
+                        <div
+                            key={field.key}
+                            class="
+                                slds-col
+                                slds-size_1-of-2
+                                slds-p-vertical_xx-small
+                            "
+                        >
+                            <c-output-data
+                                label={field.label}
+                                type={field.type}
+                                type-attributes={field.typeAttributes}
+                                value={field.value}
+                                variant={field.variant}
+                            ></c-output-data>
+                        </div>
+                    </template>
+                </div>
             </div>
-            <div class="slds-grid" data-element-id="div-event-detail-from">
-                <lightning-icon
-                    class="
-                        avonni-scheduler__event-detail-icon
-                        slds-m-right_xx-small
-                    "
-                    icon-name="utility:clock"
-                    size="x-small"
-                ></lightning-icon>
-                {selectionFrom}
+
+            <div class="slds-popover__footer slds-text-align_right">
+                <lightning-button-group>
+                    <template for:each={firstEventActions} for:item="action">
+                        <lightning-button
+                            key={action.name}
+                            name={action.name}
+                            label={action.label}
+                            icon-name={action.iconName}
+                        ></lightning-button>
+                    </template>
+                    <lightning-button-menu
+                        if:true={lastEventActions.length}
+                        alternative-text="More actions"
+                        variant="border-filled"
+                    >
+                        <template for:each={lastEventActions} for:item="action">
+                            <lightning-menu-item
+                                key={action.name}
+                                label={action.label}
+                                prefix-icon-name={action.iconName}
+                                value={action.name}
+                            ></lightning-menu-item>
+                        </template>
+                    </lightning-button-menu>
+                </lightning-button-group>
             </div>
-            <div class="slds-grid" data-element-id="div-event-detail-to">
-                <lightning-icon
-                    class="
-                        avonni-scheduler__event-detail-icon
-                        slds-m-right_xx-small
-                    "
-                    icon-name="utility:clock"
-                    size="x-small"
-                ></lightning-icon>
-                {selectionTo}
-            </div>
-        </div>
+        </lightning-focus-trap>
     </div>
 
     <!-- Event context menu -->

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -360,7 +360,10 @@
                 </div>
             </div>
 
-            <div class="slds-popover__footer slds-text-align_right">
+            <div
+                if:true={computedContextMenuEvent.length}
+                class="slds-popover__footer slds-text-align_right"
+            >
                 <lightning-button-group>
                     <template for:each={firstEventActions} for:item="action">
                         <lightning-button

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -180,30 +180,30 @@
 
             <!-- Actions -->
             <lightning-button
-                if:true={oneHeaderActionButton}
-                class={headerActionButtonClass}
-                icon-name={oneHeaderActionButton.iconName}
-                label={oneHeaderActionButton.label}
-                value={oneHeaderActionButton.name}
-                onclick={handleHeaderActionSelect}
+                if:true={oneToolbarActionButton}
+                class={toolbarActionButtonClass}
+                icon-name={oneToolbarActionButton.iconName}
+                label={oneToolbarActionButton.label}
+                value={oneToolbarActionButton.name}
+                onclick={handleToolbarActionSelect}
             ></lightning-button>
             <lightning-button-icon
-                if:true={oneHeaderActionButtonIcon}
-                class={headerActionButtonClass}
-                alternative-text={oneHeaderActionButtonIcon.name}
-                icon-name={oneHeaderActionButtonIcon.iconName}
-                value={oneHeaderActionButtonIcon.name}
+                if:true={oneToolbarActionButtonIcon}
+                class={toolbarActionButtonClass}
+                alternative-text={oneToolbarActionButtonIcon.name}
+                icon-name={oneToolbarActionButtonIcon.iconName}
+                value={oneToolbarActionButtonIcon.name}
                 variant="border-filled"
-                onclick={handleHeaderActionSelect}
+                onclick={handleToolbarActionSelect}
             ></lightning-button-icon>
             <c-button-menu
-                if:true={moreThanOneHeaderAction}
-                class={headerActionButtonClass}
+                if:true={moreThanOneToolbarAction}
+                class={toolbarActionButtonClass}
                 alternative-text="Actions"
                 menu-alignment="right"
-                onselect={handleHeaderActionSelect}
+                onselect={handleToolbarActionSelect}
             >
-                <template for:each={headerActions} for:item="action">
+                <template for:each={toolbarActions} for:item="action">
                     <lightning-menu-item
                         key={action.name}
                         icon-name={action.iconName}

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -229,15 +229,6 @@
             data-element-id="avonni-filter-menu-resources"
             onselect={handleToolbarResourceSelect}
         ></c-filter-menu>
-
-        <lightning-button-icon-stateful
-            if:true={showSidePanelToggle}
-            class="slds-m-left_x-small"
-            icon-name="utility:rows"
-            selected={sidePanelIsExpanded}
-            variant="border-filled"
-            onclick={handleToolbarSidePanelToggle}
-        ></lightning-button-icon-stateful>
     </div>
 
     <template if:false={isLoading}>
@@ -261,7 +252,6 @@
             resize-column-disabled={resizeColumnDisabled}
             resources={computedResources}
             selected-resources={selectedResources}
-            side-panel-is-expanded={sidePanelIsExpanded}
             start={start}
             time-span={currentTimeSpan}
             orientation={variant}
@@ -277,7 +267,6 @@
             oneventselect={handleEventSelect}
             onopeneditdialog={handleOpenEditDialog}
             onopenrecurrencedialog={handleOpenRecurrenceDialog}
-            ontogglesidepanel={handleToggleSidePanel}
             onvisibleintervalchange={handleVisibleIntervalChange}
         ></c-primitive-scheduler-timeline>
 
@@ -312,7 +301,6 @@
             resources={computedResources}
             selected-date={selectedDate}
             selected-resources={selectedResources}
-            side-panel-is-expanded={sidePanelIsExpanded}
             side-panel-position={sidePanelPosition}
             time-span={currentTimeSpan}
             zoom-to-fit={zoomToFit}
@@ -329,7 +317,6 @@
             onopeneditdialog={handleOpenEditDialog}
             onopenrecurrencedialog={handleOpenRecurrenceDialog}
             onresourceselect={handleResourceSelect}
-            ontogglesidepanel={handleToggleSidePanel}
             onvisibleintervalchange={handleVisibleIntervalChange}
         ></c-primitive-scheduler-calendar>
 
@@ -350,7 +337,6 @@
             resources={computedResources}
             selected-date={selectedDate}
             selected-resources={selectedResources}
-            side-panel-is-expanded={sidePanelIsExpanded}
             side-panel-position={sidePanelPosition}
             time-span={currentTimeSpan}
             data-element-id="avonni-primitive-scheduler-agenda"
@@ -366,7 +352,6 @@
             onopeneditdialog={handleOpenEditDialog}
             onopenrecurrencedialog={handleOpenRecurrenceDialog}
             onresourceselect={handleResourceSelect}
-            ontogglesidepanel={handleToggleSidePanel}
             onvisibleintervalchange={handleVisibleIntervalChange}
         ></c-primitive-scheduler-agenda>
     </template>

--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -185,6 +185,7 @@
                 icon-name={oneHeaderActionButton.iconName}
                 label={oneHeaderActionButton.label}
                 value={oneHeaderActionButton.name}
+                onclick={handleHeaderActionSelect}
             ></lightning-button>
             <lightning-button-icon
                 if:true={oneHeaderActionButtonIcon}
@@ -193,6 +194,7 @@
                 icon-name={oneHeaderActionButtonIcon.iconName}
                 value={oneHeaderActionButtonIcon.name}
                 variant="border-filled"
+                onclick={handleHeaderActionSelect}
             ></lightning-button-icon>
             <c-button-menu
                 if:true={moreThanOneHeaderAction}

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -93,6 +93,7 @@ export default class Scheduler extends LightningElement {
     _eventsPalette = EVENTS_PALETTES.default;
     _eventsTheme = EVENTS_THEMES.default;
     _hiddenDisplays = [];
+    _hideSidePanel = false;
     _hideToolbar = false;
     _isLoading = false;
     _loadingStateAlternativeText = DEFAULT_LOADING_STATE_ALTERNATIVE_TEXT;
@@ -570,6 +571,21 @@ export default class Scheduler extends LightningElement {
         this._hiddenDisplays = displays.filter((display) => {
             return DISPLAYS.valid.includes(display);
         });
+    }
+
+    /**
+     * If present, the side panel will be hidden. This attribute only affects the agenda and calendar displays.
+     *
+     * @type {boolean}
+     * @public
+     * @default false
+     */
+    @api
+    get hideSidePanel() {
+        return this._hideSidePanel;
+    }
+    set hideSidePanel(value) {
+        this._hideSidePanel = normalizeBoolean(value);
     }
 
     /**

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -947,6 +947,9 @@ export default class Scheduler extends LightningElement {
     }
     set start(value) {
         const computedDate = dateTimeObjectFrom(value);
+        if (computedDate.ts === this._start.ts) {
+            return;
+        }
         this._start = computedDate || dateTimeObjectFrom(DEFAULT_START_DATE);
         this.selectedDate = dateTimeObjectFrom(this._start);
 
@@ -1551,6 +1554,22 @@ export default class Scheduler extends LightningElement {
                 // Start is not on a Sunday and the unit is week
                 start = removeFromDate(start, 'day', 1);
             }
+        }
+
+        if (start !== this.start) {
+            /**
+             * The event fired when the start date changes.
+             *
+             * @event
+             * @name startchange
+             * @param {string} value New start date, as an ISO 8601 formatted string.
+             * @public
+             */
+            this.dispatchEvent(
+                new CustomEvent('startchange', {
+                    detail: { value: start.toISO() }
+                })
+            );
         }
         this._start = start;
     }

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -134,7 +134,6 @@ export default class Scheduler extends LightningElement {
     currentTimeSpan = {};
     detailPopoverFields = [];
     selectedDate = dateTimeObjectFrom(DEFAULT_START_DATE);
-    sidePanelIsExpanded = true;
     showContextMenu = false;
     showEditDialog = false;
     showDeleteConfirmationDialog = false;
@@ -1349,15 +1348,6 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
-     * True if the side panel toggle button should be displayed.
-     *
-     * @type {boolean}
-     */
-    get showSidePanelToggle() {
-        return !this.collapseDisabled && !this.hideSidePanel;
-    }
-
-    /**
      * If true, when editing a recurring event, the user always have the choice to save the changes only for the occurrence or for every occurrences of the event.
      *
      * @type {boolean}
@@ -1475,6 +1465,19 @@ export default class Scheduler extends LightningElement {
      */
 
     /**
+     * Collapse the side panel. If the panel was fully expanded, collapse it to its original position. Otherwise, hide it.
+     *
+     * @public
+     */
+    @api
+    collapseSidePanel() {
+        if (!this.schedule) {
+            return;
+        }
+        this.schedule.collapseSidePanel();
+    }
+
+    /**
      * Create a new event.
      *
      * @param {object} event Event object of the new event.
@@ -1506,6 +1509,19 @@ export default class Scheduler extends LightningElement {
             return;
         }
         this.schedule.deleteEvent(eventName);
+    }
+
+    /**
+     * Expand the side panel. If the panel was already opened, expand it fully. Otherwise, open it.
+     *
+     * @public
+     */
+    @api
+    expandSidePanel() {
+        if (!this.schedule) {
+            return;
+        }
+        this.schedule.expandSidePanel();
     }
 
     /**
@@ -2310,15 +2326,6 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
-     * Handle the toggle of the side panel from the schedule.
-     *
-     * @param {Event} event togglesidepanel event.
-     */
-    handleToggleSidePanel(event) {
-        this.sidePanelIsExpanded = event.detail.isExpanded;
-    }
-
-    /**
      * Handle the toggling of the toolbar calendar.
      *
      * @param {Event} event
@@ -2459,13 +2466,6 @@ export default class Scheduler extends LightningElement {
         }
         this._selectedResources = selectedResources;
         this.dispatchResourceSelectEvent(name);
-    }
-
-    /**
-     * Handle the toggle of the side panel from the toolbar button.
-     */
-    handleToolbarSidePanelToggle() {
-        this.sidePanelIsExpanded = !this.sidePanelIsExpanded;
     }
 
     /**

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -97,7 +97,6 @@ export default class Scheduler extends LightningElement {
     _eventsPalette = EVENTS_PALETTES.default;
     _eventsDisplayFields = DEFAULT_EVENTS_DISPLAY_FIELDS;
     _eventsTheme = EVENTS_THEMES.default;
-    _headerActions = [];
     _hiddenDisplays = [];
     _hideResourcesFilter = false;
     _hideSidePanel = false;
@@ -115,6 +114,7 @@ export default class Scheduler extends LightningElement {
     _sidePanelPosition = SIDE_PANEL_POSITIONS.default;
     _start = dateTimeObjectFrom(DEFAULT_START_DATE);
     _timeSpans = TIME_SPANS.default;
+    _toolbarActions = [];
     _variant = VARIANTS.default;
     _zoomToFit = false;
 
@@ -588,24 +588,6 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
-     * Array of action objects. If present, the actions will be shown in the toolbar.
-     *
-     * @type {object[]}
-     * @public
-     */
-    @api
-    get headerActions() {
-        return this._headerActions;
-    }
-    set headerActions(value) {
-        const actions = normalizeArray(value, 'object');
-        if (equal(this._headerActions, actions)) {
-            return;
-        }
-        this._headerActions = actions;
-    }
-
-    /**
      * Deprecated. Set the headers in each time span instead.
      *
      * @type {string}
@@ -1058,6 +1040,24 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
+     * Array of action objects. If present, the actions will be shown in the toolbar.
+     *
+     * @type {object[]}
+     * @public
+     */
+    @api
+    get toolbarActions() {
+        return this._toolbarActions;
+    }
+    set toolbarActions(value) {
+        const actions = normalizeArray(value, 'object');
+        if (equal(this._toolbarActions, actions)) {
+            return;
+        }
+        this._toolbarActions = actions;
+    }
+
+    /**
      * Deprecated. Use the `time-spans` instead.
      *
      * @type {object[]}
@@ -1181,7 +1181,7 @@ export default class Scheduler extends LightningElement {
         return classSet('avonni-scheduler__display-menu')
             .add({
                 'avonni-scheduler__toolbar-button-group_first':
-                    this.headerActions.length
+                    this.toolbarActions.length
             })
             .toString();
     }
@@ -1207,7 +1207,7 @@ export default class Scheduler extends LightningElement {
         return this.computedContextMenuEvent.slice(0, 2);
     }
 
-    get headerActionButtonClass() {
+    get toolbarActionButtonClass() {
         return classSet({
             'avonni-scheduler__toolbar-button-group_last':
                 this.moreThanOneDisplay
@@ -1260,40 +1260,40 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
-     * True if there is more than one header action.
+     * True if there is more than one toolbar action.
      *
      * @type {boolean}
      */
-    get moreThanOneHeaderAction() {
-        return this.headerActions.length > 1;
+    get moreThanOneToolbarAction() {
+        return this.toolbarActions.length > 1;
     }
 
     /**
-     * If only one header action is present, and it has a label, returns the action object.
+     * If only one toolbar action is present, and it has a label, returns the action object.
      * Otherwise, returns false.
      *
      * @type {object|boolean}
      */
-    get oneHeaderActionButton() {
-        if (this.headerActions.length === 1 && this.headerActions[0].label) {
-            return this.headerActions[0];
+    get oneToolbarActionButton() {
+        if (this.toolbarActions.length === 1 && this.toolbarActions[0].label) {
+            return this.toolbarActions[0];
         }
         return false;
     }
 
     /**
-     * If only one header action is present, and it doesn't have a label but it has an icon, returns the action object.
+     * If only one toolbar action is present, and it doesn't have a label but it has an icon, returns the action object.
      * Otherwise, returns false.
      *
      * @type {object|boolean}
      */
-    get oneHeaderActionButtonIcon() {
+    get oneToolbarActionButtonIcon() {
         if (
-            this.headerActions.length === 1 &&
-            this.headerActions[0].iconName &&
-            !this.headerActions[0].label
+            this.toolbarActions.length === 1 &&
+            this.toolbarActions[0].iconName &&
+            !this.toolbarActions[0].label
         ) {
-            return this.headerActions[0];
+            return this.toolbarActions[0];
         }
         return false;
     }
@@ -2208,24 +2208,24 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
-     * Handle a click on a header action.
+     * Handle a click on a toolbar action.
      *
      * @param {Event} event click or select event.
      */
-    handleHeaderActionSelect(event) {
+    handleToolbarActionSelect(event) {
         const name = event.detail.value || event.currentTarget.value;
 
         /**
-         * The event fired when a user clicks on a header action.
+         * The event fired when a user clicks on a toolbar action.
          *
          * @event
-         * @name headeractionclick
+         * @name toolbaractionclick
          * @param {string} name Name of the action clicked.
          * @public
          * @bubbles
          */
         this.dispatchEvent(
-            new CustomEvent('headeractionclick', {
+            new CustomEvent('toolbaractionclick', {
                 detail: { name },
                 bubbles: true
             })

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -32,6 +32,7 @@
 
 import { LightningElement, api, track } from 'lwc';
 import {
+    equal,
     normalizeArray,
     normalizeBoolean,
     normalizeString,
@@ -96,6 +97,7 @@ export default class Scheduler extends LightningElement {
     _eventsPalette = EVENTS_PALETTES.default;
     _eventsDisplayFields = DEFAULT_EVENTS_DISPLAY_FIELDS;
     _eventsTheme = EVENTS_THEMES.default;
+    _headerActions = [];
     _hiddenDisplays = [];
     _hideResourcesFilter = false;
     _hideSidePanel = false;
@@ -598,6 +600,24 @@ export default class Scheduler extends LightningElement {
         console.warn(
             'The "headers" attribute is deprecated. Set the headers in each time span instead.'
         );
+    }
+
+    /**
+     * Array of action objects. If present, the actions will be shown in the toolbar.
+     *
+     * @type {object[]}
+     * @public
+     */
+    @api
+    get headerActions() {
+        return this._headerActions;
+    }
+    set headerActions(value) {
+        const actions = normalizeArray(value, 'object');
+        if (equal(this._headerActions, actions)) {
+            return;
+        }
+        this._headerActions = actions;
     }
 
     /**
@@ -1156,6 +1176,15 @@ export default class Scheduler extends LightningElement {
             : (actions.length && actions) || DEFAULT_CONTEXT_MENU_EVENT_ACTIONS;
     }
 
+    get displayButtonClass() {
+        return classSet('avonni-scheduler__display-menu')
+            .add({
+                'avonni-scheduler__toolbar-button-group_first':
+                    this.headerActions.length
+            })
+            .toString();
+    }
+
     /**
      * Computed title of the edit dialog.
      *
@@ -1175,6 +1204,13 @@ export default class Scheduler extends LightningElement {
      */
     get firstEventActions() {
         return this.computedContextMenuEvent.slice(0, 2);
+    }
+
+    get headerActionButtonClass() {
+        return classSet({
+            'avonni-scheduler__toolbar-button-group_last':
+                this.moreThanOneDisplay
+        }).toString();
     }
 
     /**
@@ -1220,6 +1256,45 @@ export default class Scheduler extends LightningElement {
      */
     get moreThanOneDisplay() {
         return this.displayOptions.length > 1;
+    }
+
+    /**
+     * True if there is more than one header action.
+     *
+     * @type {boolean}
+     */
+    get moreThanOneHeaderAction() {
+        return this.headerActions.length > 1;
+    }
+
+    /**
+     * If only one header action is present, and it has a label, returns the action object.
+     * Otherwise, returns false.
+     *
+     * @type {object|boolean}
+     */
+    get oneHeaderActionButton() {
+        if (this.headerActions.length === 1 && this.headerActions[0].label) {
+            return this.headerActions[0];
+        }
+        return false;
+    }
+
+    /**
+     * If only one header action is present, and it doesn't have a label but it has an icon, returns the action object.
+     * Otherwise, returns false.
+     *
+     * @type {object|boolean}
+     */
+    get oneHeaderActionButtonIcon() {
+        if (
+            this.headerActions.length === 1 &&
+            this.headerActions[0].iconName &&
+            !this.headerActions[0].label
+        ) {
+            return this.headerActions[0];
+        }
+        return false;
     }
 
     /**

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -1889,6 +1889,7 @@ export default class Scheduler extends LightningElement {
         if (!this.computedContextMenuEvent.length) {
             return;
         }
+        clearTimeout(this._openDetailPopoverTimeout);
         this.hideDetailPopover();
         this.contextMenuActions = [...this.computedContextMenuEvent];
         this.selection = event.currentTarget.selectEvent(event.detail);

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -1215,6 +1215,19 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
+     * Type attributes of the toolbar resource filter, visible in the timeline display.
+     *
+     * @type {object}
+     */
+    get resourceFilterTypeAttributes() {
+        return {
+            allowSearch: true,
+            isMultiSelect: true,
+            items: this.resourceOptions
+        };
+    }
+
+    /**
      * Array of resources options. The objects have two keys: label and value. Used in the edit form to generate a combobox of key fields.
      *
      * @type {object[]}

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -517,7 +517,7 @@ export default class Scheduler extends LightningElement {
     /**
      * Default palette used for the event colors. Valid values include aurora, bluegrass, dusk, fire, heat, lake, mineral, nightfall, ocean, pond, sunrise, water, watermelon and wildflowers (see Palette table for more information).
      *
-     * @type {string[]}
+     * @type {string}
      * @public
      * @default aurora
      */

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -42,6 +42,7 @@ import {
 } from 'c/utilsPrivate';
 import {
     getDisabledWeekdaysLabels,
+    parseTimeFrame,
     positionPopover,
     previousAllowedDay,
     previousAllowedMonth,
@@ -240,9 +241,14 @@ export default class Scheduler extends LightningElement {
         return this._availableTimeFrames;
     }
     set availableTimeFrames(value) {
-        const timeFrames = normalizeArray(value);
+        const timeFrames = normalizeArray(value, 'string');
+        const validTimeFrames = timeFrames.filter((timeFrame) => {
+            return parseTimeFrame(timeFrame).valid;
+        });
         this._availableTimeFrames =
-            timeFrames.length > 0 ? timeFrames : DEFAULT_AVAILABLE_TIME_FRAMES;
+            validTimeFrames.length > 0
+                ? validTimeFrames
+                : DEFAULT_AVAILABLE_TIME_FRAMES;
     }
 
     /**

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -96,6 +96,7 @@ export default class Scheduler extends LightningElement {
     _eventsDisplayFields = DEFAULT_EVENTS_DISPLAY_FIELDS;
     _eventsTheme = EVENTS_THEMES.default;
     _hiddenDisplays = [];
+    _hideResourcesFilter = false;
     _hideSidePanel = false;
     _hideToolbar = false;
     _isLoading = false;
@@ -107,7 +108,6 @@ export default class Scheduler extends LightningElement {
     _resources = [];
     _selectedDisplay = DISPLAYS.default;
     _selectedResources = [];
-    _selectedResourcesReadOnly = false;
     _selectedTimeSpan = DEFAULT_SELECTED_TIME_SPAN;
     _sidePanelPosition = SIDE_PANEL_POSITIONS.default;
     _start = dateTimeObjectFrom(DEFAULT_START_DATE);
@@ -609,6 +609,21 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
+     * If present, the resources filter is hidden.
+     *
+     * @type {boolean}
+     * @public
+     * @default false
+     */
+    @api
+    get hideResourcesFilter() {
+        return this._hideResourcesFilter;
+    }
+    set hideResourcesFilter(value) {
+        this._hideResourcesFilter = normalizeBoolean(value);
+    }
+
+    /**
      * If present, the side panel will be hidden. This attribute only affects the agenda and calendar displays.
      *
      * @type {boolean}
@@ -865,21 +880,6 @@ export default class Scheduler extends LightningElement {
     }
     set selectedResources(value) {
         this._selectedResources = normalizeArray(value, 'string');
-    }
-
-    /**
-     * If present, it is not possible for the user to select or unselect resources.
-     *
-     * @type {boolean}
-     * @public
-     * @default false
-     */
-    @api
-    get selectedResourcesReadOnly() {
-        return this._selectedResourcesReadOnly;
-    }
-    set selectedResourcesReadOnly(value) {
-        this._selectedResourcesReadOnly = normalizeBoolean(value);
     }
 
     /**
@@ -1255,7 +1255,7 @@ export default class Scheduler extends LightningElement {
      * @type {boolean}
      */
     get showResourceFilter() {
-        return this.isTimeline && !this.selectedResourcesReadOnly;
+        return this.isTimeline && !this.hideResourcesFilter;
     }
 
     /**

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -1717,11 +1717,14 @@ export default class Scheduler extends LightningElement {
     /**
      * Handle the click on an action.
      *
-     * @param {Event} event `privateselect` event fired by the context menu, or `select` event fired by the detail popover button menu, or `click` event fired by a detail popover button.
+     * @param {Event} selectEvent `privateselect` event fired by the context menu, or `select` event fired by the detail popover button menu, or `click` event fired by a detail popover button.
      */
-    handleActionSelect(event) {
+    handleActionSelect(selectEvent) {
         const name =
-            event.detail.name || event.detail.value || event.currentTarget.name;
+            selectEvent.detail.name ||
+            selectEvent.detail.value ||
+            selectEvent.currentTarget.name;
+        const { event, from, to } = this.selection;
 
         /**
          * The event fired when a user clicks on an action.
@@ -1736,10 +1739,10 @@ export default class Scheduler extends LightningElement {
         this.dispatchEvent(
             new CustomEvent('actionclick', {
                 detail: {
+                    from,
                     name,
-                    targetName: this.selection.event
-                        ? this.selection.event.name
-                        : undefined
+                    targetName: event ? event.name : undefined,
+                    to
                 },
                 bubbles: true
             })
@@ -1755,7 +1758,7 @@ export default class Scheduler extends LightningElement {
             case 'Standard.Scheduler.AddEvent':
                 this.showEditDialog = true;
                 this.selection = this.schedule.newEvent(this.selection);
-                this.computedEvents.push(this.selection.event);
+                this.computedEvents.push(event);
                 break;
             default:
                 this.schedule.cleanSelection(true);

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -150,6 +150,7 @@ export default class Scheduler extends LightningElement {
         this._connected = true;
 
         this.classList.add('slds-is-relative');
+        this.classList.add('slds-show');
     }
 
     renderedCallback() {

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -1849,6 +1849,31 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
+     * Handle a click on a header action.
+     *
+     * @param {Event} event click or select event.
+     */
+    handleHeaderActionSelect(event) {
+        const name = event.detail.value || event.currentTarget.value;
+
+        /**
+         * The event fired when a user clicks on a header action.
+         *
+         * @event
+         * @name headeractionclick
+         * @param {string} name Name of the action clicked.
+         * @public
+         * @bubbles
+         */
+        this.dispatchEvent(
+            new CustomEvent('headeractionclick', {
+                detail: { name },
+                bubbles: true
+            })
+        );
+    }
+
+    /**
      * Handle a change of the selected date.
      *
      * @param {Event} event

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -105,6 +105,7 @@ export default class Scheduler extends LightningElement {
     _resources = [];
     _selectedDisplay = DISPLAYS.default;
     _selectedResources = [];
+    _selectedResourcesReadOnly = false;
     _selectedTimeSpan = DEFAULT_SELECTED_TIME_SPAN;
     _sidePanelPosition = SIDE_PANEL_POSITIONS.default;
     _start = dateTimeObjectFrom(DEFAULT_START_DATE);
@@ -835,6 +836,21 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
+     * If present, it is not possible for the user to select or unselect resources.
+     *
+     * @type {boolean}
+     * @public
+     * @default false
+     */
+    @api
+    get selectedResourcesReadOnly() {
+        return this._selectedResourcesReadOnly;
+    }
+    set selectedResourcesReadOnly(value) {
+        this._selectedResourcesReadOnly = normalizeBoolean(value);
+    }
+
+    /**
      * Unique name of the selected time span. The selected time span will determine the visible duration of the scheduler.
      *
      * @type {string}
@@ -1199,6 +1215,15 @@ export default class Scheduler extends LightningElement {
             this.recurrentEditModes.length > 1 &&
             this.selection.event.recurrence
         );
+    }
+
+    /**
+     * True if the resource filter should be shown in the toolbar.
+     *
+     * @type {boolean}
+     */
+    get showResourceFilter() {
+        return this.isTimeline && !this.selectedResourcesReadOnly;
     }
 
     /**

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -1729,10 +1729,11 @@ export default class Scheduler extends LightningElement {
                 break;
             case 'Standard.Scheduler.AddEvent':
                 this.showEditDialog = true;
+                this.selection = this.schedule.newEvent(this.selection);
                 this.computedEvents.push(this.selection.event);
                 break;
             default:
-                this.schedule.cleanSelection();
+                this.schedule.cleanSelection(true);
                 break;
         }
     }
@@ -1891,13 +1892,12 @@ export default class Scheduler extends LightningElement {
      */
     handleEmptySpotContextMenu(event) {
         if (!this.computedContextMenuEmptySpot.length) {
-            this.schedule.cleanSelection(true);
             return;
         }
         this.hideAllPopovers();
         this.contextMenuActions = [...this.computedContextMenuEmptySpot];
         this.showContextMenu = true;
-        this.selection = event.detail.selection;
+        this.selection = event.detail;
     }
 
     /**

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -148,6 +148,8 @@ export default class Scheduler extends LightningElement {
         this.initToolbarCalendarDisabledDates();
         this.computeVisibleIntervalLabel(this.start, this.start);
         this._connected = true;
+
+        this.classList.add('slds-is-relative');
     }
 
     renderedCallback() {
@@ -156,7 +158,7 @@ export default class Scheduler extends LightningElement {
             const popover = this.template.querySelector(
                 '[data-element-id="div-detail-popover"]'
             );
-            positionPopover(popover, this.selection);
+            positionPopover(this.bounds, popover, this.selection);
         }
 
         // Position the context menu
@@ -164,7 +166,7 @@ export default class Scheduler extends LightningElement {
             const contextMenu = this.template.querySelector(
                 '[data-element-id="avonni-primitive-dropdown-menu"]'
             );
-            positionPopover(contextMenu, this.selection);
+            positionPopover(this.bounds, contextMenu, this.selection);
         }
 
         // If the edit dialog is opened, focus on the first input
@@ -1084,6 +1086,15 @@ export default class Scheduler extends LightningElement {
      *  PRIVATE PROPERTIES
      * -------------------------------------------------------------
      */
+
+    /**
+     * Coordinates of the schedule's bounding box.
+     *
+     * @type {DOMRect}
+     */
+    get bounds() {
+        return this.template.host.getBoundingClientRect();
+    }
 
     /**
      * Display options visible in the toolbar.

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -1333,7 +1333,7 @@ export default class Scheduler extends LightningElement {
      * @type {string}
      */
     get toolbarCalendarWrapperClass() {
-        return classSet('slds-col slds-has-flexi-truncate')
+        return classSet('avonni-scheduler__flex-col slds-has-flexi-truncate')
             .add({
                 'slds-text-align_center slds-p-horizontal_small':
                     this.showToolbarTimeSpans

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -134,6 +134,7 @@ export default class Scheduler extends LightningElement {
     currentTimeSpan = {};
     detailPopoverFields = [];
     selectedDate = dateTimeObjectFrom(DEFAULT_START_DATE);
+    sidePanelIsExpanded = true;
     showContextMenu = false;
     showEditDialog = false;
     showDeleteConfirmationDialog = false;
@@ -587,22 +588,6 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
-     * Deprecated. Set the headers in each time span instead.
-     *
-     * @type {string}
-     * @deprecated
-     */
-    @api
-    get headers() {
-        return null;
-    }
-    set headers(value) {
-        console.warn(
-            'The "headers" attribute is deprecated. Set the headers in each time span instead.'
-        );
-    }
-
-    /**
      * Array of action objects. If present, the actions will be shown in the toolbar.
      *
      * @type {object[]}
@@ -618,6 +603,22 @@ export default class Scheduler extends LightningElement {
             return;
         }
         this._headerActions = actions;
+    }
+
+    /**
+     * Deprecated. Set the headers in each time span instead.
+     *
+     * @type {string}
+     * @deprecated
+     */
+    @api
+    get headers() {
+        return null;
+    }
+    set headers(value) {
+        console.warn(
+            'The "headers" attribute is deprecated. Set the headers in each time span instead.'
+        );
     }
 
     /**
@@ -1345,6 +1346,15 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
+     * True if the side panel toggle button should be displayed.
+     *
+     * @type {boolean}
+     */
+    get showSidePanelToggle() {
+        return !this.collapseDisabled && !this.hideSidePanel;
+    }
+
+    /**
      * If true, when editing a recurring event, the user always have the choice to save the changes only for the occurrence or for every occurrences of the event.
      *
      * @type {boolean}
@@ -1849,31 +1859,6 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
-     * Handle a click on a header action.
-     *
-     * @param {Event} event click or select event.
-     */
-    handleHeaderActionSelect(event) {
-        const name = event.detail.value || event.currentTarget.value;
-
-        /**
-         * The event fired when a user clicks on a header action.
-         *
-         * @event
-         * @name headeractionclick
-         * @param {string} name Name of the action clicked.
-         * @public
-         * @bubbles
-         */
-        this.dispatchEvent(
-            new CustomEvent('headeractionclick', {
-                detail: { name },
-                bubbles: true
-            })
-        );
-    }
-
-    /**
      * Handle a change of the selected date.
      *
      * @param {Event} event
@@ -2223,6 +2208,31 @@ export default class Scheduler extends LightningElement {
     }
 
     /**
+     * Handle a click on a header action.
+     *
+     * @param {Event} event click or select event.
+     */
+    handleHeaderActionSelect(event) {
+        const name = event.detail.value || event.currentTarget.value;
+
+        /**
+         * The event fired when a user clicks on a header action.
+         *
+         * @event
+         * @name headeractionclick
+         * @param {string} name Name of the action clicked.
+         * @public
+         * @bubbles
+         */
+        this.dispatchEvent(
+            new CustomEvent('headeractionclick', {
+                detail: { name },
+                bubbles: true
+            })
+        );
+    }
+
+    /**
      * Handle the `hidepopovers` event dispatched by a primitive schedule. Hide the appropriate popovers.
      *
      * @param {Event} event
@@ -2278,6 +2288,15 @@ export default class Scheduler extends LightningElement {
         const { selectedResources, name } = event.detail;
         this._selectedResources = selectedResources;
         this.dispatchResourceSelectEvent(name);
+    }
+
+    /**
+     * Handle the toggle of the side panel from the schedule.
+     *
+     * @param {Event} event togglesidepanel event.
+     */
+    handleToggleSidePanel(event) {
+        this.sidePanelIsExpanded = event.detail.isExpanded;
     }
 
     /**
@@ -2421,6 +2440,13 @@ export default class Scheduler extends LightningElement {
         }
         this._selectedResources = selectedResources;
         this.dispatchResourceSelectEvent(name);
+    }
+
+    /**
+     * Handle the toggle of the side panel from the toolbar button.
+     */
+    handleToolbarSidePanelToggle() {
+        this.sidePanelIsExpanded = !this.sidePanelIsExpanded;
     }
 
     /**

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -66,6 +66,7 @@ import {
     DEFAULT_SELECTED_TIME_SPAN,
     DISPLAYS,
     PALETTES,
+    SIDE_PANEL_POSITIONS,
     TIME_SPANS,
     VARIANTS
 } from './defaults';
@@ -105,6 +106,7 @@ export default class Scheduler extends LightningElement {
     _selectedDisplay = DISPLAYS.default;
     _selectedResources = [];
     _selectedTimeSpan = DEFAULT_SELECTED_TIME_SPAN;
+    _sidePanelPosition = SIDE_PANEL_POSITIONS.default;
     _start = dateTimeObjectFrom(DEFAULT_START_DATE);
     _timeSpans = TIME_SPANS.default;
     _variant = VARIANTS.default;
@@ -851,6 +853,24 @@ export default class Scheduler extends LightningElement {
             this.initCurrentTimeSpan();
             this.computeVisibleIntervalLabel(this.start, this.start);
         }
+    }
+
+    /**
+     * Position of the side panel, relative to the schedule. This attribute only affects the agenda and calendar displays.
+     *
+     * @type {string}
+     * @default left
+     * @public
+     */
+    @api
+    get sidePanelPosition() {
+        return this._sidePanelPosition;
+    }
+    set sidePanelPosition(value) {
+        this._sidePanelPosition = normalizeString(value, {
+            fallbackValue: SIDE_PANEL_POSITIONS.default,
+            validValues: SIDE_PANEL_POSITIONS.valid
+        });
     }
 
     /**

--- a/src/modules/base/schedulerSharedStyle/avonniSchedulerSharedStyle.js-meta.xml
+++ b/src/modules/base/schedulerSharedStyle/avonniSchedulerSharedStyle.js-meta.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>56.0</apiVersion>
+    <isExposed>false</isExposed>
+    <masterLabel>Avonni Scheduler Shared Styles</masterLabel>
+</LightningComponentBundle>

--- a/src/modules/base/schedulerSharedStyle/schedulerSharedStyle.css
+++ b/src/modules/base/schedulerSharedStyle/schedulerSharedStyle.css
@@ -34,13 +34,32 @@
     flex: 1 1 auto;
 }
 
+.avonni-scheduler__border_bottom {
+    border-bottom: 1px solid #c9c9c9;
+}
+
+.avonni-scheduler__border_right {
+    border-right: 1px solid #c9c9c9;
+}
+
+.avonni-scheduler__border_left {
+    border-left: 1px solid #c9c9c9;
+}
+
+.avonni-scheduler__border_top {
+    border-top: 1px solid #c9c9c9;
+}
+
+/* Splitter */
+
 .avonni-scheduler__splitter {
+    position: relative;
+    background-color: #fff;
     min-height: 100%;
 }
 
 .avonni-scheduler__second-col {
     flex: 1 1 0;
-    margin-top: -1px;
 }
 
 .avonni-scheduler__splitter_resizable,

--- a/src/modules/base/schedulerSharedStyle/schedulerSharedStyle.css
+++ b/src/modules/base/schedulerSharedStyle/schedulerSharedStyle.css
@@ -1,3 +1,35 @@
+/**
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2021, Avonni Labs, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * - Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 .avonni-scheduler__splitter {
     min-height: 100%;
 }

--- a/src/modules/base/schedulerSharedStyle/schedulerSharedStyle.css
+++ b/src/modules/base/schedulerSharedStyle/schedulerSharedStyle.css
@@ -30,6 +30,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+.avonni-scheduler__flex-col {
+    flex: 1 1 auto;
+}
+
 .avonni-scheduler__splitter {
     min-height: 100%;
 }

--- a/src/modules/base/schedulerSharedStyle/schedulerSharedStyle.css
+++ b/src/modules/base/schedulerSharedStyle/schedulerSharedStyle.css
@@ -1,0 +1,31 @@
+.avonni-scheduler__splitter {
+    min-height: 100%;
+}
+
+.avonni-scheduler__second-col {
+    flex: 1 1 0;
+    margin-top: -1px;
+}
+
+.avonni-scheduler__splitter_resizable,
+.avonni-scheduler__splitter-resize-handle {
+    cursor: col-resize;
+}
+
+.avonni-scheduler__splitter-resize-handle {
+    height: 25px;
+    width: 2px;
+    background-color: #747474;
+}
+
+.avonni-scheduler__splitter-expand-left-button {
+    margin-top: -6px;
+}
+
+.avonni-scheduler__panel_collapsed {
+    max-width: 0;
+}
+
+.avonni-scheduler__panel_expanded {
+    min-width: calc(100% - 12px);
+}

--- a/src/modules/base/schedulerSharedStyle/schedulerSharedStyle.css
+++ b/src/modules/base/schedulerSharedStyle/schedulerSharedStyle.css
@@ -50,6 +50,14 @@
     border-top: 1px solid #c9c9c9;
 }
 
+.avonni-scheduler__time-zone {
+    color: var(--lwc-colorTextPlaceholder, #747474);
+    font-size: 11px;
+    font-weight: 400;
+    height: 2.5rem;
+    text-transform: uppercase;
+}
+
 /* Splitter */
 
 .avonni-scheduler__splitter {

--- a/src/modules/base/schedulerUtils/cell.js
+++ b/src/modules/base/schedulerUtils/cell.js
@@ -82,11 +82,21 @@ export default class SchedulerCell {
      */
     get computedClass() {
         return classSet(
-            'avonni-scheduler__calendar-cell slds-border_right slds-border_bottom slds-p-around_none'
+            'avonni-scheduler__calendar-cell avonni-scheduler__border_right slds-border_bottom slds-p-around_none'
         ).add({
             'avonni-scheduler__calendar-cell_outside-of-current-month':
-                this.currentMonth && this.currentMonth !== this.month
+                this.currentMonth && this.currentMonth !== this.month,
+            'avonni-scheduler__calendar-cell_today': this.isToday
         });
+    }
+
+    get isToday() {
+        const today = dateTimeObjectFrom(Date.now());
+        return (
+            this._startDate.year === today.year &&
+            this._startDate.month === today.month &&
+            this._startDate.day === today.day
+        );
     }
 
     /**

--- a/src/modules/base/schedulerUtils/dateComputations.js
+++ b/src/modules/base/schedulerUtils/dateComputations.js
@@ -65,6 +65,35 @@ const isAllowedMonth = (date, allowedMonths) => {
 };
 
 /**
+ * Check if the given time frame is valid, and parse it into a start and an end date.
+ *
+ * @param {string} timeFrame Time frame to validate and parse.
+ * @returns {object} Object with three possible keys: valid, start and end.
+ */
+const parseTimeFrame = (timeFrame) => {
+    const startMatch = timeFrame.match(/^([0-9:]+)-/);
+    const endMatch = timeFrame.match(/-([0-9:]+)$/);
+
+    if (!startMatch || !endMatch) {
+        console.error(
+            `Wrong time frame format for ${timeFrame}. The time frame needs to follow the pattern ‘start-end’, with start and end being ISO8601 formatted time strings.`
+        );
+        return { valid: false };
+    }
+    const start = DateTime.fromISO(startMatch[1]);
+    const end = DateTime.fromISO(endMatch[1]);
+
+    if (end < start) {
+        console.error(
+            `Wrong time frame format for ${timeFrame}. The end time is smaller than the start time.`
+        );
+        return { valid: false };
+    }
+
+    return { start, end, valid: true };
+};
+
+/**
  * Check if a time is included in a time frame.
  *
  * @param {DateTime} date DateTime object.
@@ -72,21 +101,8 @@ const isAllowedMonth = (date, allowedMonths) => {
  * @returns {boolean} true or false.
  */
 const isInTimeFrame = (date, timeFrame) => {
-    const startMatch = timeFrame.match(/^([0-9:]+)-/);
-    const endMatch = timeFrame.match(/-([0-9:]+)$/);
-    if (!startMatch || !endMatch) {
-        console.error(
-            `Wrong time frame format for ${timeFrame}. The time frame needs to follow the pattern ‘start-end’, with start and end being ISO8601 formatted time strings.`
-        );
-        return true;
-    }
-
-    const start = DateTime.fromISO(startMatch[1]);
-    const end = DateTime.fromISO(endMatch[1]);
-    if (end < start) {
-        console.error(
-            `Wrong time frame format for ${timeFrame}. The end time is smaller than the start time.`
-        );
+    const { start, end, valid } = parseTimeFrame(timeFrame);
+    if (!valid) {
         return true;
     }
 
@@ -472,6 +488,7 @@ export {
     nextAllowedDay,
     nextAllowedMonth,
     nextAllowedTime,
+    parseTimeFrame,
     previousAllowedDay,
     previousAllowedMonth,
     previousAllowedTime,

--- a/src/modules/base/schedulerUtils/positions.js
+++ b/src/modules/base/schedulerUtils/positions.js
@@ -176,20 +176,23 @@ function computeEventLevelInCellGroup(
  */
 export function positionPopover(bounds, popover, { x, y }, horizontalCenter) {
     // Make sure the popover is not outside of the screen
-    const { left, right, bottom, top } = bounds;
     const height = popover.offsetHeight;
     const width = popover.offsetWidth;
     const popoverBottom = y + height;
     const popoverRight = x + width;
 
-    const yTransform = popoverBottom > bottom ? (height + 10) * -1 : 10;
+    const bottomView = window.innerHeight;
+    const rightView = window.innerWidth;
+
+    const yTransform = popoverBottom > bottomView ? (height + 10) * -1 : 10;
     let xTransform = 10;
-    if (popoverRight > right) {
+    if (popoverRight > rightView) {
         xTransform = (width + 10) * -1;
     } else if (horizontalCenter) {
         xTransform = (width / 2) * -1;
     }
 
+    const { left, top } = bounds;
     popover.style.transform = `translate(${xTransform}px, ${yTransform}px)`;
     popover.style.top = `${y - top}px`;
     popover.style.left = `${x - left}px`;

--- a/src/modules/base/schedulerUtils/positions.js
+++ b/src/modules/base/schedulerUtils/positions.js
@@ -180,19 +180,18 @@ export function positionPopover(bounds, popover, { x, y }, horizontalCenter) {
     const width = popover.offsetWidth;
     const popoverBottom = y + height;
     const popoverRight = x + width;
+    const { left, top, right } = bounds;
 
     const bottomView = window.innerHeight;
-    const rightView = window.innerWidth;
-
     const yTransform = popoverBottom > bottomView ? (height + 10) * -1 : 10;
+
     let xTransform = 10;
-    if (popoverRight > rightView) {
+    if (popoverRight > right) {
         xTransform = (width + 10) * -1;
     } else if (horizontalCenter) {
         xTransform = (width / 2) * -1;
     }
 
-    const { left, top } = bounds;
     popover.style.transform = `translate(${xTransform}px, ${yTransform}px)`;
     popover.style.top = `${y - top}px`;
     popover.style.left = `${x - left}px`;

--- a/src/modules/base/schedulerUtils/positions.js
+++ b/src/modules/base/schedulerUtils/positions.js
@@ -174,27 +174,25 @@ function computeEventLevelInCellGroup(
  * @param {object} position Position of the popover. Valid keys are x and y.
  * @param {boolean} horizontalCenter If true, the popover should be centered horizontally.
  */
-export function positionPopover(popover, { x, y }, horizontalCenter) {
+export function positionPopover(bounds, popover, { x, y }, horizontalCenter) {
     // Make sure the popover is not outside of the screen
+    const { left, right, bottom, top } = bounds;
     const height = popover.offsetHeight;
     const width = popover.offsetWidth;
     const popoverBottom = y + height;
     const popoverRight = x + width;
 
-    const bottomView = window.innerHeight;
-    const rightView = window.innerWidth;
-
-    const yTransform = popoverBottom > bottomView ? (height + 10) * -1 : 10;
+    const yTransform = popoverBottom > bottom ? (height + 10) * -1 : 10;
     let xTransform = 10;
-    if (popoverRight > rightView) {
+    if (popoverRight > right) {
         xTransform = (width + 10) * -1;
     } else if (horizontalCenter) {
         xTransform = (width / 2) * -1;
     }
 
     popover.style.transform = `translate(${xTransform}px, ${yTransform}px)`;
-    popover.style.top = `${y}px`;
-    popover.style.left = `${x}px`;
+    popover.style.top = `${y - top}px`;
+    popover.style.left = `${x - left}px`;
 }
 
 /**

--- a/src/modules/base/schedulerUtils/positions.js
+++ b/src/modules/base/schedulerUtils/positions.js
@@ -192,6 +192,11 @@ export function positionPopover(bounds, popover, { x, y }, horizontalCenter) {
         xTransform = (width / 2) * -1;
     }
 
+    // The context menu is in fixed position by default,
+    // to prevent a scroll jump when appearing
+    popover.classList.remove('slds-is-fixed');
+    popover.classList.add('slds-is-absolute');
+
     popover.style.transform = `translate(${xTransform}px, ${yTransform}px)`;
     popover.style.top = `${y - top}px`;
     popover.style.left = `${x - left}px`;

--- a/src/modules/base/schedulerUtils/scheduleBase.js
+++ b/src/modules/base/schedulerUtils/scheduleBase.js
@@ -583,10 +583,12 @@ export class ScheduleBase extends LightningElement {
      */
     get splitterClass() {
         return classSet(
-            'avonni-scheduler__splitter slds-grid slds-grid_vertical slds-grid_align-center slds-grid_vertical-align-center slds-border_top slds-border_bottom slds-border_left slds-border_right'
+            'avonni-scheduler__splitter slds-grid slds-grid_vertical slds-grid_align-center slds-grid_vertical-align-center avonni-scheduler__border_top avonni-scheduler__border_bottom'
         )
             .add({
-                'avonni-scheduler__splitter_resizable': this.showSplitterResize
+                'avonni-scheduler__splitter_resizable': this.showSplitterResize,
+                'avonni-scheduler__border_left': !this._isCollapsed,
+                'avonni-scheduler__border_right': !this._isExpanded
             })
             .toString();
     }

--- a/src/modules/base/schedulerUtils/scheduleBase.js
+++ b/src/modules/base/schedulerUtils/scheduleBase.js
@@ -422,6 +422,29 @@ export class ScheduleBase extends LightningElement {
     }
 
     /**
+     * If present, the side panel is expanded. Otherwise, it is collapsed.
+     *
+     * @type {boolean}
+     * @public
+     * @default false
+     */
+    @api
+    get sidePanelIsExpanded() {
+        return this._sidePanelIsExpanded;
+    }
+    set sidePanelIsExpanded(value) {
+        this._sidePanelIsExpanded = normalizeBoolean(value);
+
+        if (this._sidePanelIsExpanded) {
+            this._isExpanded = false;
+            this._isCollapsed = false;
+        } else {
+            this._isCollapsed = true;
+            this._isExpanded = false;
+        }
+    }
+
+    /**
      * Object used to set the duration of the schedule. It should have two keys:
      * * unit (minute, hour, day, week, month or year)
      * * span (number).
@@ -1066,6 +1089,9 @@ export class ScheduleBase extends LightningElement {
         if (this.panelElement) {
             this.panelElement.style.flexBasis = null;
         }
+
+        this._sidePanelIsExpanded = !this._isCollapsed;
+        this.dispatchToggleSidePanel();
     }
 
     /**
@@ -1081,6 +1107,9 @@ export class ScheduleBase extends LightningElement {
         if (this.panelElement) {
             this.panelElement.style.flexBasis = null;
         }
+
+        this._sidePanelIsExpanded = !this._isCollapsed;
+        this.dispatchToggleSidePanel();
     }
 
     /**
@@ -1231,6 +1260,27 @@ export class ScheduleBase extends LightningElement {
             new CustomEvent('openrecurrencedialog', {
                 detail: {
                     selection
+                }
+            })
+        );
+    }
+
+    /**
+     * Dispatch the `togglesidepanel` event.
+     */
+    dispatchToggleSidePanel() {
+        /**
+         * The event fired when the side panel is toggled.
+         *
+         * @event
+         * @name togglesidepanel
+         * @param {boolean} isExpanded
+         * @public
+         */
+        this.dispatchEvent(
+            new CustomEvent('togglesidepanel', {
+                detail: {
+                    isExpanded: this.sidePanelIsExpanded
                 }
             })
         );

--- a/src/modules/base/schedulerUtils/scheduleBase.js
+++ b/src/modules/base/schedulerUtils/scheduleBase.js
@@ -422,29 +422,6 @@ export class ScheduleBase extends LightningElement {
     }
 
     /**
-     * If present, the side panel is expanded. Otherwise, it is collapsed.
-     *
-     * @type {boolean}
-     * @public
-     * @default false
-     */
-    @api
-    get sidePanelIsExpanded() {
-        return this._sidePanelIsExpanded;
-    }
-    set sidePanelIsExpanded(value) {
-        this._sidePanelIsExpanded = normalizeBoolean(value);
-
-        if (this._sidePanelIsExpanded) {
-            this._isExpanded = false;
-            this._isCollapsed = false;
-        } else {
-            this._isCollapsed = true;
-            this._isExpanded = false;
-        }
-    }
-
-    /**
      * Object used to set the duration of the schedule. It should have two keys:
      * * unit (minute, hour, day, week, month or year)
      * * span (number).
@@ -620,6 +597,19 @@ export class ScheduleBase extends LightningElement {
         this._eventData.refreshEvents();
     }
 
+    @api
+    collapseSidePanel() {
+        if (this._isExpanded) {
+            this._isExpanded = false;
+        } else {
+            this._isCollapsed = true;
+        }
+
+        if (this.panelElement) {
+            this.panelElement.style.flexBasis = null;
+        }
+    }
+
     /**
      * Create a new event.
      *
@@ -640,6 +630,19 @@ export class ScheduleBase extends LightningElement {
     @api
     deleteEvent(name) {
         this._eventData.deleteEvent(name);
+    }
+
+    @api
+    expandSidePanel() {
+        if (this._isCollapsed) {
+            this._isCollapsed = false;
+        } else {
+            this._isExpanded = true;
+        }
+
+        if (this.panelElement) {
+            this.panelElement.style.flexBasis = null;
+        }
     }
 
     /**
@@ -1082,36 +1085,14 @@ export class ScheduleBase extends LightningElement {
      * Handle a click on the splitter collapse button.
      */
     handleSplitterCollapse() {
-        if (this._isExpanded) {
-            this._isExpanded = false;
-        } else {
-            this._isCollapsed = true;
-        }
-
-        if (this.panelElement) {
-            this.panelElement.style.flexBasis = null;
-        }
-
-        this._sidePanelIsExpanded = !this._isCollapsed;
-        this.dispatchToggleSidePanel();
+        this.collapseSidePanel();
     }
 
     /**
      * Handle a click on the splitter expand button.
      */
     handleSplitterExpand() {
-        if (this._isCollapsed) {
-            this._isCollapsed = false;
-        } else {
-            this._isExpanded = true;
-        }
-
-        if (this.panelElement) {
-            this.panelElement.style.flexBasis = null;
-        }
-
-        this._sidePanelIsExpanded = !this._isCollapsed;
-        this.dispatchToggleSidePanel();
+        this.expandSidePanel();
     }
 
     /**
@@ -1262,27 +1243,6 @@ export class ScheduleBase extends LightningElement {
             new CustomEvent('openrecurrencedialog', {
                 detail: {
                     selection
-                }
-            })
-        );
-    }
-
-    /**
-     * Dispatch the `togglesidepanel` event.
-     */
-    dispatchToggleSidePanel() {
-        /**
-         * The event fired when the side panel is toggled.
-         *
-         * @event
-         * @name togglesidepanel
-         * @param {boolean} isExpanded
-         * @public
-         */
-        this.dispatchEvent(
-            new CustomEvent('togglesidepanel', {
-                detail: {
-                    isExpanded: this.sidePanelIsExpanded
                 }
             })
         );

--- a/src/modules/base/schedulerUtils/scheduleBase.js
+++ b/src/modules/base/schedulerUtils/scheduleBase.js
@@ -797,21 +797,21 @@ export class ScheduleBase extends LightningElement {
     handleEmptySpotContextMenu(event) {
         event.preventDefault();
 
-        const x = event.clientX;
-        const y = event.clientY;
-        this.newEvent({ x, y });
-
         /**
          * The event fired when the context menu is opened on an empty spot of the schedule.
          *
          * @event
          * @name emptyspotcontextmenu
-         * @param {object} selection Information on the newly created event.
+         * @param {number} x Position of the cursor on the X axis.
+         * @param {number} y Position of the cursor on the Y axis.
          * @public
          */
         this.dispatchEvent(
             new CustomEvent('emptyspotcontextmenu', {
-                detail: { selection: this._eventData.selection }
+                detail: {
+                    x: event.clientX,
+                    y: event.clientY
+                }
             })
         );
     }

--- a/src/modules/base/schedulerUtils/scheduleBase.js
+++ b/src/modules/base/schedulerUtils/scheduleBase.js
@@ -895,9 +895,9 @@ export class ScheduleBase extends LightningElement {
     }
 
     /**
-     * Handle the `privatemouseenter` event fired by a primitive event occurrence. Select the hovered event and show the detail popover.
+     * Handle the cursor entering an event.
      *
-     * @param {Event} event
+     * @param {Event} event `privatemouseenter` event fired by a primitive event occurrence.
      */
     handleEventMouseEnter(event) {
         if (this._mouseIsDown) {
@@ -923,10 +923,27 @@ export class ScheduleBase extends LightningElement {
     }
 
     /**
-     * Dispatch the `hidepopovers` event only for the detail popover.
+     * Handle the cursor leaving an event.
+     *
+     * @param {Event} event `privatemouseleave` event fired by a primitive event occurrence.
      */
-    handleHideDetailPopover() {
-        this.dispatchHidePopovers(['detail']);
+    handleEventMouseLeave(event) {
+        /**
+         * The event fired when the mouse leaves an event.
+         *
+         * @event
+         * @name eventmouseleave
+         * @param {string} eventName Name of the event.
+         * @param {string} key Key of the occurrence.
+         * @param {number} x Horizontal position of the occurrence.
+         * @param {number} y Vertical position of the occurrence.
+         * @public
+         */
+        this.dispatchEvent(
+            new CustomEvent('eventmouseleave', {
+                detail: event.detail
+            })
+        );
     }
 
     /**

--- a/src/modules/base/schedulerUtils/scheduleBase.js
+++ b/src/modules/base/schedulerUtils/scheduleBase.js
@@ -836,6 +836,18 @@ export class ScheduleBase extends LightningElement {
     handleEmptySpotContextMenu(event) {
         event.preventDefault();
 
+        let from, to;
+        const agendaDate = event.currentTarget.dataset.date;
+        if (agendaDate) {
+            from = dateTimeObjectFrom(Number(agendaDate));
+            to = from.endOf('day');
+        } else {
+            from = dateTimeObjectFrom(
+                Number(event.currentTarget.dataset.start)
+            );
+            to = dateTimeObjectFrom(Number(event.currentTarget.dataset.end));
+        }
+
         /**
          * The event fired when the context menu is opened on an empty spot of the schedule.
          *
@@ -843,13 +855,17 @@ export class ScheduleBase extends LightningElement {
          * @name emptyspotcontextmenu
          * @param {number} x Position of the cursor on the X axis.
          * @param {number} y Position of the cursor on the Y axis.
+         * @param {DateTime} from Start date of the cell clicked.
+         * @param {DateTime} to End date of the cell clicked.
          * @public
          */
         this.dispatchEvent(
             new CustomEvent('emptyspotcontextmenu', {
                 detail: {
                     x: event.clientX,
-                    y: event.clientY
+                    y: event.clientY,
+                    from: from.toISO(),
+                    to: to.toISO()
                 }
             })
         );

--- a/src/modules/base/schedulerUtils/schedulerUtils.js
+++ b/src/modules/base/schedulerUtils/schedulerUtils.js
@@ -40,6 +40,7 @@ export {
     nextAllowedDay,
     nextAllowedMonth,
     nextAllowedTime,
+    parseTimeFrame,
     previousAllowedDay,
     previousAllowedMonth,
     previousAllowedTime,

--- a/src/modules/base/splitter/splitter.js
+++ b/src/modules/base/splitter/splitter.js
@@ -59,7 +59,6 @@ export default class Splitter extends LightningElement {
             '[data-element-id="slot-default"]'
         );
         let slotElements = slot.assignedElements();
-        const paneElements = [];
 
         if (slotElements.length > 0) {
             let amount = 1;
@@ -78,7 +77,6 @@ export default class Splitter extends LightningElement {
                 const nextElement = element.nextSibling;
 
                 if (element.localName.indexOf('-splitter-pane') > -1) {
-                    paneElements.push(element);
                     element.classList.add('container');
                     element.classList.add('slot-' + amount);
                     element.setAttribute('slot-id', amount);
@@ -302,13 +300,6 @@ export default class Splitter extends LightningElement {
                     isStatic = false;
                 }
             });
-
-            // Used by the scheduler to be able to get the width of the two panes
-            this.dispatchEvent(
-                new CustomEvent('privateslotchange', {
-                    detail: { paneElements }
-                })
-            );
         }
         // slot.remove();
 

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.html
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.html
@@ -17,7 +17,6 @@
             events-palette={eventsPalette}
             events-display-fields={eventsDisplayFields}
             events-theme={eventsTheme}
-            header-actions={headerActions}
             hidden-displays={hiddenDisplays}
             hide-resources-filter={hideResourcesFilter}
             hide-side-panel={hideSidePanel}
@@ -35,6 +34,7 @@
             side-panel-position={sidePanelPosition}
             start={start}
             time-spans={timeSpans}
+            toolbar-actions={toolbarActions}
             variant={variant}
             zoom-to-fit={zoomToFit}
         ></c-scheduler>

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.html
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.html
@@ -28,6 +28,7 @@
             resources={resources}
             selected-display={selectedDisplay}
             selected-resources={selectedResources}
+            selected-resources-read-only={selectedResourcesReadOnly}
             selected-time-span={selectedTimeSpan}
             side-panel-position={sidePanelPosition}
             start={start}

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.html
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.html
@@ -17,6 +17,7 @@
             events-palette={eventsPalette}
             events-display-fields={eventsDisplayFields}
             events-theme={eventsTheme}
+            header-actions={headerActions}
             hidden-displays={hiddenDisplays}
             hide-resources-filter={hideResourcesFilter}
             hide-side-panel={hideSidePanel}

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.html
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.html
@@ -17,6 +17,7 @@
             events-palette={eventsPalette}
             events-theme={eventsTheme}
             hidden-displays={hiddenDisplays}
+            hide-side-panel={hideSidePanel}
             hide-toolbar={hideToolbar}
             is-loading={isLoading}
             loading-state-alternative-text={loadingStateAlternativeText}

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.html
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.html
@@ -15,6 +15,7 @@
             events={events}
             events-labels={eventsLabels}
             events-palette={eventsPalette}
+            events-display-fields={eventsDisplayFields}
             events-theme={eventsTheme}
             hidden-displays={hiddenDisplays}
             hide-side-panel={hideSidePanel}

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.html
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.html
@@ -18,6 +18,7 @@
             events-display-fields={eventsDisplayFields}
             events-theme={eventsTheme}
             hidden-displays={hiddenDisplays}
+            hide-resources-filter={hideResourcesFilter}
             hide-side-panel={hideSidePanel}
             hide-toolbar={hideToolbar}
             is-loading={isLoading}
@@ -29,7 +30,6 @@
             resources={resources}
             selected-display={selectedDisplay}
             selected-resources={selectedResources}
-            selected-resources-read-only={selectedResourcesReadOnly}
             selected-time-span={selectedTimeSpan}
             side-panel-position={sidePanelPosition}
             start={start}

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.html
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.html
@@ -29,6 +29,7 @@
             selected-display={selectedDisplay}
             selected-resources={selectedResources}
             selected-time-span={selectedTimeSpan}
+            side-panel-position={sidePanelPosition}
             start={start}
             time-spans={timeSpans}
             variant={variant}

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.js
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.js
@@ -15,6 +15,7 @@ export default class Scheduler extends LightningElement {
     @api events;
     @api eventsLabels;
     @api eventsPalette;
+    @api eventsDisplayFields;
     @api eventsTheme;
     @api hiddenDisplays;
     @api hideSidePanel;

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.js
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.js
@@ -17,7 +17,6 @@ export default class Scheduler extends LightningElement {
     @api eventsPalette;
     @api eventsDisplayFields;
     @api eventsTheme;
-    @api headerActions;
     @api hiddenDisplays;
     @api hideResourcesFilter;
     @api hideSidePanel;
@@ -35,6 +34,7 @@ export default class Scheduler extends LightningElement {
     @api sidePanelPosition;
     @api start;
     @api timeSpans;
+    @api toolbarActions;
     @api variant;
     @api zoomToFit;
 }

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.js
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.js
@@ -18,6 +18,7 @@ export default class Scheduler extends LightningElement {
     @api eventsDisplayFields;
     @api eventsTheme;
     @api hiddenDisplays;
+    @api hideResourcesFilter;
     @api hideSidePanel;
     @api hideToolbar;
     @api isLoading;
@@ -29,7 +30,6 @@ export default class Scheduler extends LightningElement {
     @api resources;
     @api selectedDisplay;
     @api selectedResources;
-    @api selectedResourcesReadOnly;
     @api selectedTimeSpan;
     @api sidePanelPosition;
     @api start;

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.js
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.js
@@ -17,6 +17,7 @@ export default class Scheduler extends LightningElement {
     @api eventsPalette;
     @api eventsTheme;
     @api hiddenDisplays;
+    @api hideSidePanel;
     @api hideToolbar;
     @api isLoading;
     @api loadingStateAlternativeText;

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.js
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.js
@@ -29,6 +29,7 @@ export default class Scheduler extends LightningElement {
     @api selectedDisplay;
     @api selectedResources;
     @api selectedTimeSpan;
+    @api sidePanelPosition;
     @api start;
     @api timeSpans;
     @api variant;

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.js
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.js
@@ -28,6 +28,7 @@ export default class Scheduler extends LightningElement {
     @api resources;
     @api selectedDisplay;
     @api selectedResources;
+    @api selectedResourcesReadOnly;
     @api selectedTimeSpan;
     @api sidePanelPosition;
     @api start;

--- a/src/modules/base/storybookWrappers/scheduler/scheduler.js
+++ b/src/modules/base/storybookWrappers/scheduler/scheduler.js
@@ -17,6 +17,7 @@ export default class Scheduler extends LightningElement {
     @api eventsPalette;
     @api eventsDisplayFields;
     @api eventsTheme;
+    @api headerActions;
     @api hiddenDisplays;
     @api hideResourcesFilter;
     @api hideSidePanel;


### PR DESCRIPTION
### Features
**Scheduler**
- Added the `events-display-fields`, `toolbar-actions`, `hide-resources-filter`, `hide-side-panel` and `side-panel-position` attributes.
- Added the `startchange` and `toolbaractionclick` events.
- Added the `collapseSidePanel()` and `expandSidePanel()` public methods.
- Updated the event popover to show the context menu actions.
- Added `from` and `to` keys to the `actionclick` event.
- Updated the UI to be closer to Salesforce's Calendar.

### Fixes
**Scheduler**
- Removed the hover animation on events when the scheduler is in read-only mode.