### PR TITLE
[fix] (ABC-1077): Disable date time picker slot if the given date is included in the slot

### DIFF
--- a/src/modules/base/dateTimePicker/__docs__/dateTimePicker.stories.js
+++ b/src/modules/base/dateTimePicker/__docs__/dateTimePicker.stories.js
@@ -1,5 +1,3 @@
-
-
 import { DateTimePicker } from '../__examples__/dateTimePicker';
 
 export default {
@@ -406,10 +404,11 @@ export const Weekly = Template.bind({});
 Weekly.args = {
     label: 'Date picker',
     fieldLevelHelp: 'Pick one or several time slots',
+    value: '2021-03-16T12:30:00.00Z',
     disabledDateTimes: [
         'Wed',
-        new Date('2021-03-16T12:00:00.00Z'),
-        new Date('2021-03-16T13:00:00.00Z')
+        '2021-03-15',
+        new Date('2021-03-16T13:50:00.00Z')
     ],
     showTimeZone: true,
     required: true,

--- a/src/modules/base/dateTimePicker/__examples__/weekly/weekly.html
+++ b/src/modules/base/dateTimePicker/__examples__/weekly/weekly.html
@@ -1,13 +1,14 @@
 <template>
     <avonni-date-time-picker
-        label="Date picker"
-        field-level-help="Pick one or several time slots"
         disabled-date-times={disabledDateTimes}
-        show-time-zone="true"
-        required="true"
-        variant="weekly"
+        field-level-help="Pick one or several time slots"
+        label="Date picker"
+        required
+        show-disabled-dates
+        show-end-time
+        show-time-zone
         type="checkbox"
-        show-end-time="true"
-        show-disabled-dates="true"
+        value="2021-03-16T12:30:00.00Z"
+        variant="weekly"
     ></avonni-date-time-picker>
 </template>

--- a/src/modules/base/dateTimePicker/__examples__/weekly/weekly.js
+++ b/src/modules/base/dateTimePicker/__examples__/weekly/weekly.js
@@ -3,7 +3,7 @@ import { LightningElement } from 'lwc';
 export default class DateTimePickerWeekly extends LightningElement {
     disabledDateTimes = [
         'Wed',
-        new Date('2021-03-16T12:00:00.00Z'),
-        new Date('2021-03-16T13:00:00.00Z')
+        '2021-03-15',
+        new Date('2021-03-16T13:50:00.00Z')
     ];
 }

--- a/src/modules/base/dateTimePicker/__tests__/dateTimePicker.test.js
+++ b/src/modules/base/dateTimePicker/__tests__/dateTimePicker.test.js
@@ -171,8 +171,11 @@ describe('DateTimePicker', () => {
             const wedHours = days[3].querySelectorAll(
                 '[data-element-id="button-default"]'
             );
-            wedHours.forEach((slot) => {
-                expect(slot.disabled).toBeTruthy();
+            wedHours.forEach((timeSlot) => {
+                if (!timeSlot.disabled) {
+                    console.log(timeSlot.dataset.time);
+                }
+                expect(timeSlot.disabled).toBeTruthy();
             });
             const day16Hours = days[1].querySelectorAll(
                 '[data-element-id="button-default"]'
@@ -198,6 +201,33 @@ describe('DateTimePicker', () => {
             expect(hours[5].disabled).toBeTruthy();
             expect(hours[6].disabled).toBeFalsy();
         });
+    });
+
+    it('Date time picker: full day disabled', () => {
+        element.goToDate(new Date(2023, 8, 16));
+
+        return Promise.resolve()
+            .then(() => {
+                const hours = element.shadowRoot.querySelectorAll(
+                    '[data-element-id="button-default"]'
+                );
+                const emptyMessage = element.shadowRoot.querySelector(
+                    '[data-element-id="p-empty-message"]'
+                );
+                expect(emptyMessage).toBeFalsy();
+                expect(hours.length).toBeTruthy();
+                element.disabledDateTimes = ['2023-09-16'];
+            })
+            .then(() => {
+                const hours = element.shadowRoot.querySelectorAll(
+                    '[data-element-id="button-default"]'
+                );
+                const emptyMessage = element.shadowRoot.querySelector(
+                    '[data-element-id="p-empty-message"]'
+                );
+                expect(emptyMessage).toBeTruthy();
+                expect(hours.length).toBeFalsy();
+            });
     });
 
     // field level help
@@ -581,77 +611,27 @@ describe('DateTimePicker', () => {
     });
 
     // show disabled dates
-    it('Date time picker: show disabled dates daily', () => {
+    it('Date time picker: show disabled dates = false', () => {
         element.disabled = true;
-        element.showDisabledDates = true;
+        element.showDisabledDates = false;
 
         return Promise.resolve().then(() => {
             const times = element.shadowRoot.querySelectorAll(
                 '[data-element-id="button-default"]'
             );
-            times.forEach((time) => {
-                expect(time.disabled).toBeTruthy();
-            });
+            expect(times.length).toBeFalsy();
         });
     });
 
-    it('Date time picker: show disabled dates weekly', () => {
+    it('Date time picker: show disabled dates = true', () => {
         element.disabled = true;
         element.showDisabledDates = true;
-        element.variant = 'weekly';
 
         return Promise.resolve().then(() => {
             const times = element.shadowRoot.querySelectorAll(
                 '[data-element-id="button-default"]'
             );
-            times.forEach((time) => {
-                expect(time.disabled).toBeTruthy();
-            });
-        });
-    });
-
-    it('Date time picker: show disabled dates inline', () => {
-        element.disabled = true;
-        element.showDisabledDates = true;
-        element.variant = 'inline';
-
-        return Promise.resolve().then(() => {
-            const times = element.shadowRoot.querySelectorAll(
-                '[data-element-id="button-default"]'
-            );
-            times.forEach((time) => {
-                expect(time.disabled).toBeTruthy();
-            });
-        });
-    });
-
-    it('Date time picker: show disabled dates timeline', () => {
-        element.disabled = true;
-        element.showDisabledDates = true;
-        element.variant = 'timeline';
-
-        return Promise.resolve().then(() => {
-            const times = element.shadowRoot.querySelectorAll(
-                '[data-element-id="button-default"]'
-            );
-            times.forEach((time) => {
-                expect(time.disabled).toBeTruthy();
-            });
-        });
-    });
-
-    it('Date time picker: show disabled dates monthly', () => {
-        element.disabled = true;
-        element.showDisabledDates = true;
-        element.variant = 'monthly';
-
-        return Promise.resolve().then(() => {
-            const times = element.shadowRoot.querySelectorAll(
-                '[data-element-id="button-default"]'
-            );
-            times.forEach((time) => {
-                expect(time.disabled).toBeTruthy();
-            });
+            expect(times.length).toBeTruthy();
         });
     });
 

--- a/src/modules/base/dateTimePicker/__tests__/dateTimePicker.test.js
+++ b/src/modules/base/dateTimePicker/__tests__/dateTimePicker.test.js
@@ -1,5 +1,3 @@
-
-
 import { createElement } from 'lwc';
 import DateTimePicker from 'c/dateTimePicker';
 
@@ -152,6 +150,53 @@ describe('DateTimePicker', () => {
                 '[data-element-id="avonni-calendar"]'
             );
             expect(calendar.disabled).toBeTruthy();
+        });
+    });
+
+    it('Date time picker: disabled date times', () => {
+        element.value = new Date(2023, 9, 16, 9);
+        element.disabledDateTimes = [
+            new Date(2023, 9, 16, 10, 30),
+            'Wed',
+            new Date(2023, 9, 16, 14).toISOString()
+        ];
+        element.variant = 'weekly';
+        element.timezone = 'America/Montreal';
+        element.showDisabledDates = true;
+
+        return Promise.resolve().then(() => {
+            const days = element.shadowRoot.querySelectorAll(
+                '[data-element-id="div-day"]'
+            );
+            const wedHours = days[3].querySelectorAll(
+                '[data-element-id="button-default"]'
+            );
+            wedHours.forEach((slot) => {
+                expect(slot.disabled).toBeTruthy();
+            });
+            const day16Hours = days[1].querySelectorAll(
+                '[data-element-id="button-default"]'
+            );
+            expect(day16Hours[4].disabled).toBeFalsy();
+            expect(day16Hours[5].disabled).toBeTruthy();
+            expect(day16Hours[6].disabled).toBeFalsy();
+            expect(day16Hours[12].disabled).toBeTruthy();
+        });
+    });
+
+    it('Date time picker: imprecise disabled date times', () => {
+        element.value = new Date(2023, 9, 16, 9);
+        element.disabledDateTimes = [new Date(2023, 9, 16, 10, 43)];
+        element.timezone = 'America/Montreal';
+        element.showDisabledDates = true;
+
+        return Promise.resolve().then(() => {
+            const hours = element.shadowRoot.querySelectorAll(
+                '[data-element-id="button-default"]'
+            );
+            expect(hours[4].disabled).toBeFalsy();
+            expect(hours[5].disabled).toBeTruthy();
+            expect(hours[6].disabled).toBeFalsy();
         });
     });
 

--- a/src/modules/base/dateTimePicker/dateTimePicker.html
+++ b/src/modules/base/dateTimePicker/dateTimePicker.html
@@ -1,5 +1,3 @@
-
-
 <template>
     <!-- Input label -->
     <p
@@ -122,7 +120,7 @@
                 <!-- Monthly calendar -->
                 <c-calendar
                     value={firstWeekDayToString}
-                    disabled-dates={disabledDateTimes}
+                    disabled-dates={disabledFullDays}
                     disabled={disabled}
                     max={computedMax}
                     min={computedMin}

--- a/src/modules/base/dateTimePicker/dateTimePicker.js
+++ b/src/modules/base/dateTimePicker/dateTimePicker.js
@@ -813,6 +813,22 @@ export default class DateTimePicker extends LightningElement {
     }
 
     /**
+     * Array of ISO dates that should be disabled.
+     *
+     * @type {string[]}
+     */
+    get disabledFullDays() {
+        const valid = [];
+        this.disabledDateTimes.forEach((date) => {
+            const dateTime = this._createDateTimeFromDateString(date);
+            if (dateTime) {
+                valid.push(dateTime.toISO());
+            }
+        });
+        return valid;
+    }
+
+    /**
      * Returns first weekday in an ISO8601 string format.
      *
      * @type {string}
@@ -971,6 +987,27 @@ export default class DateTimePicker extends LightningElement {
      *  PRIVATE METHODS
      * -------------------------------------------------------------
      */
+
+    /**
+     * Create a luxon DateTime object from an ISO date that has no time.
+     *
+     * @param {string} date Date string to transform.
+     * @returns {DateTime|boolean} Returns a DateTime object or false if the string is not an ISO date with no time.
+     */
+    _createDateTimeFromDateString(date) {
+        const isDateWithoutTime =
+            typeof date === 'string' && date.match(/^\d{4}-\d{2}-\d{2}$/);
+        if (!isDateWithoutTime) {
+            return false;
+        }
+        const dateParts = date.split('-');
+        const year = Number(dateParts[0]);
+        const month = Number(dateParts[1]);
+        const day = Number(dateParts[2]);
+        return this._processDate(new Date())
+            .set({ year, month, day })
+            .startOf('day');
+    }
 
     /**
      * Transform the given value into a Date object, or return null.
@@ -1241,13 +1278,8 @@ export default class DateTimePicker extends LightningElement {
                 dateTime.match(/^\d{4}-\d{2}-\d{2}$/);
 
             if (isDateWithoutTime) {
-                const dateParts = dateTime.split('-');
-                const year = Number(dateParts[0]);
-                const month = Number(dateParts[1]);
-                const day = Number(dateParts[2]);
-                const normalizedDate = this._processDate(new Date())
-                    .set({ year, month, day })
-                    .startOf('day');
+                const normalizedDate =
+                    this._createDateTimeFromDateString(dateTime);
                 disabledDates.push({ allDay: true, date: normalizedDate });
             } else if (date && isInTimeFrame(date, timeFrame)) {
                 disabledDates.push({ allDay: false, date });

--- a/src/modules/base/dateTimePicker/dateTimePicker.js
+++ b/src/modules/base/dateTimePicker/dateTimePicker.js
@@ -1088,14 +1088,12 @@ export default class DateTimePicker extends LightningElement {
 
         for (let i = 0; i < daysDisplayed; i++) {
             const day = this.firstWeekDay.plus({ days: i });
-            const disabled = this.disabled || this._isDisabledDay(day);
 
             // Create dayTime object
             const dayTime = {
                 key: i,
                 day,
-                disabled,
-                show: !disabled || this.showDisabledDates,
+                disabled: this.disabled || this._isDisabledDay(day),
                 isToday:
                     this._today.startOf('day').ts === day.startOf('day').ts,
                 times: []
@@ -1112,7 +1110,17 @@ export default class DateTimePicker extends LightningElement {
                 dayTime.label = `${labelWeekday} ${labelDay}`;
             }
 
+            // Create the time slots
             this._createTimeSlots(dayTime);
+
+            if (!dayTime.disabled) {
+                // Update the disable state of the day,
+                // in case all of its time slots are disabled
+                dayTime.disabled = dayTime.times.every((time) => time.disabled);
+            }
+            dayTime.show = !dayTime.disabled || this.showDisabledDates;
+
+            // Add the day to the table
             processedTable.push(dayTime);
         }
 

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -7,11 +7,11 @@ import {
     dateTimeObjectFrom,
     addToDate,
     deepCopy,
+    parseTimeFrame,
     removeFromDate
 } from 'c/utilsPrivate';
 import {
     getDisabledWeekdaysLabels,
-    parseTimeFrame,
     positionPopover,
     previousAllowedDay,
     previousAllowedMonth,

--- a/src/modules/base/schedulerUtils/dateComputations.js
+++ b/src/modules/base/schedulerUtils/dateComputations.js
@@ -1,12 +1,10 @@
-
-
 import {
     addToDate,
     dateTimeObjectFrom,
+    isInTimeFrame,
     normalizeArray,
     removeFromDate
 } from 'c/utilsPrivate';
-import { DateTime } from 'c/luxon';
 import { DEFAULT_AVAILABLE_DAYS_OF_THE_WEEK } from './defaults';
 
 /**
@@ -32,59 +30,6 @@ const isAllowedDay = (date, allowedDays) => {
 const isAllowedMonth = (date, allowedMonths) => {
     // Luxon months start at 1
     return allowedMonths.includes(date.month - 1);
-};
-
-/**
- * Check if the given time frame is valid, and parse it into a start and an end date.
- *
- * @param {string} timeFrame Time frame to validate and parse.
- * @returns {object} Object with three possible keys: valid, start and end.
- */
-const parseTimeFrame = (timeFrame, options) => {
-    const startMatch = timeFrame.match(/^([0-9:]+)-/);
-    const endMatch = timeFrame.match(/-([0-9:]+)$/);
-
-    if (!startMatch || !endMatch) {
-        console.error(
-            `Wrong time frame format for ${timeFrame}. The time frame needs to follow the pattern ‘start-end’, with start and end being ISO8601 formatted time strings.`
-        );
-        return { valid: false };
-    }
-    const start = DateTime.fromISO(startMatch[1], options);
-    const end = DateTime.fromISO(endMatch[1], options);
-
-    if (end < start) {
-        console.error(
-            `Wrong time frame format for ${timeFrame}. The end time is smaller than the start time.`
-        );
-        return { valid: false };
-    }
-
-    return { start, end, valid: true };
-};
-
-/**
- * Check if a time is included in a time frame.
- *
- * @param {DateTime} date DateTime object.
- * @param {string} timeFrame The time frame of reference, in the format '00:00-00:00'.
- * @returns {boolean} true or false.
- */
-const isInTimeFrame = (date, timeFrame) => {
-    const { start, end, valid } = parseTimeFrame(timeFrame, {
-        zone: date.zoneName
-    });
-    if (!valid) {
-        return true;
-    }
-
-    const time = date.set({
-        year: start.year,
-        month: start.month,
-        day: start.day
-    });
-
-    return time < end && time >= start;
 };
 
 /**
@@ -460,7 +405,6 @@ export {
     nextAllowedDay,
     nextAllowedMonth,
     nextAllowedTime,
-    parseTimeFrame,
     previousAllowedDay,
     previousAllowedMonth,
     previousAllowedTime,

--- a/src/modules/base/schedulerUtils/schedulerUtils.js
+++ b/src/modules/base/schedulerUtils/schedulerUtils.js
@@ -1,5 +1,3 @@
-
-
 export {
     containsAllowedDateTimes,
     getDisabledWeekdaysLabels,
@@ -10,7 +8,6 @@ export {
     nextAllowedDay,
     nextAllowedMonth,
     nextAllowedTime,
-    parseTimeFrame,
     previousAllowedDay,
     previousAllowedMonth,
     previousAllowedTime,

--- a/src/modules/base/utilsPrivate/dateTimeUtils.js
+++ b/src/modules/base/utilsPrivate/dateTimeUtils.js
@@ -1,5 +1,3 @@
-
-
 import { DateTime, Interval } from 'c/luxon';
 
 /**
@@ -72,6 +70,59 @@ const intervalFrom = (start, end) => {
         return null;
     }
     return Interval.fromDateTimes(start, end);
+};
+
+/**
+ * Check if the given time frame is valid, and parse it into a start and an end date.
+ *
+ * @param {string} timeFrame Time frame to validate and parse.
+ * @returns {object} Object with three possible keys: valid, start and end.
+ */
+const parseTimeFrame = (timeFrame, options) => {
+    const startMatch = timeFrame.match(/^([0-9:]+)-/);
+    const endMatch = timeFrame.match(/-([0-9:]+)$/);
+
+    if (!startMatch || !endMatch) {
+        console.error(
+            `Wrong time frame format for ${timeFrame}. The time frame needs to follow the pattern ‘start-end’, with start and end being ISO8601 formatted time strings.`
+        );
+        return { valid: false };
+    }
+    const start = DateTime.fromISO(startMatch[1], options);
+    const end = DateTime.fromISO(endMatch[1], options);
+
+    if (end < start) {
+        console.error(
+            `Wrong time frame format for ${timeFrame}. The end time is smaller than the start time.`
+        );
+        return { valid: false };
+    }
+
+    return { start, end, valid: true };
+};
+
+/**
+ * Check if a time is included in a time frame.
+ *
+ * @param {DateTime} date DateTime object.
+ * @param {string} timeFrame The time frame of reference, in the format '00:00-00:00'.
+ * @returns {boolean} true or false.
+ */
+const isInTimeFrame = (date, timeFrame) => {
+    const { start, end, valid } = parseTimeFrame(timeFrame, {
+        zone: date.zoneName
+    });
+    if (!valid) {
+        return true;
+    }
+
+    const time = date.set({
+        year: start.year,
+        month: start.month,
+        day: start.day
+    });
+
+    return time < end && time >= start;
 };
 
 /**
@@ -192,6 +243,8 @@ export {
     getWeekday,
     getWeekNumber,
     intervalFrom,
+    isInTimeFrame,
     numberOfUnitsBetweenDates,
+    parseTimeFrame,
     removeFromDate
 };

--- a/src/modules/base/utilsPrivate/utilsPrivate.js
+++ b/src/modules/base/utilsPrivate/utilsPrivate.js
@@ -1,5 +1,3 @@
-
-
 export { EventEmitter } from './eventEmitter';
 export { toNorthAmericanPhoneNumber } from './phonify';
 export * from './linkUtils';
@@ -64,7 +62,9 @@ export {
     formatDateFromStyle,
     getWeekNumber,
     intervalFrom,
+    isInTimeFrame,
     numberOfUnitsBetweenDates,
+    parseTimeFrame,
     removeFromDate
 } from './dateTimeUtils';
 import { smartSetAttribute } from './smartSetAttribute';


### PR DESCRIPTION
### Fixes
**Date Time Picker**
- Loosened the `disabled-date-times` attribute, so the dates it contains does not need to be the exact time of a slot. For example, if `2023-10-16T10:03` is included in the array, a time slot starting at 10:00 would be disabled.