### PR TITLE
[fix] (ABC-1079): Show scheduler events with empty titles

### DIFF
--- a/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceAgenda.test.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceAgenda.test.js
@@ -1,5 +1,3 @@
-
-
 import { createElement } from 'lwc';
 import PrimitiveSchedulerEventOccurrence from '../primitiveSchedulerEventOccurrence';
 import { FROM, RESOURCE_KEY, RESOURCES, TO } from './defaults';
@@ -62,7 +60,7 @@ describe('Primitive Scheduler Event Occurrence: agenda variant', () => {
                 'slds-truncate slds-grid avonni-scheduler__event-label_center slds-grid_vertical-align-center'
             );
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small avonni-scheduler__event_display-as-dot avonni-scheduler__event_past'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small avonni-scheduler__event_horizontal avonni-scheduler__event_display-as-dot avonni-scheduler__event_past'
             );
             expect(eventContent.style.cssText).toBeFalsy();
         });
@@ -98,7 +96,7 @@ describe('Primitive Scheduler Event Occurrence: agenda variant', () => {
                 'slds-truncate slds-grid avonni-scheduler__event-label_center slds-p-horizontal_x-small'
             );
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small avonni-scheduler__event_past slds-text-color_inverse slds-current-color avonni-scheduler__event_standalone-multi-day-starts-in-previous-cell avonni-scheduler__event_standalone-multi-day-ends-in-later-cell avonni-scheduler__event_default'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small avonni-scheduler__event_horizontal avonni-scheduler__event_past slds-text-color_inverse slds-current-color avonni-scheduler__event_standalone-multi-day-starts-in-previous-cell avonni-scheduler__event_standalone-multi-day-ends-in-later-cell avonni-scheduler__event_default'
             );
             expect(eventContent.style.cssText).toBe(
                 'background-color: rgb(51, 51, 51); --avonni-primitive-scheduler-event-occurrence-background-color: rgb(51, 51, 51);'

--- a/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceCalendar.test.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceCalendar.test.js
@@ -1,5 +1,3 @@
-
-
 import { createElement } from 'lwc';
 import { dateTimeObjectFrom } from 'c/utilsPrivate';
 import PrimitiveSchedulerEventOccurrence from '../primitiveSchedulerEventOccurrence';
@@ -155,7 +153,7 @@ describe('Primitive Scheduler Event Occurrence: calendar variants', () => {
                 'slds-grid slds-grid_vertical-align-center avonni-scheduler__event-wrapper'
             );
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small slds-text-color_inverse slds-current-color avonni-scheduler__event_past avonni-scheduler__event_default'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small avonni-scheduler__event_horizontal slds-text-color_inverse slds-current-color avonni-scheduler__event_past avonni-scheduler__event_default'
             );
         });
     });
@@ -236,7 +234,7 @@ describe('Primitive Scheduler Event Occurrence: calendar variants', () => {
                 'slds-grid avonni-scheduler__event-wrapper'
             );
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small avonni-scheduler__event_past avonni-scheduler__event_display-as-dot'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small avonni-scheduler__event_horizontal avonni-scheduler__event_past avonni-scheduler__event_display-as-dot'
             );
         });
     });
@@ -342,7 +340,7 @@ describe('Primitive Scheduler Event Occurrence: calendar variants', () => {
                 'slds-grid slds-grid_vertical-align-center avonni-scheduler__event-wrapper'
             );
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small slds-text-color_inverse slds-current-color avonni-scheduler__event_past avonni-scheduler__event_default avonni-scheduler__event_standalone-multi-day-starts-in-previous-cell avonni-scheduler__event_standalone-multi-day-ends-in-later-cell'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small avonni-scheduler__event_horizontal slds-text-color_inverse slds-current-color avonni-scheduler__event_past avonni-scheduler__event_default avonni-scheduler__event_standalone-multi-day-starts-in-previous-cell avonni-scheduler__event_standalone-multi-day-ends-in-later-cell'
             );
             expect(centerLabel.className).toBe(
                 'slds-truncate slds-grid avonni-scheduler__event-label_center slds-p-horizontal_x-small'

--- a/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceTimeline.test.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceTimeline.test.js
@@ -1,5 +1,3 @@
-
-
 import { createElement } from 'lwc';
 import PrimitiveSchedulerEventOccurrence from '../primitiveSchedulerEventOccurrence';
 import {
@@ -84,7 +82,7 @@ describe('Primitive Scheduler Event Occurrence: timeline variants', () => {
                 'slds-truncate slds-grid avonni-scheduler__event-label_center slds-p-horizontal_x-small'
             );
             expect(eventContent.className).toBe(
-                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small slds-text-color_inverse slds-current-color avonni-scheduler__event_past avonni-scheduler__event_default'
+                'avonni-scheduler__event slds-grid slds-has-flexi-truncate avonni-primitive-scheduler-event-occurrence__flex-col slds-p-horizontal_x-small avonni-scheduler__event_horizontal slds-text-color_inverse slds-current-color avonni-scheduler__event_past avonni-scheduler__event_default'
             );
             expect(eventContent.style.cssText).toBe(
                 'background-color: rgb(3, 56, 7); --avonni-primitive-scheduler-event-occurrence-background-color: rgb(3, 56, 7);'

--- a/src/modules/base/primitiveSchedulerEventOccurrence/eventOccurrence.css
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/eventOccurrence.css
@@ -1,5 +1,3 @@
-
-
 @import './shared.css';
 
 :host {
@@ -13,6 +11,10 @@
     position: relative;
     z-index: 2;
     border-radius: var(--lwc-borderRadiusMedium, 0.25rem);
+}
+
+.avonni-scheduler__event_horizontal {
+    min-height: 1.1rem;
 }
 
 .avonni-scheduler__event_past {

--- a/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
@@ -1,5 +1,3 @@
-
-
 import { LightningElement, api } from 'lwc';
 import { classSet } from 'c/utils';
 import { DateTime } from 'c/luxon';
@@ -719,6 +717,7 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
         )
             .add({
                 'slds-p-horizontal_x-small': !this.isVerticalCalendar,
+                'avonni-scheduler__event_horizontal': !this.isVertical,
                 'slds-text-color_inverse slds-current-color':
                     !this.displayAsDot &&
                     (theme === 'default' ||


### PR DESCRIPTION
### Fixes
**Scheduler**
- Fixed the display of events when they have no title.