### PR TITLE
[Fix](ABC-916): Visual picker link - Hide checkmark when no icon

### DIFF
--- a/src/modules/base/visualPickerLink/__docs__/visualPickerLink.jsdoc.js
+++ b/src/modules/base/visualPickerLink/__docs__/visualPickerLink.jsdoc.js
@@ -43,3 +43,80 @@
  * @name --avonni-visual-picker-icon-color-foreground-default
  * @type color
  */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-visual-picker-link-tile-color-background
+ * @type color
+ * @default rgb(255, 255, 255)
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-visual-picker-link-tile-color-background-info-only
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-visual-picker-link-tile-radius-border
+ * @type radius
+ * @default 0.25rem
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-visual-picker-link-tile-sizing-border
+ * @type sizing
+ * @default 1px
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-visual-picker-link-tile-styling-border
+ * @type styling
+ * @default solid
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-visual-picker-link-tile-color-border
+ * @type color
+ * @default rgb(229, 229, 229)
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-visual-picker-link-tile-sizing-border-hover
+ * @type sizing
+ * @default 1px
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-visual-picker-link-tile-styling-border-hover
+ * @type styling
+ * @default solid
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-visual-picker-link-tile-color-border-hover
+ * @type color
+ * @default #1b96ff
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-visual-picker-link-title-text-color
+ * @type color
+ * @default #080707
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-visual-picker-link-title-font-size
+ * @type font
+ * @default 1em
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-visual-picker-link-title-font-style
+ * @type font
+ * @default normal
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-visual-picker-link-title-font-weight
+ * @type font
+ * @default 700
+ */

--- a/src/modules/base/visualPickerLink/__docs__/visualPickerLink.stories.js
+++ b/src/modules/base/visualPickerLink/__docs__/visualPickerLink.stories.js
@@ -82,7 +82,7 @@ export default {
             control: {
                 type: 'boolean'
             },
-            description: 'Show as completed.',
+            description: 'If present, a checkmark is added to the icon.',
             table: {
                 defaultValue: { summary: 'false' },
                 type: { summary: 'boolean' }

--- a/src/modules/base/visualPickerLink/__tests__/visualPickerLink.test.js
+++ b/src/modules/base/visualPickerLink/__tests__/visualPickerLink.test.js
@@ -65,7 +65,7 @@ describe('VisualPickerLink', () => {
 
         return Promise.resolve().then(() => {
             const wrapper = element.shadowRoot.querySelector(
-                '.slds-welcome-mat__tile'
+                '.avonni-visual-picker-link__tile'
             );
             expect(wrapper.classList).not.toContain(
                 'slds-welcome-mat__tile_complete'
@@ -78,7 +78,7 @@ describe('VisualPickerLink', () => {
 
         return Promise.resolve().then(() => {
             const wrapper = element.shadowRoot.querySelector(
-                '.slds-welcome-mat__tile'
+                '.avonni-visual-picker-link__tile'
             );
             expect(wrapper.classList).toContain(
                 'slds-welcome-mat__tile_complete'
@@ -121,7 +121,7 @@ describe('VisualPickerLink', () => {
             );
 
             expect(tileBody.classList).not.toContain(
-                'avonni-welcome-mat__tile-no-icon'
+                'avonni-visual-picker-link__tile-no-icon'
             );
         });
     });
@@ -137,7 +137,7 @@ describe('VisualPickerLink', () => {
                 'a div:first-of-type.slds-media__figure'
             );
             const iconRight = element.shadowRoot.querySelector(
-                '.avonni-media__figure-right'
+                '.avonni-visual-picker-link__figure-right'
             );
             const tileBody = element.shadowRoot.querySelector(
                 '.slds-welcome-mat__tile-body'
@@ -146,7 +146,7 @@ describe('VisualPickerLink', () => {
             expect(iconLeft).toBeTruthy();
             expect(iconRight).toBeFalsy();
             expect(tileBody.classList).not.toContain(
-                'avonni-welcome-mat__tile-body-right'
+                'avonni-visual-picker-link__tile-body-right'
             );
         });
     });
@@ -160,7 +160,7 @@ describe('VisualPickerLink', () => {
                 'a div:first-of-type.slds-media__figure'
             );
             const iconRight = element.shadowRoot.querySelector(
-                '.avonni-media__figure-right'
+                '.avonni-visual-picker-link__figure-right'
             );
             const tileBody = element.shadowRoot.querySelector(
                 '.slds-welcome-mat__tile-body'
@@ -169,7 +169,7 @@ describe('VisualPickerLink', () => {
             expect(iconLeft).toBeFalsy();
             expect(iconRight).toBeTruthy();
             expect(tileBody.classList).toContain(
-                'avonni-welcome-mat__tile-body-right'
+                'avonni-visual-picker-link__tile-body-right'
             );
         });
     });
@@ -180,7 +180,7 @@ describe('VisualPickerLink', () => {
 
         return Promise.resolve().then(() => {
             const wrapper = element.shadowRoot.querySelector(
-                '.slds-welcome-mat__tile'
+                '.avonni-visual-picker-link__tile'
             );
             const link = element.shadowRoot.querySelector(
                 '[data-element-id="a"]'
@@ -188,7 +188,7 @@ describe('VisualPickerLink', () => {
 
             expect(link).toBeTruthy();
             expect(wrapper.classList).not.toContain(
-                'slds-welcome-mat__tile_info-only'
+                'avonni-visual-picker-link__tile_info-only'
             );
         });
     });
@@ -198,7 +198,7 @@ describe('VisualPickerLink', () => {
 
         return Promise.resolve().then(() => {
             const wrapper = element.shadowRoot.querySelector(
-                '.slds-welcome-mat__tile'
+                '.avonni-visual-picker-link__tile'
             );
             const link = element.shadowRoot.querySelector(
                 '[data-element-id="a"]'
@@ -206,7 +206,7 @@ describe('VisualPickerLink', () => {
 
             expect(link).toBeFalsy();
             expect(wrapper.classList).toContain(
-                'slds-welcome-mat__tile_info-only'
+                'avonni-visual-picker-link__tile_info-only'
             );
         });
     });
@@ -217,7 +217,7 @@ describe('VisualPickerLink', () => {
 
         return Promise.resolve().then(() => {
             const title = element.shadowRoot.querySelector(
-                '.slds-welcome-mat__tile-title'
+                '.avonni-visual-picker-link__tile-title'
             );
             expect(title.textContent).toBe('A string title');
         });

--- a/src/modules/base/visualPickerLink/shared.css
+++ b/src/modules/base/visualPickerLink/shared.css
@@ -30,26 +30,27 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-.avonni-welcome-mat__tile-body-right {
+.avonni-visual-picker-link__tile-body-right {
     border-left: 0;
     border-right: var(--lwc-borderWidthThin, 1px) solid
         var(--lwc-colorBorder, rgb(221, 219, 218));
 }
 
-.avonni-welcome-mat__tile-no-icon {
+.avonni-visual-picker-link__tile-no-icon {
     border: 0;
 }
 
-.avonni-media__figure-right {
+.avonni-visual-picker-link__figure-right {
     margin-left: 0.375rem;
     margin-right: 0.375rem;
 }
 
-.slds-welcome-mat__tile_info-only .avonni-welcome-mat__tile-body-right {
+.avonni-visual-picker-link__tile_info-only
+    .avonni-visual-picker-link__tile-body-right {
     border-right: 0;
 }
 
-.avonni-visual-picker-icon {
+.avonni-visual-picker-link__icon {
     --sds-c-icon-radius-border: var(--avonni-visual-picker-icon-radius-border);
     --sds-c-icon-color-background: var(
         --avonni-visual-picker-icon-color-background
@@ -62,8 +63,94 @@
     );
 }
 
-.slds-welcome-mat__tile_complete .avonni-visual-picker-icon {
+.avonni-visual-picker-link__tile_complete .avonni-visual-picker-link__icon {
     --sds-c-icon-color-background: var(
         --avonni-visual-picker-icon-color-background-complete
     );
+}
+
+.avonni-visual-picker-link__tile-title {
+    color: var(--avonni-visual-picker-link-title-text-color, #080707);
+    font-weight: var(--avonni-visual-picker-link-title-font-weight, 700);
+    font-size: var(--avonni-visual-picker-link-title-font-size, 1em);
+    font-style: var(--avonni-visual-picker-link-title-font-style, normal);
+}
+
+.avonni-visual-picker-link__tile:not(.avonni-visual-picker-link__tile_complete):not(.avonni-visual-picker-link__tile_info-only) {
+    box-shadow: 0 2px 2px
+        var(--slds-g-color-neutral-base-10, rgba(0, 0, 0, 0.05));
+    border-radius: var(--avonni-visual-picker-link-tile-radius-border, 0.25rem);
+    background: var(
+        --avonni-visual-picker-link-tile-color-background,
+        rgb(255, 255, 255)
+    );
+}
+
+.avonni-visual-picker-link__tile:not(.avonni-visual-picker-link__tile_complete).avonni-visual-picker-link__tile_info-only {
+    background-color: var(
+        --avonni-visual-picker-link-tile-color-background-info-only
+    );
+}
+
+.avonni-visual-picker-link__tile.avonni-visual-picker-link__tile_info-only {
+    border-radius: var(--avonni-visual-picker-link-tile-radius-border, 0);
+    border-width: var(--avonni-visual-picker-link-tile-sizing-border);
+    border-style: var(--avonni-visual-picker-link-tile-styling-border);
+    border-color: var(--avonni-visual-picker-link-tile-color-border);
+}
+
+.avonni-visual-picker-link__tile:last-child {
+    margin-bottom: 0;
+}
+
+.avonni-visual-picker-link__tile:first-child {
+    margin-top: 0;
+}
+
+.avonni-visual-picker-link__tile {
+    margin: var(--lwc-spacingMedium, 1rem) 0;
+}
+
+.avonni-visual-picker-link__tile .slds-media {
+    padding: 0.5rem;
+}
+
+.avonni-visual-picker-link__box {
+    border-radius: var(--avonni-visual-picker-link-tile-radius-border, 0.25rem);
+    border-width: var(--avonni-visual-picker-link-tile-sizing-border, 1px);
+    border-style: var(--avonni-visual-picker-link-tile-styling-border, solid);
+    border-color: var(
+        --avonni-visual-picker-link-tile-color-border,
+        rgb(229, 229, 229)
+    );
+}
+
+.avonni-visual-picker-box_link {
+    color: inherit;
+    text-decoration: inherit;
+}
+
+.avonni-visual-picker-box_link:hover,
+.avonni-visual-picker-box_link:focus {
+    cursor: pointer;
+    outline: 0;
+    border-width: var(
+        --avonni-visual-picker-link-tile-sizing-border-hover,
+        1px
+    );
+    border-style: var(
+        --avonni-visual-picker-link-tile-styling-border-hover,
+        solid
+    );
+    border-color: var(
+        --avonni-visual-picker-link-tile-color-border-hover,
+        #1b96ff
+    );
+    box-shadow: 0 0 0 1px
+        var(--avonni-visual-picker-link-tile-color-border-hover, #1b96ff) inset;
+}
+
+.avonni-visual-picker-link__tile_info-only
+    .avonni-visual-picker-link__tile-body {
+    border-left: 0;
 }

--- a/src/modules/base/visualPickerLink/visualPickerLink.html
+++ b/src/modules/base/visualPickerLink/visualPickerLink.html
@@ -54,11 +54,11 @@
                                     class="avonni-visual-picker-icon"
                                 ></lightning-icon>
                                 <lightning-icon
-                                    icon-name="utility:check"
+                                    class="slds-icon-action-check"
                                     alternative-text="Completed"
+                                    icon-name="utility:check"
                                     variant="inverse"
                                     size="xx-small"
-                                    class="slds-icon-action-check"
                                 ></lightning-icon>
                             </div>
                         </div>

--- a/src/modules/base/visualPickerLink/visualPickerLink.html
+++ b/src/modules/base/visualPickerLink/visualPickerLink.html
@@ -37,7 +37,12 @@
         <div class={computedContainerClass}>
             <a
                 href={href}
-                class="slds-media slds-box slds-box_link"
+                class="
+                    slds-media
+                    slds-p-around_medium
+                    avonni-visual-picker-link__box
+                    avonni-visual-picker-box_link
+                "
                 data-element-id="a"
                 onclick={handleClick}
             >
@@ -49,11 +54,12 @@
                         <div class="slds-welcome-mat__tile-figure">
                             <div class="slds-welcome-mat__tile-icon-container">
                                 <lightning-icon
-                                    icon-name={iconName}
                                     data-element-id="lightning-icon-left"
-                                    class="avonni-visual-picker-icon"
+                                    class="avonni-visual-picker-link__icon"
+                                    icon-name={iconName}
                                 ></lightning-icon>
                                 <lightning-icon
+                                    if:true={completed}
                                     class="slds-icon-action-check"
                                     alternative-text="Completed"
                                     icon-name="utility:check"
@@ -67,18 +73,22 @@
                 <div class="slds-media__body">
                     <div class={computedTileBodyClass}>
                         <template if:true={showTitle}>
-                            <div class="slds-welcome-mat__tile-title">
+                            <div class="avonni-visual-picker-link__tile-title">
                                 <slot name="title"></slot>
                             </div>
                         </template>
                         <template if:false={showTitle}>
                             <template if:true={title}>
-                                <h3 class="slds-welcome-mat__tile-title">
+                                <h3
+                                    class="
+                                        avonni-visual-picker-link__tile-title
+                                    "
+                                >
                                     {title}
                                 </h3>
                             </template>
                         </template>
-                        <p class="slds-welcome-mat__tile-description">
+                        <p class="avonni-visual-picker-link__tile-description">
                             <slot></slot>
                         </p>
                     </div>
@@ -93,14 +103,15 @@
                                 <lightning-icon
                                     icon-name={iconName}
                                     data-element-id="lightning-icon-right"
-                                    class="avonni-visual-picker-icon"
+                                    class="avonni-visual-picker-link__icon"
                                 ></lightning-icon>
                                 <lightning-icon
+                                    if:true={completed}
+                                    class="slds-icon-action-check"
                                     icon-name="utility:check"
                                     alternative-text="Completed"
                                     variant="inverse"
                                     size="xx-small"
-                                    class="slds-icon-action-check"
                                 ></lightning-icon>
                             </div>
                         </div>

--- a/src/modules/base/visualPickerLink/visualPickerLink.js
+++ b/src/modules/base/visualPickerLink/visualPickerLink.js
@@ -69,7 +69,9 @@ export default class VisualPickerLink extends LightningElement {
     @api title;
 
     _completed = false;
+
     _iconPosition = ICON_POSITIONS.default;
+
     _infoOnly = false;
 
     showTitle = true;
@@ -100,7 +102,7 @@ export default class VisualPickerLink extends LightningElement {
      */
 
     /**
-     * If present, the picker is displayed as <a href="https://www.lightningdesignsystem.com/components/welcome-mat/#With-Completed-Steps">completed</a>.
+     * If present, a checkmark is added to the icon.
      *
      * @type {boolean}
      * @public
@@ -135,7 +137,7 @@ export default class VisualPickerLink extends LightningElement {
     }
 
     /**
-     * If present, the picker is displayed as <a href="https://www.lightningdesignsystem.com/components/welcome-mat/#Info-only">info only</a>.
+     * If present, The <a> tags are removed from the tiles. The tiles also lose their button appearance, removing borders and shadows.
      *
      * @type {boolean}
      * @public
@@ -162,10 +164,10 @@ export default class VisualPickerLink extends LightningElement {
      * @type {string}
      */
     get computedContainerClass() {
-        return classSet('slds-welcome-mat__tile')
+        return classSet('avonni-visual-picker-link__tile')
             .add({
                 'slds-welcome-mat__tile_complete': this._completed,
-                'slds-welcome-mat__tile_info-only': this._infoOnly
+                'avonni-visual-picker-link__tile_info-only': this._infoOnly
             })
             .toString();
     }
@@ -178,9 +180,9 @@ export default class VisualPickerLink extends LightningElement {
     get computedTileBodyClass() {
         return classSet('slds-welcome-mat__tile-body')
             .add({
-                'avonni-welcome-mat__tile-body-right':
+                'avonni-visual-picker-link__tile-body-right':
                     this._iconPosition === 'right',
-                'avonni-welcome-mat__tile-no-icon': !this.iconName
+                'avonni-visual-picker-link__tile-no-icon': !this.iconName
             })
             .toString();
     }
@@ -195,7 +197,8 @@ export default class VisualPickerLink extends LightningElement {
             'slds-media__figure slds-media__figure_fixed-width slds-align_absolute-center'
         )
             .add({
-                'avonni-media__figure-right': this._iconPosition === 'right'
+                'avonni-visual-picker-link__figure-right':
+                    this._iconPosition === 'right'
             })
             .toString();
     }

--- a/src/modules/base/visualPickerLink/visualPickerLinkInfoOnly.html
+++ b/src/modules/base/visualPickerLink/visualPickerLinkInfoOnly.html
@@ -46,14 +46,15 @@
                                 <lightning-icon
                                     icon-name={iconName}
                                     data-element-id="lightning-icon-left"
-                                    class="avonni-visual-picker-icon"
+                                    class="avonni-visual-picker-link__icon"
                                 ></lightning-icon>
                                 <lightning-icon
+                                    if:true={completed}
+                                    class="slds-icon-action-check"
                                     icon-name="utility:check"
                                     alternative-text="Completed"
                                     variant="inverse"
                                     size="xx-small"
-                                    class="slds-icon-action-check"
                                 ></lightning-icon>
                             </div>
                         </div>
@@ -62,18 +63,22 @@
                 <div class="slds-media__body">
                     <div class={computedTileBodyClass}>
                         <template if:true={showTitle}>
-                            <h3 class="slds-welcome-mat__tile-title">
+                            <h3 class="avonni-visual-picker-link__tile-title">
                                 <slot name="title"></slot>
                             </h3>
                         </template>
                         <template if:false={showTitle}>
                             <template if:true={title}>
-                                <div class="slds-welcome-mat__tile-title">
+                                <div
+                                    class="
+                                        avonni-visual-picker-link__tile-title
+                                    "
+                                >
                                     {title}
                                 </div>
                             </template>
                         </template>
-                        <p class="slds-welcome-mat__tile-description">
+                        <p class="avonni-visual-picker-link__tile-description">
                             <slot></slot>
                         </p>
                     </div>
@@ -87,15 +92,16 @@
                             <div class="slds-welcome-mat__tile-icon-container">
                                 <lightning-icon
                                     data-element-id="lightning-icon-right"
-                                    class="avonni-visual-picker-icon"
+                                    class="avonni-visual-picker-link__icon"
                                     icon-name={iconName}
                                 ></lightning-icon>
                                 <lightning-icon
+                                    if:true={completed}
+                                    class="slds-icon-action-check"
                                     icon-name="utility:check"
                                     alternative-text="Completed"
                                     variant="inverse"
                                     size="xx-small"
-                                    class="slds-icon-action-check"
                                 ></lightning-icon>
                             </div>
                         </div>

--- a/src/modules/base/visualPickerLink/visualPickerLinkInfoOnly.html
+++ b/src/modules/base/visualPickerLink/visualPickerLinkInfoOnly.html
@@ -36,24 +36,29 @@
     <div class="slds-welcome-mat">
         <div class={computedContainerClass}>
             <div class="slds-media">
-                <div if:true={leftPosition} class={computedIconContainerClass}>
-                    <div class="slds-welcome-mat__tile-figure">
-                        <div class="slds-welcome-mat__tile-icon-container">
-                            <lightning-icon
-                                icon-name={iconName}
-                                data-element-id="lightning-icon-left"
-                                class="avonni-visual-picker-icon"
-                            ></lightning-icon>
-                            <lightning-icon
-                                icon-name="utility:check"
-                                alternative-text="Completed"
-                                variant="inverse"
-                                size="xx-small"
-                                class="slds-icon-action-check"
-                            ></lightning-icon>
+                <template if:true={iconName}>
+                    <div
+                        if:true={leftPosition}
+                        class={computedIconContainerClass}
+                    >
+                        <div class="slds-welcome-mat__tile-figure">
+                            <div class="slds-welcome-mat__tile-icon-container">
+                                <lightning-icon
+                                    icon-name={iconName}
+                                    data-element-id="lightning-icon-left"
+                                    class="avonni-visual-picker-icon"
+                                ></lightning-icon>
+                                <lightning-icon
+                                    icon-name="utility:check"
+                                    alternative-text="Completed"
+                                    variant="inverse"
+                                    size="xx-small"
+                                    class="slds-icon-action-check"
+                                ></lightning-icon>
+                            </div>
                         </div>
                     </div>
-                </div>
+                </template>
                 <div class="slds-media__body">
                     <div class={computedTileBodyClass}>
                         <template if:true={showTitle}>
@@ -73,24 +78,29 @@
                         </p>
                     </div>
                 </div>
-                <div if:false={leftPosition} class={computedIconContainerClass}>
-                    <div class="slds-welcome-mat__tile-figure">
-                        <div class="slds-welcome-mat__tile-icon-container">
-                            <lightning-icon
-                                data-element-id="lightning-icon-right"
-                                class="avonni-visual-picker-icon"
-                                icon-name={iconName}
-                            ></lightning-icon>
-                            <lightning-icon
-                                icon-name="utility:check"
-                                alternative-text="Completed"
-                                variant="inverse"
-                                size="xx-small"
-                                class="slds-icon-action-check"
-                            ></lightning-icon>
+                <template if:true={iconName}>
+                    <div
+                        if:false={leftPosition}
+                        class={computedIconContainerClass}
+                    >
+                        <div class="slds-welcome-mat__tile-figure">
+                            <div class="slds-welcome-mat__tile-icon-container">
+                                <lightning-icon
+                                    data-element-id="lightning-icon-right"
+                                    class="avonni-visual-picker-icon"
+                                    icon-name={iconName}
+                                ></lightning-icon>
+                                <lightning-icon
+                                    icon-name="utility:check"
+                                    alternative-text="Completed"
+                                    variant="inverse"
+                                    size="xx-small"
+                                    class="slds-icon-action-check"
+                                ></lightning-icon>
+                            </div>
                         </div>
                     </div>
-                </div>
+                </template>
             </div>
         </div>
     </div>


### PR DESCRIPTION
### Features
**Visual Picker Link**
- Added new styling hooks
```
--avonni-visual-picker-link-tile-color-background
--avonni-visual-picker-link-tile-color-background-info-only
--avonni-visual-picker-link-tile-radius-border
--avonni-visual-picker-link-tile-sizing-border
--avonni-visual-picker-link-tile-styling-border
--avonni-visual-picker-link-tile-color-border
--avonni-visual-picker-link-tile-sizing-border-hover
--avonni-visual-picker-link-tile-styling-border-hover
--avonni-visual-picker-link-tile-color-border-hover
--avonni-visual-picker-link-title-text-color
--avonni-visual-picker-link-title-font-size
--avonni-visual-picker-link-title-font-style
--avonni-visual-picker-link-title-font-weight
```
### Fixes
**Visual Picker Link**
- Fixed issue with checkmark when completed and no icon
