### PR TITLE
[feat] (ABC-1003): Add open event to button icon popover

### DIFF
--- a/src/modules/base/buttonIconPopover/__tests__/buttonIconPopover.test.js
+++ b/src/modules/base/buttonIconPopover/__tests__/buttonIconPopover.test.js
@@ -728,14 +728,30 @@ describe('Button Icon Popover', () => {
     });
 
     // button icon popover close
-    it('Button icon Popover: event close', () => {
-        const handler = jest.fn();
-        element.addEventListener('close', handler);
-        element.close();
+    it('Button icon Popover: event close and open', () => {
+        const closeHandler = jest.fn();
+        const openHandler = jest.fn();
+        element.addEventListener('close', closeHandler);
+        element.addEventListener('open', openHandler);
 
-        expect(handler).toHaveBeenCalled();
-        expect(handler.mock.calls[0][0].bubbles).toBeFalsy();
-        expect(handler.mock.calls[0][0].cancelable).toBeFalsy();
-        expect(handler.mock.calls[0][0].composed).toBeFalsy();
+        let button = element.shadowRoot.querySelector(
+            '[data-element-id="lightning-button-icon-main"]'
+        );
+        button.click();
+        expect(openHandler).toHaveBeenCalled();
+        expect(openHandler.mock.calls[0][0].bubbles).toBeFalsy();
+        expect(openHandler.mock.calls[0][0].cancelable).toBeFalsy();
+        expect(openHandler.mock.calls[0][0].composed).toBeFalsy();
+
+        return Promise.resolve().then(() => {
+            button = element.shadowRoot.querySelector(
+                '[data-element-id="lightning-button-icon-main"]'
+            );
+            button.click();
+            expect(closeHandler).toHaveBeenCalled();
+            expect(closeHandler.mock.calls[0][0].bubbles).toBeFalsy();
+            expect(closeHandler.mock.calls[0][0].cancelable).toBeFalsy();
+            expect(closeHandler.mock.calls[0][0].composed).toBeFalsy();
+        });
     });
 });

--- a/src/modules/base/buttonIconPopover/buttonIconPopover.html
+++ b/src/modules/base/buttonIconPopover/buttonIconPopover.html
@@ -56,6 +56,7 @@
 
     <div
         class={computedPopoverClass}
+        data-element-id="div-popover"
         onmousedown={handlePopoverMouseDown}
         onmouseup={handlePopoverMouseUp}
         onmouseenter={handleMouseEnterBody}

--- a/src/modules/base/buttonIconPopover/buttonIconPopover.js
+++ b/src/modules/base/buttonIconPopover/buttonIconPopover.js
@@ -544,14 +544,6 @@ export default class ButtonIconPopover extends LightningElement {
         if (this.popoverVisible) {
             this.toggleMenuVisibility();
         }
-        /**
-         * The event fired when the popover is closed.
-         *
-         * @event
-         * @name close
-         * @public
-         */
-        this.dispatchEvent(new CustomEvent('close'));
     }
 
     /*
@@ -788,6 +780,9 @@ export default class ButtonIconPopover extends LightningElement {
             if (this.popoverVisible) {
                 this._boundingRect = this.getBoundingClientRect();
                 this.pollBoundingRect();
+                this.dispatchOpen();
+            } else {
+                this.dispatchClose();
             }
 
             this.classList.toggle('slds-is-open');
@@ -806,6 +801,7 @@ export default class ButtonIconPopover extends LightningElement {
                 if (this._connected) {
                     observePosition(this, 300, this._boundingRect, () => {
                         this.close();
+                        this.dispatchClose();
                     });
 
                     this.pollBoundingRect();
@@ -819,5 +815,33 @@ export default class ButtonIconPopover extends LightningElement {
      */
     isAutoAlignment() {
         return this._placement.startsWith('auto');
+    }
+
+    /**
+     * Dispatch the `close` event.
+     */
+    dispatchClose() {
+        /**
+         * The event fired when the popover is closed.
+         *
+         * @event
+         * @name close
+         * @public
+         */
+        this.dispatchEvent(new CustomEvent('close'));
+    }
+
+    /**
+     * Dispatch the `open` event.
+     */
+    dispatchOpen() {
+        /**
+         * The event fired when the popover is opened.
+         *
+         * @event
+         * @name open
+         * @public
+         */
+        this.dispatchEvent(new CustomEvent('open'));
     }
 }


### PR DESCRIPTION
### Features
**Button Icon Popover**
- Added the `open` event.

### Fixes
**Name of the Component**
- Prevented dispatch of the `close` event when the `close()` method is called programatically.
