### PR TITLE
[fix] (ABC-1025): Show loading spinner for vertical range filter menus

### DIFF
--- a/src/modules/base/filterMenu/filterMenuVertical.html
+++ b/src/modules/base/filterMenu/filterMenuVertical.html
@@ -84,26 +84,37 @@
             No matches found
         </p>
 
-        <!-- List -->
-        <div if:true={isList} class={computedVerticalListClass}>
-            <c-input-choice-set
-                class="slds-p-vertical_xx-small"
-                accesskey={accessKey}
-                disabled={disabled}
-                is-multi-select={computedTypeAttributes.isMultiSelect}
-                label={label}
-                variant="label-hidden"
-                options={checkboxComputedItems}
-                value={currentValue}
-                name={name}
-                data-element-id="avonni-input-choice-set"
-                onchange={handleChoiceSetChange}
-            ></c-input-choice-set>
+        <div class={computedVerticalListClass}>
+            <!-- List -->
+            <template if:true={isList}>
+                <c-input-choice-set
+                    class="slds-p-vertical_xx-small"
+                    accesskey={accessKey}
+                    disabled={disabled}
+                    is-multi-select={computedTypeAttributes.isMultiSelect}
+                    label={label}
+                    variant="label-hidden"
+                    options={checkboxComputedItems}
+                    value={currentValue}
+                    name={name}
+                    data-element-id="avonni-input-choice-set"
+                    onchange={handleChoiceSetChange}
+                ></c-input-choice-set>
+                <lightning-button
+                    if:true={showLoadMoreButton}
+                    label="Load more"
+                    variant="base"
+                    data-element-id="lightning-button-load-more"
+                    onclick={dispatchLoadMore}
+                ></lightning-button>
+            </template>
+
+            <!-- Loading spinner -->
             <template if:true={isLoading}>
                 <div
                     class="
                         slds-is-relative
-                        slds-p-around_medium
+                        slds-m-around_large
                         slds-show_inline-block
                     "
                 >
@@ -114,57 +125,50 @@
                     ></lightning-spinner>
                 </div>
             </template>
-            <lightning-button
-                if:true={showLoadMoreButton}
-                label="Load more"
-                variant="base"
-                data-element-id="lightning-button-load-more"
-                onclick={dispatchLoadMore}
-            ></lightning-button>
+
+            <template if:false={isLoading}>
+                <!-- Date Range -->
+                <c-input-date-range
+                    if:true={isDateRange}
+                    class="slds-show slds-m-vertical_small"
+                    date-style={computedTypeAttributes.dateStyle}
+                    end-date={dateRangeEndDate}
+                    label={label}
+                    label-end-date={computedTypeAttributes.labelEndDate}
+                    label-end-time={computedTypeAttributes.labelEndTime}
+                    label-start-date={computedTypeAttributes.labelStartDate}
+                    label-start-time={computedTypeAttributes.labelStartTime}
+                    start-date={dateRangeStartDate}
+                    time-style={computedTypeAttributes.timeStyle}
+                    timezone={computedTypeAttributes.timezone}
+                    type={computedTypeAttributes.type}
+                    variant="label-hidden"
+                    data-element-id="avonni-input-date-range"
+                    onchange={handleDateRangeChange}
+                ></c-input-date-range>
+
+                <!-- Range -->
+                <c-slider
+                    if:true={isRange}
+                    class="slds-m-vertical_small"
+                    disable-swap
+                    hide-min-max-values={computedTypeAttributes.hideMinMaxValues}
+                    label={label}
+                    max={computedTypeAttributes.max}
+                    min={computedTypeAttributes.min}
+                    show-pin={computedTypeAttributes.showPin}
+                    show-tick-marks={computedTypeAttributes.showTickMarks}
+                    step={computedTypeAttributes.step}
+                    tick-mark-style={computedTypeAttributes.tickMarkStyle}
+                    unit={computedTypeAttributes.unit}
+                    unit-attributes={computedTypeAttributes.unitAttributes}
+                    value={rangeValue}
+                    variant="label-hidden"
+                    data-element-id="avonni-slider"
+                    onchange={handleRangeChange}
+                ></c-slider>
+            </template>
         </div>
-
-        <template if:false={isLoading}>
-            <!-- Date Range -->
-            <c-input-date-range
-                if:true={isDateRange}
-                class="slds-show slds-m-vertical_small"
-                date-style={computedTypeAttributes.dateStyle}
-                end-date={dateRangeEndDate}
-                label={label}
-                label-end-date={computedTypeAttributes.labelEndDate}
-                label-end-time={computedTypeAttributes.labelEndTime}
-                label-start-date={computedTypeAttributes.labelStartDate}
-                label-start-time={computedTypeAttributes.labelStartTime}
-                start-date={dateRangeStartDate}
-                time-style={computedTypeAttributes.timeStyle}
-                timezone={computedTypeAttributes.timezone}
-                type={computedTypeAttributes.type}
-                variant="label-hidden"
-                data-element-id="avonni-input-date-range"
-                onchange={handleDateRangeChange}
-            ></c-input-date-range>
-
-            <!-- Range -->
-            <c-slider
-                if:true={isRange}
-                class="slds-m-vertical_small"
-                disable-swap
-                hide-min-max-values={computedTypeAttributes.hideMinMaxValues}
-                label={label}
-                max={computedTypeAttributes.max}
-                min={computedTypeAttributes.min}
-                show-pin={computedTypeAttributes.showPin}
-                show-tick-marks={computedTypeAttributes.showTickMarks}
-                step={computedTypeAttributes.step}
-                tick-mark-style={computedTypeAttributes.tickMarkStyle}
-                unit={computedTypeAttributes.unit}
-                unit-attributes={computedTypeAttributes.unitAttributes}
-                value={rangeValue}
-                variant="label-hidden"
-                data-element-id="avonni-slider"
-                onchange={handleRangeChange}
-            ></c-slider>
-        </template>
     </template>
 
     <!-- Reset and apply buttons -->


### PR DESCRIPTION
### Fixes
**Filter Menu**
- Fixed the display of a loading spinner for vertical `range` and `date-range` filter menus, when `is-loading` is true.
