### PR TITLE
[fix] (ABC-980): Kanban - Fix issue with ResizeObserver

### DIFF
--- a/src/modules/base/kanban/kanban.js
+++ b/src/modules/base/kanban/kanban.js
@@ -1571,7 +1571,7 @@ export default class Kanban extends LightningElement {
             return null;
         }
 
-        const resizeObserver = new AvonniResizeObserver(() => {
+        return new AvonniResizeObserver(container, () => {
             this._scrollWidth = this.template.querySelector(
                 '[data-element-id="avonni-kanban__container"]'
             ).scrollWidth;
@@ -1583,8 +1583,6 @@ export default class Kanban extends LightningElement {
             const { x, y } = this.getBoundingClientRect();
             this._kanbanOffset = { x, y };
         });
-        resizeObserver.observe(container);
-        return resizeObserver;
     }
 
     /**

--- a/src/modules/base/kanban/kanban.js
+++ b/src/modules/base/kanban/kanban.js
@@ -1050,7 +1050,8 @@ export default class Kanban extends LightningElement {
         const overflowX = fieldContainer.scrollWidth > this._initialScrollWidth;
 
         if (!overflowX && (!overflowY || !this._hasSubGroups)) {
-            this._currentScrollTarget.scrollBy(scrollStep.x, scrollStep.y);
+            this._currentScrollTarget.scrollLeft += scrollStep.x;
+            this._currentScrollTarget.scrollTop += scrollStep.y;
             scrollStep.x =
                 this._currentScrollTarget.scrollLeft === 0 && scrollStep.x < 0
                     ? 0
@@ -1776,12 +1777,13 @@ export default class Kanban extends LightningElement {
             ? this._draggedTile
             : this._draggedGroup;
         const style = window.getComputedStyle(draggedItem);
-        const matrix = new DOMMatrixReadOnly(style.transform);
+        const matrixValues = style.transform
+            .match(/matrix.*\((.+)\)/)[1]
+            .split(', ');
         const currentTranslate = {
-            translateX: matrix.m41,
-            translateY: matrix.m42
+            translateX: parseFloat(matrixValues[4]),
+            translateY: parseFloat(matrixValues[5])
         };
-
         draggedItem.style.transform = `translateX(${
             currentTranslate.translateX + delta.x
         }px) translateY(${


### PR DESCRIPTION
### Fixes
**Kanban**
- Add missing parameter in `ResizeObserver`
- Fix crash issues caused by `scrollBy()` and `DOMMatrixReadOnly`
