### PR TITLE
[feat] (ABC-974): Add open and close events to filter menu group

### DIFF
--- a/src/modules/base/filterMenu/__tests__/filterMenu.test.js
+++ b/src/modules/base/filterMenu/__tests__/filterMenu.test.js
@@ -2224,7 +2224,7 @@ describe('FilterMenu', () => {
         return Promise.resolve()
             .then(() => {
                 expect(openHandler).toHaveBeenCalled();
-                expect(openHandler.mock.calls[0][0].bubbles).toBeFalsy();
+                expect(openHandler.mock.calls[0][0].bubbles).toBeTruthy();
                 expect(openHandler.mock.calls[0][0].cancelable).toBeFalsy();
                 expect(openHandler.mock.calls[0][0].composed).toBeFalsy();
 
@@ -2237,7 +2237,7 @@ describe('FilterMenu', () => {
             })
             .then(() => {
                 expect(closeHandler).toHaveBeenCalled();
-                expect(closeHandler.mock.calls[0][0].bubbles).toBeFalsy();
+                expect(closeHandler.mock.calls[0][0].bubbles).toBeTruthy();
                 expect(closeHandler.mock.calls[0][0].cancelable).toBeFalsy();
                 expect(closeHandler.mock.calls[0][0].composed).toBeFalsy();
 

--- a/src/modules/base/filterMenu/filterMenu.js
+++ b/src/modules/base/filterMenu/filterMenu.js
@@ -1667,8 +1667,9 @@ export default class FilterMenu extends LightningElement {
                  * @event
                  * @name open
                  * @public
+                 * @bubbles
                  */
-                this.dispatchEvent(new CustomEvent('open'));
+                this.dispatchEvent(new CustomEvent('open', { bubbles: true }));
 
                 // update the bounding rect when the menu is toggled
                 this._boundingRect = this.getBoundingClientRect();
@@ -1686,8 +1687,9 @@ export default class FilterMenu extends LightningElement {
                  * @event
                  * @name close
                  * @public
+                 * @bubbles
                  */
-                this.dispatchEvent(new CustomEvent('close'));
+                this.dispatchEvent(new CustomEvent('close', { bubbles: true }));
                 this._previousScroll = undefined;
             }
         }

--- a/src/modules/base/filterMenuGroup/__tests__/filterMenuGroup.test.js
+++ b/src/modules/base/filterMenuGroup/__tests__/filterMenuGroup.test.js
@@ -641,6 +641,35 @@ describe('FilterMenuGroup', () => {
             });
     });
 
+    // close
+    it('Filter menu group: close event', () => {
+        element.menus = MENUS;
+
+        const handler = jest.fn();
+        element.addEventListener('close', handler);
+
+        return Promise.resolve().then(() => {
+            const menu = element.shadowRoot.querySelector(
+                '[data-element-id="avonni-filter-menu"]'
+            );
+            menu.dispatchEvent(
+                new CustomEvent('close', {
+                    detail: {
+                        name: MENUS[0].name
+                    },
+                    bubbles: true
+                })
+            );
+
+            expect(handler).toHaveBeenCalled();
+            const call = handler.mock.calls[0][0];
+            expect(call.detail.name).toBe(MENUS[0].name);
+            expect(call.bubbles).toBeFalsy();
+            expect(call.composed).toBeFalsy();
+            expect(call.cancelable).toBeFalsy();
+        });
+    });
+
     // loadmore
     it('Filter menu group: loadmore event', () => {
         element.menus = MENUS;
@@ -660,6 +689,35 @@ describe('FilterMenuGroup', () => {
 
             expect(handler).toHaveBeenCalled();
             const call = handler.mock.calls[0][0];
+            expect(call.bubbles).toBeFalsy();
+            expect(call.composed).toBeFalsy();
+            expect(call.cancelable).toBeFalsy();
+        });
+    });
+
+    // open
+    it('Filter menu group: open event', () => {
+        element.menus = MENUS;
+
+        const handler = jest.fn();
+        element.addEventListener('open', handler);
+
+        return Promise.resolve().then(() => {
+            const menu = element.shadowRoot.querySelector(
+                '[data-element-id="avonni-filter-menu"]'
+            );
+            menu.dispatchEvent(
+                new CustomEvent('open', {
+                    detail: {
+                        name: MENUS[0].name
+                    },
+                    bubbles: true
+                })
+            );
+
+            expect(handler).toHaveBeenCalled();
+            const call = handler.mock.calls[0][0];
+            expect(call.detail.name).toBe(MENUS[0].name);
             expect(call.bubbles).toBeFalsy();
             expect(call.composed).toBeFalsy();
             expect(call.cancelable).toBeFalsy();

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.html
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.html
@@ -48,7 +48,9 @@
         class={filtersWrapperClass}
         data-element-id="ul"
         onapply={handleApply}
+        onclose={handleClose}
         onloadmore={handleLoadMore}
+        onopen={handleOpen}
         onreset={handleReset}
         onsearch={handleSearch}
         onselect={handleSelect}

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.js
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.js
@@ -399,6 +399,32 @@ export default class FilterMenuGroup extends LightningElement {
     }
 
     /**
+     * Handle the closing of a menu popover.
+     *
+     * @param {Event} event close event fired by the menu.
+     */
+    handleClose(event) {
+        event.stopPropagation();
+        const menuName = event.target.dataset.name;
+
+        /**
+         * The event fired when a horizontal menu popover is closed.
+         *
+         * @event
+         * @name close
+         * @param {string} name Name of the closed menu.
+         * @public
+         */
+        this.dispatchEvent(
+            new CustomEvent('close', {
+                detail: {
+                    name: menuName
+                }
+            })
+        );
+    }
+
+    /**
      * Handle the load more event.
      *
      * @param {Event} event `loadmore` event fired by the menu.
@@ -417,6 +443,32 @@ export default class FilterMenuGroup extends LightningElement {
          */
         this.dispatchEvent(
             new CustomEvent('loadmore', { detail: { name: menuName } })
+        );
+    }
+
+    /**
+     * Handle the opening of a menu popover.
+     *
+     * @param {Event} event open event fired by the menu.
+     */
+    handleOpen(event) {
+        event.stopPropagation();
+        const menuName = event.target.dataset.name;
+
+        /**
+         * The event fired when a horizontal menu popover is opened.
+         *
+         * @event
+         * @name open
+         * @param {string} name Name of the opened menu.
+         * @public
+         */
+        this.dispatchEvent(
+            new CustomEvent('open', {
+                detail: {
+                    name: menuName
+                }
+            })
         );
     }
 


### PR DESCRIPTION
### Breaking Changes
**Filter Menu**
- Updated the `close` and `open` events to make them bubble.

### Features
**Filter Menu Group**
- Added the `close` and `open` events.
