### PR TITLE
[fix] (ABC-921): Fix decimal step with percent in input counter

### DIFF
--- a/src/modules/base/avatarGroup/__tests__/avatarGroup.test.js
+++ b/src/modules/base/avatarGroup/__tests__/avatarGroup.test.js
@@ -111,12 +111,12 @@ describe('Avatar Group', () => {
         document.body.appendChild(element);
     });
 
-    it('Avatar Group:: Default attributes', () => {
+    it('Avatar Group: Default attributes', () => {
         expect(element.size).toBe('medium');
         expect(element.variant).toBe('square');
         expect(element.items).toMatchObject([]);
         expect(element.layout).toBe('stack');
-        expect(element.maxCount).toBe(5);
+        expect(element.maxCount).toBeUndefined();
         expect(element.name).toBeUndefined();
         expect(element.listButtonShowLessIconName).toBeUndefined();
         expect(element.listButtonShowLessIconPosition).toBe('left');
@@ -511,7 +511,26 @@ describe('Avatar Group', () => {
     });
 
     //max count
-    it('Avatar group: max count stack', () => {
+    it('Avatar group: max count', () => {
+        element.items = [
+            ...items,
+            ...items,
+            ...items,
+            ...items,
+            ...items,
+            ...items
+        ];
+        element.maxCount = 3;
+
+        return Promise.resolve().then(() => {
+            const avatars = element.shadowRoot.querySelectorAll(
+                '[data-element-id="avonni-avatar"]'
+            );
+            expect(avatars).toHaveLength(3);
+        });
+    });
+
+    it('Avatar group: default max count stack', () => {
         element.layout = 'stack';
         element.items = [
             ...items,
@@ -523,16 +542,14 @@ describe('Avatar Group', () => {
         ];
 
         return Promise.resolve().then(() => {
-            expect(element.maxCount).toBe(5);
             const avatars = element.shadowRoot.querySelectorAll(
-                '.avonni-avatar-group__avatar-container'
+                '[data-element-id="avonni-avatar"]'
             );
-            expect(avatars).toHaveLength(6);
+            expect(avatars).toHaveLength(5);
         });
     });
 
-    it('Avatar group: max count grid', () => {
-        element.maxCount = '11';
+    it('Avatar group: default max count grid', () => {
         element.layout = 'grid';
         element.items = [
             ...items,
@@ -549,14 +566,13 @@ describe('Avatar Group', () => {
 
         return Promise.resolve().then(() => {
             const avatars = element.shadowRoot.querySelectorAll(
-                '.avonni-avatar-group__avatar-container'
+                '[data-element-id="avonni-avatar"]'
             );
-            expect(avatars).toHaveLength(12);
+            expect(avatars).toHaveLength(11);
         });
     });
 
-    it('Avatar group: max count list', () => {
-        element.maxCount = '11';
+    it('Avatar group: default max count list', () => {
         element.items = [
             ...items,
             ...items,
@@ -569,7 +585,7 @@ describe('Avatar Group', () => {
 
         return Promise.resolve().then(() => {
             const avatars = element.shadowRoot.querySelectorAll(
-                '.avonni-avatar-group__avatar-container'
+                '[data-element-id="avonni-avatar"]'
             );
             expect(avatars).toHaveLength(11);
         });

--- a/src/modules/base/inputCounter/__tests__/inputCounter.test.js
+++ b/src/modules/base/inputCounter/__tests__/inputCounter.test.js
@@ -197,6 +197,29 @@ describe('Input Counter', () => {
             });
     });
 
+    it('Input Counter: decimal step with percent type', () => {
+        element.type = 'percent';
+        element.step = 0.2;
+
+        const input = element.shadowRoot.querySelector(
+            '[data-element-id="input"]'
+        );
+
+        return Promise.resolve()
+            .then(() => {
+                expect(input.step).toBe('0.2');
+                expect(element.value).toBeNull();
+            })
+            .then(() => {
+                const addButton = element.shadowRoot.querySelector(
+                    '[data-element-id="lightning-button-icon-increment"]'
+                );
+                addButton.click();
+                expect(input.value).toBe('20%');
+                expect(element.value).toBe(0.2);
+            });
+    });
+
     // value
     it('Input Counter: value', () => {
         element.value = 5;

--- a/src/modules/base/inputCounter/inputCounter.js
+++ b/src/modules/base/inputCounter/inputCounter.js
@@ -477,6 +477,18 @@ export default class InputCounter extends LightningElement {
     }
 
     /**
+     * Value normalized to be passed in the validation constraint. If the type is percent, the value is multiplied by 100 to reflect its end result (0.1 will be transformed into 10%).
+     *
+     * @type {number}
+     */
+    get validationValue() {
+        if (this.type === 'percent' && !isNaN(this.value)) {
+            return this.value * 100;
+        }
+        return this.value;
+    }
+
+    /**
      * Compute constraintApi with fieldConstraintApiWithProxyInput.
      */
     get _constraint() {
@@ -488,7 +500,7 @@ export default class InputCounter extends LightningElement {
             this._constraintApiProxyInputUpdater =
                 this._constraintApi.setInputAttributes({
                     type: () => 'number',
-                    value: () => this.value,
+                    value: () => this.validationValue,
                     max: () => this.max,
                     min: () => this.min,
                     step: () => this.inputStep,
@@ -592,8 +604,7 @@ export default class InputCounter extends LightningElement {
         this._value = increaseNumberByStep({
             value: this.value,
             increment,
-            step: this.step,
-            fractionDigits: this.fractionDigits
+            step: this.step
         });
         this.normalizeValue();
         this.dispatchChange();

--- a/src/modules/base/inputCounter/numberFormat.js
+++ b/src/modules/base/inputCounter/numberFormat.js
@@ -131,12 +131,7 @@ export function hasValidNumberSymbol(value) {
     return value.match(matchSymbols) ? true : false;
 }
 
-export function increaseNumberByStep({
-    value,
-    increment,
-    step,
-    fractionDigits
-}) {
+export function increaseNumberByStep({ value, increment, step }) {
     const startingValue = value === '' || value == null ? '0' : value;
     const stepAsFloat = parseFloat(step);
 
@@ -147,5 +142,5 @@ export function increaseNumberByStep({
         const increaseBy = increment * stepAsFloat;
         result = parseFloat(startingValue) + increaseBy;
     }
-    return Number(result.toFixed(fractionDigits));
+    return Number(result);
 }


### PR DESCRIPTION
### Fixes
**Input Counter**
- Allowed a decimal step for the percent type, without a `fraction-digits`.
