### PR TITLE
[fix] (ABC-1084): Patch lwc datatable row select button type update

### DIFF
--- a/src/modules/base/datatable/datatable.js
+++ b/src/modules/base/datatable/datatable.js
@@ -557,7 +557,6 @@ export default class Datatable extends LightningDatatable {
     }
 
     set loadMoreOffset(value) {
-        if (value === undefined) return;
         super.loadMoreOffset = value;
     }
 
@@ -573,7 +572,6 @@ export default class Datatable extends LightningDatatable {
     }
 
     set maxColumnWidth(value) {
-        if (value === undefined) return;
         super.maxColumnWidth = value;
     }
 
@@ -589,7 +587,15 @@ export default class Datatable extends LightningDatatable {
     }
 
     set maxRowSelection(value) {
-        if (value === undefined) return;
+        if (
+            this.maxRowSelection === 1 &&
+            (value === undefined || value === null)
+        ) {
+            // Patch for a bug in the Lightning Datatable:
+            // If the maxRowSelection was 1 and it is removed,
+            // the radio buttons are not changed into checkboxes.
+            super.maxRowSelection = 2;
+        }
         super.maxRowSelection = value;
     }
 


### PR DESCRIPTION
### Fixes
**Data Table**
- Fixed the update of the row selection button type (radio or checkbox), when the value of `max-row-selection` is going from `1` to `undefined`.

