### PR TITLE
[fix] (ABC-912): Fix invisible calendar interval background

### DIFF
--- a/src/modules/base/calendar/calendar.css
+++ b/src/modules/base/calendar/calendar.css
@@ -103,6 +103,10 @@ lightning-combobox {
     font-weight: var(--avonni-calendar-week-label-font-weight, 600);
 }
 
+.avonni-calendar__table {
+    z-index: 0;
+}
+
 .avonni-calendar__table-row > .avonni-calendar__date-cell:hover > .slds-day {
     background-color: var(
         --avonni-calendar-date-color-background-hover,

--- a/src/modules/base/calendar/calendar.js
+++ b/src/modules/base/calendar/calendar.js
@@ -453,7 +453,9 @@ export default class Calendar extends LightningElement {
      */
     get tableClasses() {
         const isLabeled = this._dateLabels.length > 0;
-        return classSet('slds-datepicker__month')
+        return classSet(
+            'slds-datepicker__month slds-is-relative avonni-calendar__table'
+        )
             .add({ 'avonni-calendar__date-with-labels': isLabeled })
             .toString();
     }


### PR DESCRIPTION
### Fixes
**Calendar**
- Fixed interval background not appearing when the component does not have a parent with a `z-index` CSS property.