### PR TITLE
[fix] (ABC-922): Handle non existent hour on time change in scheduler

### DIFF
--- a/src/modules/base/primitiveSchedulerCalendar/__tests__/primitiveSchedulerCalendar.test.js
+++ b/src/modules/base/primitiveSchedulerCalendar/__tests__/primitiveSchedulerCalendar.test.js
@@ -1546,6 +1546,30 @@ describe('Primitive Scheduler Calendar', () => {
         });
     });
 
+    it('Primitive Scheduler Calendar: selectedDate is on spring time change', () => {
+        element.selectedDate = new Date(2023, 2, 12);
+
+        return Promise.resolve().then(() => {
+            const hourHeaders = element.shadowRoot.querySelector(
+                '[data-element-id="avonni-primitive-scheduler-header-group-vertical"]'
+            );
+            expect(hourHeaders.start.ts).toBe(new Date(2023, 2, 13).getTime());
+
+            const threeAMCells = element.shadowRoot.querySelectorAll(
+                '[data-element-id="div-cell"][data-start="1678604400000"]'
+            );
+            expect(threeAMCells).toHaveLength(2);
+            expect(threeAMCells[0].classList).toContain('slds-theme_shade');
+            expect(threeAMCells[0].classList).toContain(
+                'slds-theme_alert-texture'
+            );
+            expect(threeAMCells[1].classList).not.toContain(
+                'slds-theme_alert-texture'
+            );
+            expect(threeAMCells[1].classList).not.toContain('slds-theme_shade');
+        });
+    });
+
     // selected-resources
     it('Primitive Scheduler Calendar: selectedResources', () => {
         element.resources = RESOURCES;

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.html
@@ -281,7 +281,7 @@
                                 "
                                 available-time-frames={availableTimeFrames}
                                 headers={hourHeaders}
-                                start={start}
+                                start={hourHeadersStart}
                                 time-span={hourHeadersTimeSpan}
                                 timezone={timezone}
                                 variant="vertical"
@@ -315,15 +315,23 @@
                                                 for:item="cell"
                                             >
                                                 <div
-                                                    key={cell.start}
+                                                    key={cell.key}
                                                     class={cell.computedClass}
                                                     data-element-id="div-cell"
                                                     data-end={cell.end}
                                                     data-start={cell.start}
+                                                    title={cell.title}
                                                     oncontextmenu={handleEmptySpotContextMenu}
                                                     onmousedown={handleMouseDown}
                                                     ondblclick={handleDoubleClick}
                                                 >
+                                                    <span
+                                                        if:true={cell.title}
+                                                        class="
+                                                            slds-assistive-text
+                                                        "
+                                                        >{cell.title}</span
+                                                    >
                                                     <!-- Cell content visible only for the month time span -->
                                                     <div
                                                         if:true={isMonth}

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -397,7 +397,8 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
     get columnClass() {
         return classSet('avonni-scheduler__calendar-column')
             .add({
-                'avonni-scheduler__calendar-column_day': this.isDay
+                'avonni-scheduler__calendar-column_day':
+                    this.isDay && this.timeSpan.unit === 1
             })
             .toString();
     }

--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -1286,13 +1286,13 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
     getVisibleWeekdays(startDate) {
         const span = this.timeSpan.span;
         const oneDay = this.isDay && span <= 1;
+        const weekday = startDate.weekday === 7 ? 0 : startDate.weekday;
         let availableDays = this.availableDaysOfTheWeek;
 
         if (oneDay) {
-            availableDays = [startDate.weekday];
+            availableDays = [weekday];
         } else if (this.isDay) {
             availableDays = [];
-            const weekday = startDate.weekday === 7 ? 0 : startDate.weekday;
             let dayIndex = this.availableDaysOfTheWeek.findIndex(
                 (dayNumber) => {
                     return dayNumber === weekday;

--- a/src/modules/base/schedulerUtils/cell.js
+++ b/src/modules/base/schedulerUtils/cell.js
@@ -54,6 +54,7 @@ export default class SchedulerCell {
         this.end = props.end;
         this.events = normalizeArray(props.events);
         this.placeholders = normalizeArray(props.placeholders);
+        this.removedByTimeChange = false;
         this.timezone = props.timezone;
         this._startDate = dateTimeObjectFrom(this.start, {
             zone: this.timezone
@@ -89,10 +90,17 @@ export default class SchedulerCell {
         ).add({
             'avonni-scheduler__calendar-cell_outside-of-current-month':
                 this.currentMonth && this.currentMonth !== this.month,
-            'avonni-scheduler__calendar-cell_today': this.isToday
+            'avonni-scheduler__calendar-cell_today': this.isToday,
+            'slds-theme_shade slds-theme_alert-texture':
+                this.removedByTimeChange
         });
     }
 
+    /**
+     * True if the start date is today.
+     *
+     * @type {boolean}
+     */
     get isToday() {
         const today = dateTimeObjectFrom(Date.now(), {
             zone: this.timezone
@@ -102,6 +110,15 @@ export default class SchedulerCell {
             this._startDate.month === today.month &&
             this._startDate.day === today.day
         );
+    }
+
+    /**
+     * Unique key to use in the template iterations.
+     *
+     * @type {string|number}
+     */
+    get key() {
+        return this.removedByTimeChange ? 'removed' : this.start;
     }
 
     /**
@@ -130,6 +147,17 @@ export default class SchedulerCell {
      */
     get showMoreLabel() {
         return `+${this.overflowingEvents.length} more`;
+    }
+
+    /**
+     * Title of the cell, used in the calendar display.
+     *
+     * @type {string}
+     */
+    get title() {
+        return this.removedByTimeChange
+            ? 'This time slot does not exist due to the time change.'
+            : undefined;
     }
 
     /**

--- a/src/modules/base/schedulerUtils/cellGroup.js
+++ b/src/modules/base/schedulerUtils/cellGroup.js
@@ -55,8 +55,17 @@ export class SchedulerCellGroup {
      */
     initCells() {
         this.cells = [];
-        this.referenceCells.forEach((element) => {
-            this.cells.push(new Cell({ ...element, timezone: this.timezone }));
+        this.referenceCells.forEach((element, index) => {
+            const cell = new Cell({ ...element, timezone: this.timezone });
+            const nextCell = this.referenceCells[index + 1];
+            if (nextCell) {
+                const hasSameStart = nextCell.start === cell.start;
+                const isOneHour = cell.end - cell.start === 3600000 - 1;
+                if (hasSameStart && isOneHour) {
+                    cell.removedByTimeChange = true;
+                }
+            }
+            this.cells.push(cell);
         });
 
         const events = this.events;


### PR DESCRIPTION
### Fixes
**Scheduler**
- Fixed event creation on a Sunday, in the calendar display with one-day time span.
- Handled the spring time change in the calendar display. The skipped hour that does not exist is shown, but styled differently than the others.