### PR TITLE
[Fix](ABC-997) Data Table: Rich-text disappear when editing font size or family

### DIFF
--- a/src/modules/base/primitiveDatatableIeditPanelCustom/primitiveDatatableIeditPanelCustom.js
+++ b/src/modules/base/primitiveDatatableIeditPanelCustom/primitiveDatatableIeditPanelCustom.js
@@ -285,7 +285,6 @@ export default class PrimitiveDatatableIeditPanelCustom extends LightningElement
     @api
     focus() {
         this.interactingState.enter();
-
         if (this.inputableElement) {
             this.inputableElement.focus();
         }
@@ -440,7 +439,7 @@ export default class PrimitiveDatatableIeditPanelCustom extends LightningElement
     }
 
     handleTypeElemBlur() {
-        if (this.visible && !this.template.activeElement) {
+        if (this.visible && !this.template.activeElement && this._allowBlur) {
             this.interactingState.leave();
         }
     }


### PR DESCRIPTION
### Fixes
**Data table**
- Rich-text disappear when editing font size or family