### PR TITLE
[fix] (ABC-958): Prevent single line pill container infinite loop on expand

### DIFF
--- a/src/modules/base/pillContainer/pillContainer.css
+++ b/src/modules/base/pillContainer/pillContainer.css
@@ -79,6 +79,10 @@
     left: 0;
 }
 
+.avonni-pill-container__pill {
+    max-width: var(--lwc-sizeSmall, 15rem);
+}
+
 /*
 * ------------------------------------------------------------
 *  SORTABLE

--- a/src/modules/base/pillContainer/pillContainer.js
+++ b/src/modules/base/pillContainer/pillContainer.js
@@ -332,7 +332,11 @@ export default class PillContainer extends LightningElement {
      * @type {string}
      */
     get computedPillClass() {
-        return this.sortable ? 'avonni-pill-container__pill-sortable' : '';
+        return classSet('avonni-pill-container__pill')
+            .add({
+                'avonni-pill-container__pill-sortable': this.sortable
+            })
+            .toString();
     }
 
     /**

--- a/src/modules/base/pillContainer/pillContainer.js
+++ b/src/modules/base/pillContainer/pillContainer.js
@@ -832,7 +832,11 @@ export default class PillContainer extends LightningElement {
             fittingCount += 1;
         }
 
-        if (fittingCount === visibleItems.length && width < totalWidth) {
+        if (
+            fittingCount !== 0 &&
+            fittingCount === visibleItems.length &&
+            width < totalWidth
+        ) {
             // Add more visible items if needed
             const nextItemWidth = this._itemsWidths[fittingCount];
             const availableSpace = totalWidth - width;


### PR DESCRIPTION
### Fixes
**Pill Container**
- Prevented a screen freeze, when a single-line pill container was expanded, but the first pill could not fit the available width.