### PR TITLE
[fix] (ABC-928): Display a maximum of 500 ticks on the slider

### DIFF
--- a/src/modules/base/slider/__tests__/slider.test.js
+++ b/src/modules/base/slider/__tests__/slider.test.js
@@ -399,6 +399,18 @@ describe('Slider', () => {
         });
     });
 
+    it('showTickMarks, a maximum of 500 ticks can be visible', () => {
+        element.showTickMarks = true;
+        element.step = '0.001';
+
+        return Promise.resolve().then(() => {
+            const ruler = element.shadowRoot.querySelector(
+                '[data-element-id="ruler"]'
+            );
+            expect(ruler.childElementCount).toEqual(501);
+        });
+    });
+
     // size
     it('size = responsive', () => {
         element.size = 'responsive';

--- a/src/modules/base/slider/slider.js
+++ b/src/modules/base/slider/slider.js
@@ -49,6 +49,7 @@ const DEFAULT_MAX_PERCENTAGE = 1;
 const PERCENT_SCALING_FACTOR = 100;
 const DEFAULT_STEP = 1;
 const DEFAULT_VALUE = 50;
+const MAX_NUMBER_OF_TICKS = 500;
 
 const SLIDER_SIZES = {
     valid: ['x-small', 'small', 'medium', 'large', 'responsive'],
@@ -1134,12 +1135,17 @@ export default class Slider extends LightningElement {
         const numberOfSteps =
             (this.computedMax - this.computedMin) /
             (this.step * this._scalingFactor);
-        const stepWidth = (totalWidth - this._thumbRadius * 2) / numberOfSteps;
+        const normalizedNumberOfSteps =
+            numberOfSteps > MAX_NUMBER_OF_TICKS
+                ? MAX_NUMBER_OF_TICKS
+                : numberOfSteps;
+        const stepWidth =
+            (totalWidth - this._thumbRadius * 2) / normalizedNumberOfSteps;
 
         switch (this._tickMarkStyle) {
             case 'tick':
                 this.drawTickRuler(
-                    numberOfSteps,
+                    normalizedNumberOfSteps,
                     this._thumbRadius,
                     stepWidth,
                     drawPositions
@@ -1147,7 +1153,7 @@ export default class Slider extends LightningElement {
                 break;
             case 'dot':
                 this.drawDotRuler(
-                    numberOfSteps,
+                    normalizedNumberOfSteps,
                     this._thumbRadius,
                     stepWidth,
                     drawPositions
@@ -1156,7 +1162,7 @@ export default class Slider extends LightningElement {
             default:
                 // or when = 'inner-tick'
                 this.drawInnerTickRuler(
-                    numberOfSteps,
+                    normalizedNumberOfSteps,
                     this._thumbRadius,
                     stepWidth,
                     drawPositions


### PR DESCRIPTION
### Fixes
**Slider**
- Prevented performance issue when the ticks are visible and the step is very small. The maximum number of visible ticks has been set to 500.
