### PR TITLE
[fix] (ABC-926): Fix colors update after insertion of inline color picker

### DIFF
--- a/src/modules/base/colorPicker/colorPicker.js
+++ b/src/modules/base/colorPicker/colorPicker.js
@@ -266,6 +266,7 @@ export default class ColorPicker extends LightningElement {
         this._colors = colors.length > 0 ? colors : DEFAULT_COLORS;
 
         if (this._isConnected) {
+            this.setPaletteData();
             this.setLastSelectedColor();
         }
     }

--- a/src/modules/base/primitiveActivityTimelineItem/__tests__/primitiveActivityTimelineItem.test.js
+++ b/src/modules/base/primitiveActivityTimelineItem/__tests__/primitiveActivityTimelineItem.test.js
@@ -178,8 +178,10 @@ describe('Primitive Activity Timeline Item', () => {
         element.description = 'This is an description text';
 
         return Promise.resolve().then(() => {
-            const description = element.shadowRoot.querySelector('p');
-            expect(description.textContent).toBe('This is an description text');
+            const description = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-formatted-rich-text-description"]'
+            );
+            expect(description.value).toBe('This is an description text');
         });
     });
 

--- a/src/modules/base/primitiveActivityTimelineItem/primitiveActivityTimelineItem.html
+++ b/src/modules/base/primitiveActivityTimelineItem/primitiveActivityTimelineItem.html
@@ -167,6 +167,7 @@
                 >
                     <lightning-formatted-rich-text
                         value={description}
+                        data-element-id="lightning-formatted-rich-text-description"
                     ></lightning-formatted-rich-text>
                 </p>
                 <template if:false={closed}>


### PR DESCRIPTION
### Fixes
**Color Picker**
- Fixed the `colors` attribute update, when the update happens after the first insertion of an `inline` color picker.
