### PR TITLE
[fix] (ABC-906): Fix input date range timezone when used in filter menu

### DIFF
--- a/src/modules/base/inputDateRange/__tests__/inputDateRange.test.js
+++ b/src/modules/base/inputDateRange/__tests__/inputDateRange.test.js
@@ -36,12 +36,6 @@ import InputDateRange from 'avonni/inputDateRange';
 const startDate = new Date('7/20/2021 10:00');
 const endDate = new Date('7/21/2021 18:15');
 
-const timeZoneMock = (timezone) => {
-    jest.spyOn(Date.prototype, 'toLocaleString').mockImplementation(() => {
-        return timezone || 'GMT';
-    });
-};
-
 let element;
 describe('Input Date Range', () => {
     afterEach(() => {
@@ -191,10 +185,9 @@ describe('Input Date Range', () => {
     //time style
     it('Input Date Range: date time style short', () => {
         element.type = 'datetime';
+        element.timeStyle = 'short';
         element.startDate = startDate;
         element.endDate = endDate;
-        const startTime = '10:00';
-        const endTime = '18:15';
 
         return Promise.resolve().then(() => {
             const lightningInputs = element.shadowRoot.querySelectorAll(
@@ -203,8 +196,6 @@ describe('Input Date Range', () => {
             lightningInputs.forEach((input) => {
                 expect(input.timeStyle).toBe('short');
             });
-            expect(lightningInputs[0].value).toBe(startTime);
-            expect(lightningInputs[1].value).toBe(endTime);
         });
     });
 
@@ -213,8 +204,6 @@ describe('Input Date Range', () => {
         element.timeStyle = 'medium';
         element.startDate = startDate;
         element.endDate = endDate;
-        const startTime = '10:00';
-        const endTime = '18:15';
 
         return Promise.resolve().then(() => {
             const lightningInputs = element.shadowRoot.querySelectorAll(
@@ -223,8 +212,6 @@ describe('Input Date Range', () => {
             lightningInputs.forEach((input) => {
                 expect(input.timeStyle).toBe('medium');
             });
-            expect(lightningInputs[0].value).toBe(startTime);
-            expect(lightningInputs[1].value).toBe(endTime);
         });
     });
 
@@ -233,8 +220,6 @@ describe('Input Date Range', () => {
         element.timeStyle = 'long';
         element.startDate = startDate;
         element.endDate = endDate;
-        const startTime = '10:00';
-        const endTime = '18:15';
 
         return Promise.resolve().then(() => {
             const lightningInputs = element.shadowRoot.querySelectorAll(
@@ -243,8 +228,6 @@ describe('Input Date Range', () => {
             lightningInputs.forEach((input) => {
                 expect(input.timeStyle).toBe('long');
             });
-            expect(lightningInputs[0].value).toBe(startTime);
-            expect(lightningInputs[1].value).toBe(endTime);
         });
     });
 
@@ -901,7 +884,7 @@ describe('Input Date Range', () => {
                 const startTimeInput = element.shadowRoot.querySelector(
                     '[data-element-id="lightning-input-start-time"]'
                 );
-                expect(startTimeInput.value).toBe('04:00');
+                expect(startTimeInput.value).toBe('04:00:00.000');
 
                 const endDateInput = element.shadowRoot.querySelector(
                     '[data-element-id="input-end-date"]'
@@ -910,27 +893,26 @@ describe('Input Date Range', () => {
                 const endTimeInput = element.shadowRoot.querySelector(
                     '[data-element-id="lightning-input-end-time"]'
                 );
-                expect(endTimeInput.value).toBe('15:00');
+                expect(endTimeInput.value).toBe('15:00:00.000');
 
                 startDateInput.click();
             })
             .then(() => {
-                timeZoneMock('GMT+08:00');
                 const calendar = element.shadowRoot.querySelector(
                     '[data-element-id="calendar-start-date"]'
                 );
                 calendar.dispatchEvent(
                     new CustomEvent('change', {
                         detail: {
-                            value: ['2022-08-16T04:00:00.000Z']
+                            value: ['2022-08-16T00:00:00.000+08:00']
                         }
                     })
                 );
 
                 expect(handler).toHaveBeenCalled();
                 const detail = handler.mock.calls[0][0].detail;
-                expect(detail.startDate).toBe('2022-08-16T04:00+08:00');
-                expect(detail.endDate).toBe('2022-08-20T15:00+08:00');
+                expect(detail.startDate).toBe('2022-08-16T04:00:00.000+08:00');
+                expect(detail.endDate).toBe('2022-08-20T15:00:00.000+08:00');
             });
     });
 
@@ -942,7 +924,7 @@ describe('Input Date Range', () => {
         const date = start.getDate();
         const year = start.getFullYear();
         const month = start.getMonth() + 1;
-        const time = start.toTimeString().substring(0, 5);
+        const time = `${start.toTimeString().substring(0, 5)}:00.000`;
         const formattedDate = `${month}/${date}/${year}`;
 
         return Promise.resolve().then(() => {

--- a/src/modules/base/inputDateRange/inputDateRange.js
+++ b/src/modules/base/inputDateRange/inputDateRange.js
@@ -276,7 +276,6 @@ export default class InputDateRange extends LightningElement {
     /**
      * The display style of the time when type='time' or type='datetime'.
      * Valid values are short, medium and long. Currently, medium and long styles look the same.
-     * On mobile devices this attribute has no effect.
      *
      * @type {string}
      * @default short
@@ -540,12 +539,10 @@ export default class InputDateRange extends LightningElement {
     get calendarValue() {
         const value = [];
         if (this.startDate) {
-            const normalizedDate = new Date(this.startDate).setHours(0, 0);
-            value.push(normalizedDate);
+            value.push(this.startDate);
         }
         if (this.endDate) {
-            const normalizedDate = new Date(this.endDate).setHours(0, 0);
-            value.push(normalizedDate);
+            value.push(this.endDate);
         }
         return value;
     }
@@ -693,16 +690,11 @@ export default class InputDateRange extends LightningElement {
             this.startTimeString = '';
             return;
         }
-        if (this.timezone) {
-            // Use the date and time from the given time zone
-            const stringDate = this.startDate.toLocaleString('en-us', {
-                timeZone: this.timezone
-            });
-            this._startDate = new Date(stringDate);
-        }
+        const date = this.getDateWithTimeZone(this.startDate);
+        this._startDate = new Date(date.ts);
 
         if (this.type === 'datetime') {
-            this.startTime = this.startDate.toTimeString().substring(0, 5);
+            this.startTime = date.toISOTime({ includeOffset: false });
             this.startTimeString = this.timeFormat(this.startDate);
         }
     }
@@ -716,18 +708,20 @@ export default class InputDateRange extends LightningElement {
             this.endTimeString = '';
             return;
         }
-        if (this.timezone) {
-            // Use the date and time from the given time zone
-            const stringDate = this.endDate.toLocaleString('en-us', {
-                timeZone: this.timezone
-            });
-            this._endDate = new Date(stringDate);
-        }
+        const date = this.getDateWithTimeZone(this.endDate);
+        this._endDate = new Date(date.ts);
 
         if (this.type === 'datetime') {
-            this.endTime = this.endDate.toTimeString().substring(0, 5);
+            this.endTime = date.toISOTime({ includeOffset: false });
             this.endTimeString = this.timeFormat(this.endDate);
         }
+    }
+
+    getDateWithTimeZone(date) {
+        return dateTimeObjectFrom(date, {
+            zone: this.timezone,
+            locale: 'en-US'
+        });
     }
 
     /**
@@ -761,21 +755,16 @@ export default class InputDateRange extends LightningElement {
      * @returns {date} formatted date depending on the date style.
      */
     dateFormat(value) {
-        let date = value.getDate();
-        let year = value.getFullYear();
-        let month = value.getMonth() + 1;
+        const date = this.getDateWithTimeZone(value);
 
-        if (this.dateStyle === 'medium') {
-            month = value.toLocaleString('default', { month: 'short' });
-            return `${month} ${date}, ${year}`;
+        switch (this.dateStyle) {
+            case 'medium':
+                return date.toFormat('LLL. d, y');
+            case 'long':
+                return date.toFormat('LLLL d, y');
+            default:
+                return date.toFormat('L/d/y');
         }
-
-        if (this.dateStyle === 'long') {
-            month = value.toLocaleString('default', { month: 'long' });
-            return `${month} ${date}, ${year}`;
-        }
-
-        return `${month}/${date}/${year}`;
     }
 
     /**
@@ -785,42 +774,22 @@ export default class InputDateRange extends LightningElement {
      * @returns {time} formatted time depending on the time style.
      */
     timeFormat(value) {
-        return this.timeStyle === 'short'
-            ? value.toLocaleString('en-US', {
-                  hour: '2-digit',
-                  minute: '2-digit'
-              })
-            : value.toLocaleString('en-US', {
-                  hour: '2-digit',
-                  minute: '2-digit',
-                  second: '2-digit'
-              });
+        const date = this.getDateWithTimeZone(value);
+        switch (this.timeStyle) {
+            case 'short':
+                return date.toFormat('t');
+            default:
+                return date.toFormat('tt');
+        }
     }
 
     toISOString(dateObject, timeString) {
         if (!dateObject) {
             return null;
         }
-        const time = timeString ? `T${timeString}` : 'T00:00:00';
-        const date = dateObject && dateObject.toISOString();
-
-        let dateTime = date.replace(/T[^Z]+/, time);
-        try {
-            const formattedWithTimeZone = new Date(dateTime).toLocaleString(
-                'en-US',
-                {
-                    timeZone: this.timezone,
-                    timeZoneName: 'longOffset'
-                }
-            );
-            const tz = formattedWithTimeZone.match(/GMT([-+]\d{2}:\d{2})?/);
-            if (tz[1]) {
-                dateTime = dateTime.replace('Z', tz[1]);
-            }
-        } catch {
-            // The time zone is not supported
-        }
-        return dateTime;
+        const date = this.getDateWithTimeZone(dateObject).toISO();
+        const time = timeString ? `T${timeString}` : 'T00:00:00.000';
+        return date.replace(/T[0-9:.]+/, time);
     }
 
     /**


### PR DESCRIPTION
### Fixes
**Filter Menu**
- Prevent the time zone being from being erased when passed from the filter menu, to the input date range, to the dropdown calendars.
