### PR TITLE
[fix] (ABC-911): Use avonni combobox for calendar years

### DIFF
--- a/jest-mock/components/base/combobox/combobox.html
+++ b/jest-mock/components/base/combobox/combobox.html
@@ -1,0 +1,1 @@
+<template></template>

--- a/jest-mock/components/base/combobox/combobox.js
+++ b/jest-mock/components/base/combobox/combobox.js
@@ -1,0 +1,47 @@
+import { LightningElement, api } from 'lwc';
+
+export default class Combobox extends LightningElement {
+    @api actions;
+    @api allowSearch;
+    @api backAction;
+    @api disabled;
+    @api dropdownAlignment;
+    @api dropdownLength;
+    @api fieldLevelHelp;
+    @api groups;
+    @api hideClearIcon;
+    @api hideSelectedOptions;
+    @api isLoading;
+    @api isMultiSelect;
+    @api label;
+    @api loadingStateAlternativeText;
+    @api messageWhenBadInput;
+    @api messageWhenValueMissing;
+    @api multiLevelGroups;
+    @api name;
+    @api options;
+    @api placeholder;
+    @api readOnly;
+    @api removeSelectedOptions;
+    @api required;
+    @api scopes;
+    @api scopesGroups;
+    @api search;
+    @api selectedOptionsAriaLabel;
+    @api selectedOptionsDirection;
+    @api sortableSelectedOptions;
+    @api sortableSelectedOptionsIconName;
+    @api value;
+    @api variant;
+
+    @api blur() {}
+    @api checkValidity() {}
+    @api close() {}
+    @api focus() {}
+    @api open() {}
+    @api reportValidity() {}
+    @api resetLevel() {}
+    @api setCustomValidity() {}
+    @api showHelpMessageIfInvalid() {}
+    @api updateScope() {}
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ module.exports = {
         '^c/(calendar)$': '<rootDir>/jest-mock/components/base/$1/$1',
         '^c/(card)$': '<rootDir>/jest-mock/components/base/$1/$1',
         '^c/(colorGradient)$': '<rootDir>/jest-mock/components/base/$1/$1',
+        '^c/(combobox)$': '<rootDir>/jest-mock/components/base/$1/$1',
         '^c/(confetti)$': '<rootDir>/jest-mock/components/base/$1/$1',
         '^c/(datatable)$': '<rootDir>/jest-mock/components/base/$1/$1',
         '^c/(filterMenu)$': '<rootDir>/jest-mock/components/base/$1/$1',

--- a/src/modules/base/calendar/__tests__/calendar.test.js
+++ b/src/modules/base/calendar/__tests__/calendar.test.js
@@ -111,7 +111,7 @@ describe('Calendar', () => {
                 expect(button.disabled).toBeTruthy();
             });
             const combobox = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             );
             expect(combobox.disabled).toBeTruthy();
             const tds = element.shadowRoot.querySelectorAll(
@@ -179,7 +179,7 @@ describe('Calendar', () => {
             ).textContent;
 
             const yearValue = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             ).value;
 
             expect(monthValue).toBe('August');
@@ -388,7 +388,7 @@ describe('Calendar', () => {
             })
             .then(() => {
                 const comboBoxYear = element.shadowRoot.querySelector(
-                    '[data-element-id="lightning-combobox"]'
+                    '[data-element-id="avonni-combobox"]'
                 );
                 expect(comboBoxYear.value).toBe(2023);
                 expect(new Date(element.value)).toEqual(new Date('05/09/2022'));
@@ -412,7 +412,7 @@ describe('Calendar', () => {
             })
             .then(() => {
                 const comboBoxYear = element.shadowRoot.querySelector(
-                    '[data-element-id="lightning-combobox"]'
+                    '[data-element-id="avonni-combobox"]'
                 );
                 expect(comboBoxYear.value).toBe(2021);
                 expect(new Date(element.value)).toEqual(new Date('05/09/2022'));
@@ -577,7 +577,7 @@ describe('Calendar', () => {
             );
             expect(month.textContent).toBe('April');
             const year = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             );
             expect(year.value).toBe(2021);
         });
@@ -597,7 +597,7 @@ describe('Calendar', () => {
             );
             expect(month.textContent).toBe('December');
             const year = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             );
             expect(year.value).toBe(2030);
         });
@@ -617,7 +617,7 @@ describe('Calendar', () => {
             );
             expect(month.textContent).toBe('January');
             const year = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             );
             expect(year.value).toBe(2020);
         });
@@ -642,7 +642,7 @@ describe('Calendar', () => {
             );
             expect(month.textContent).toBe(currentMonthName);
             const year = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             );
             expect(year.value).toBe(currentDate.getFullYear());
         });
@@ -668,7 +668,7 @@ describe('Calendar', () => {
             );
             expect(month.textContent).toBe('May');
             const year = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             );
             expect(year.value).toBe(2022);
         });
@@ -693,7 +693,7 @@ describe('Calendar', () => {
             );
             expect(month.textContent).toBe('January');
             const year = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             );
             expect(year.value).toBe(2020);
         });
@@ -718,7 +718,7 @@ describe('Calendar', () => {
             );
             expect(month.textContent).toBe('December');
             const year = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             );
             expect(year.value).toBe(2021);
         });
@@ -739,7 +739,7 @@ describe('Calendar', () => {
             );
             expect(month.textContent).toBe('January');
             const year = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             );
             expect(year.value).toBe(2020);
         });
@@ -759,7 +759,7 @@ describe('Calendar', () => {
             );
             expect(month.textContent).toBe('January');
             const year = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             );
             expect(year.value).toBe(2020);
         });
@@ -783,7 +783,7 @@ describe('Calendar', () => {
             );
             expect(month.textContent).toBe('January');
             const year = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             );
             expect(year.value).toBe(2020);
         });
@@ -807,7 +807,7 @@ describe('Calendar', () => {
             );
             expect(month.textContent).toBe('April');
             const year = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             );
             expect(year.value).toBe(2022);
         });
@@ -860,7 +860,7 @@ describe('Calendar', () => {
             );
             expect(month.textContent).toBe('April');
             const year = element.shadowRoot.querySelector(
-                '[data-element-id="lightning-combobox"]'
+                '[data-element-id="avonni-combobox"]'
             );
             expect(year.value).toBe(2021);
         });

--- a/src/modules/base/calendar/calendar.css
+++ b/src/modules/base/calendar/calendar.css
@@ -71,7 +71,7 @@ div:focus {
     width: fit-content;
 }
 
-lightning-combobox {
+.avonni-calendar__year-combobox {
     width: 6rem;
 }
 

--- a/src/modules/base/calendar/calendar.html
+++ b/src/modules/base/calendar/calendar.html
@@ -90,7 +90,9 @@
                                 ></lightning-button-icon>
                             </div>
                         </div>
-                        <lightning-combobox
+                        <c-combobox
+                            class="avonni-calendar__year-combobox"
+                            hide-clear-icon
                             name="years"
                             label="Years"
                             variant="label-hidden"
@@ -99,10 +101,10 @@
                             placeholder={year}
                             options={yearsList}
                             disabled={disabled}
-                            data-element-id="lightning-combobox"
+                            data-element-id="avonni-combobox"
                             onchange={handleYearChange}
                         >
-                        </lightning-combobox>
+                        </c-combobox>
                     </div>
                 </template>
                 <table

--- a/src/modules/base/combobox/__tests__/combobox.test.js
+++ b/src/modules/base/combobox/__tests__/combobox.test.js
@@ -31,7 +31,7 @@
  */
 
 import { createElement } from 'lwc';
-import Combobox from 'c/combobox';
+import Combobox from 'avonni/combobox';
 import { options, actions, scopes, scopesGroups, groups } from './data';
 
 let element;


### PR DESCRIPTION
### Fixes
**Calendar**
- Replaced the Lightning Combobox used for the year dropdown by an Avonni Combobox. Prevented the dropdown from not closing when used inside a popover.
