### PR TITLE
[fix] (ABC-988): Kanban - Group summarization not updating

### DIFF
--- a/src/modules/base/kanban/__docs__/kanban.stories.js
+++ b/src/modules/base/kanban/__docs__/kanban.stories.js
@@ -200,7 +200,7 @@ export default {
         coverImageFieldName: 'coverImage',
         isLoading: false,
         hideHeader: false,
-        summarizeFieldName: 'Amount',
+        summarizeFieldName: 'amount',
         groupFieldName: 'status',
         variant: 'base',
         keyField: 'id'

--- a/src/modules/base/kanban/__tests__/kanban.test.js
+++ b/src/modules/base/kanban/__tests__/kanban.test.js
@@ -172,7 +172,7 @@ describe('Kanban', () => {
         element.records = RECORDS;
         element.fields = FIELDS;
         element.groupFieldName = 'status';
-        element.summarizeFieldName = 'Amount';
+        element.summarizeFieldName = 'amount';
         element.actions = ACTIONS;
 
         return Promise.resolve().then(() => {
@@ -192,7 +192,7 @@ describe('Kanban', () => {
         element.records = RECORDS;
         element.fields = FIELDS;
         element.groupFieldName = 'status';
-        element.summarizeFieldName = 'Amount';
+        element.summarizeFieldName = 'amount';
         element.actions = ACTIONS;
         element.disableItemDragAndDrop = true;
 
@@ -211,7 +211,7 @@ describe('Kanban', () => {
         element.records = RECORDS;
         element.fields = FIELDS;
         element.groupFieldName = 'status';
-        element.summarizeFieldName = 'Amount';
+        element.summarizeFieldName = 'amount';
         element.actions = ACTIONS;
 
         return Promise.resolve().then(() => {
@@ -244,7 +244,7 @@ describe('Kanban', () => {
         element.records = RECORDS;
         element.fields = FIELDS;
         element.groupFieldName = 'status';
-        element.summarizeFieldName = 'Amount';
+        element.summarizeFieldName = 'amount';
         element.actions = ACTIONS;
         element.variant = 'base';
 
@@ -277,7 +277,7 @@ describe('Kanban', () => {
         element.records = RECORDS;
         element.fields = FIELDS;
         element.groupFieldName = 'status';
-        element.summarizeFieldName = 'Amount';
+        element.summarizeFieldName = 'amount';
         element.actions = ACTIONS;
 
         const handler = jest.fn();
@@ -317,7 +317,7 @@ describe('Kanban', () => {
         element.records = RECORDS;
         element.fields = FIELDS;
         element.groupFieldName = 'status';
-        element.summarizeFieldName = 'Amount';
+        element.summarizeFieldName = 'amount';
         element.actions = ACTIONS;
 
         const handler = jest.fn();

--- a/src/modules/base/kanban/group.js
+++ b/src/modules/base/kanban/group.js
@@ -103,7 +103,7 @@ export default class KanbanGroup {
 
         this._tiles.forEach((tile) => {
             const toSummarize = tile.field.find(
-                (field) => field.label === this._summarizeFieldName
+                (field) => field.fieldName === this._summarizeFieldName
             );
             if (toSummarize && typeof toSummarize.value === 'number') {
                 this._summarize.type = toSummarize.type;

--- a/src/modules/base/kanban/groupBuilder.js
+++ b/src/modules/base/kanban/groupBuilder.js
@@ -89,6 +89,7 @@ export default class KanbanGroupsBuilder {
                     if (JSON.stringify(record[field.fieldName])) {
                         tile.addField({
                             label: field.label,
+                            fieldName: field.fieldName,
                             value: record[field.fieldName],
                             type: field.type,
                             typeAttributes: field.typeAttributes

--- a/src/modules/base/kanban/kanban.js
+++ b/src/modules/base/kanban/kanban.js
@@ -65,6 +65,7 @@ export default class Kanban extends LightningElement {
     _hideHeader = false;
     _isLoading = false;
     _records = [];
+    _subGroupFieldName;
 
     _clickedGroupIndex = 0;
     _clickOffset = { x: 0, y: 0 };
@@ -188,15 +189,6 @@ export default class Kanban extends LightningElement {
      * @public
      */
     @api summarizeFieldName;
-
-    /**
-     *
-     * Name of the data field containing the sub-group label the data belongs to.
-     *
-     * @type {string}
-     * @public
-     */
-    @api subGroupFieldName;
 
     /**
      * Array of action objects. The actions are displayed on each card and refer to tasks you can perform, such as updating or deleting the card.
@@ -328,6 +320,24 @@ export default class Kanban extends LightningElement {
     }
     set records(values) {
         this._records = normalizeArray(values);
+        if (this._connected) {
+            this.updateTiles();
+        }
+    }
+
+    /**
+     *
+     * Name of the data field containing the sub-group label the data belongs to.
+     *
+     * @type {string}
+     * @public
+     */
+    @api
+    get subGroupFieldName() {
+        return this._subGroupFieldName;
+    }
+    set subGroupFieldName(value) {
+        this._subGroupFieldName = value;
         if (this._connected) {
             this.updateTiles();
         }
@@ -1638,9 +1648,12 @@ export default class Kanban extends LightningElement {
             .forEach((fieldContainer, i) => {
                 this._subGroupsHeight[i] = fieldContainer.scrollHeight;
             });
-        this._initialScrollWidth = this.template.querySelector(
+        const fieldContainer = this.template.querySelector(
             '[data-element-id="avonni-kanban__field_container"]'
-        ).scrollWidth;
+        );
+        this._initialScrollWidth = fieldContainer
+            ? fieldContainer.scrollWidth
+            : 0;
         if (this._hasSubGroups) {
             this._initialScrollHeight = this.template.querySelector(
                 '[data-element-id="avonni-kanban__container"]'

--- a/src/modules/base/kanban/kanban.js
+++ b/src/modules/base/kanban/kanban.js
@@ -66,6 +66,7 @@ export default class Kanban extends LightningElement {
     _isLoading = false;
     _records = [];
     _subGroupFieldName;
+    _summarizeFieldName;
 
     _clickedGroupIndex = 0;
     _clickOffset = { x: 0, y: 0 };
@@ -180,15 +181,6 @@ export default class Kanban extends LightningElement {
      * @required
      */
     @api keyField;
-
-    /**
-     *
-     * Name of the data field containing the number to add to the group summarization, at the top of each column.
-     *
-     * @type {string}
-     * @public
-     */
-    @api summarizeFieldName;
 
     /**
      * Array of action objects. The actions are displayed on each card and refer to tasks you can perform, such as updating or deleting the card.
@@ -338,6 +330,24 @@ export default class Kanban extends LightningElement {
     }
     set subGroupFieldName(value) {
         this._subGroupFieldName = value;
+        if (this._connected) {
+            this.updateTiles();
+        }
+    }
+
+    /**
+     *
+     * Name of the data field containing the number to add to the group summarization, at the top of each column.
+     *
+     * @type {string}
+     * @public
+     */
+    @api
+    get summarizeFieldName() {
+        return this._summarizeFieldName;
+    }
+    set summarizeFieldName(value) {
+        this._summarizeFieldName = value;
         if (this._connected) {
             this.updateTiles();
         }
@@ -555,7 +565,17 @@ export default class Kanban extends LightningElement {
                         summary.value = this._oldSummarizeValues[group.index];
                     }
 
-                    summary.value += summarizeUpdate / SUMMARY_UPDATE_SPEED;
+                    if (
+                        (summarizeUpdate < 0 &&
+                            summary.value <=
+                                this._summarizeValues[group.index]) ||
+                        (summarizeUpdate > 0 &&
+                            summary.value >= this._summarizeValues[group.index])
+                    ) {
+                        summary.value = this._summarizeValues[group.index];
+                    } else {
+                        summary.value += summarizeUpdate / SUMMARY_UPDATE_SPEED;
+                    }
                 }, 0.5 * j);
             }
         }

--- a/src/modules/base/kanban/shared.css
+++ b/src/modules/base/kanban/shared.css
@@ -32,6 +32,7 @@
 
 .avonni-kanban__disabled_column_drag .avonni-kanban__group_header {
     pointer-events: none;
+    cursor: default !important;
 }
 
 .avonni-kanban__field_disabled_column_drag .avonni-kanban__summarize_wrapper {


### PR DESCRIPTION
### Fixes
**Kanban**
- Fix field not found for `summarize-field-name` property
- Fix component render issue after value change for `sub-group-field-name` and `summarize-field-name` 
- Fix summary update
- Fix cursor style for disabled columns