### PR TITLE
[fix] (ABC-1036): Fix scheduler error when headers have not loaded

### DIFF
--- a/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
+++ b/src/modules/base/primitiveSchedulerHeaderGroup/primitiveSchedulerHeaderGroup.js
@@ -358,7 +358,7 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
      */
     @api
     get visibleInterval() {
-        if (!this.smallestHeader) {
+        if (!Object.keys(this.smallestHeader).length) {
             return undefined;
         }
 
@@ -505,7 +505,7 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
      */
     get smallestHeader() {
         if (!this.computedHeaders.length) {
-            return null;
+            return {};
         }
 
         const lastIndex = this.computedHeaders.length - 1;
@@ -675,7 +675,7 @@ export default class PrimitiveSchedulerHeaderGroup extends LightningElement {
     }
 
     computeCellSize() {
-        if (!this.smallestHeader) {
+        if (!Object.keys(this.smallestHeader).length) {
             return;
         }
         const wrapper = this.template.querySelector(

--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
@@ -999,6 +999,9 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
      * Update the cells and events of the currently loaded resources.
      */
     updateVisibleResources() {
+        if (!this.smallestHeader) {
+            return;
+        }
         this.visibleComputedResources.forEach((resource) => {
             resource.events = this.getOccurrencesFromResourceName(
                 resource.name


### PR DESCRIPTION
### Fixes
**Scheduler**
- Fixed error thrown when the scheduler properties are updated before its header had time to load.