### PR TITLE
[fix] (ABC-1045): Clear combobox displayed value when new value is null

### DIFF
--- a/src/modules/base/primitiveCombobox/primitiveCombobox.js
+++ b/src/modules/base/primitiveCombobox/primitiveCombobox.js
@@ -1208,9 +1208,7 @@ export default class PrimitiveCombobox extends LightningElement {
                 selectedOption.selected = true;
                 this.selectedOption = selectedOption;
                 this.inputValue = selectedOption.label;
-            }
-
-            if (!this.inputValue) {
+            } else {
                 // Filter the options if there is a search term
                 this.inputValue = this._searchTerm;
                 this.search({


### PR DESCRIPTION
### Fixes
**Combobox**
- Prevented the combobox from displaying the old value, when the new value passed is `null`.
