### PR TITLE
[feat] (ABC-915): Show a pointer on any part of the choice set options

### DIFF
--- a/src/modules/base/inputChoiceSet/__tests__/inputChoiceSet.test.js
+++ b/src/modules/base/inputChoiceSet/__tests__/inputChoiceSet.test.js
@@ -99,7 +99,30 @@ describe('Input choice set', () => {
     /* ----- ATTRIBUTES ----- */
 
     // disabled
-    it('Input choice set: disabled', () => {
+    it('Input choice set: disabled = false', () => {
+        element.options = options;
+        element.disabled = false;
+
+        return Promise.resolve().then(() => {
+            const inputs = element.shadowRoot.querySelectorAll(
+                '[data-element-id="input"]'
+            );
+            inputs.forEach((input) => {
+                expect(input.disabled).toBeFalsy();
+            });
+
+            const labels = element.shadowRoot.querySelectorAll(
+                '[data-element-id="label"]'
+            );
+            labels.forEach((label) => {
+                expect(label.classList).toContain(
+                    'avonni-input-choice-set__option-label'
+                );
+            });
+        });
+    });
+
+    it('Input choice set: disabled = true', () => {
         element.options = options;
         element.disabled = true;
 
@@ -109,6 +132,15 @@ describe('Input choice set', () => {
             );
             inputs.forEach((input) => {
                 expect(input.disabled).toBeTruthy();
+            });
+
+            const labels = element.shadowRoot.querySelectorAll(
+                '[data-element-id="label"]'
+            );
+            labels.forEach((label) => {
+                expect(label.classList).not.toContain(
+                    'avonni-input-choice-set__option-label'
+                );
             });
         });
     });

--- a/src/modules/base/inputChoiceSet/inputChoiceSet.css
+++ b/src/modules/base/inputChoiceSet/inputChoiceSet.css
@@ -65,6 +65,10 @@
     border-bottom: 1px solid #dddbda;
 }
 
+.avonni-input-choice-set__option-label {
+    cursor: pointer;
+}
+
 .slds-checkbox_button.avonni-input-choice-set__horizontal {
     border-right: 1px solid #dddbda;
     border-bottom: none;

--- a/src/modules/base/inputChoiceSet/inputChoiceSet.js
+++ b/src/modules/base/inputChoiceSet/inputChoiceSet.js
@@ -457,13 +457,19 @@ export default class InputChoiceSet extends LightningElement {
      * @type {string}
      */
     get computedLabelClass() {
-        const buttonLabelClass = `slds-checkbox_button__label slds-align_absolute-center avonni-input-choice-set__${this.orientation}`;
-        const checkboxLabelClass =
-            this.isMultiSelect && this.checkboxVariant
-                ? 'slds-checkbox__label'
-                : 'slds-radio__label';
+        let label;
+        if (this.checkboxVariant && this.isMultiSelect) {
+            label = 'slds-checkbox__label';
+        } else if (this.checkboxVariant) {
+            label = 'slds-radio__label';
+        } else {
+            label = `slds-checkbox_button__label slds-align_absolute-center avonni-input-choice-set__${this.orientation}`;
+        }
 
-        return this.checkboxVariant ? checkboxLabelClass : buttonLabelClass;
+        if (!this.disabled) {
+            label += ' avonni-input-choice-set__option-label';
+        }
+        return label;
     }
 
     /**


### PR DESCRIPTION
### Fixes
**Input Choice Set**
- On hover, displayed a pointer cursor on the whole button, instead of displaying it only on the label.