### PR TITLE
[feat] (ABC-1090): Fire open and close events in vertical filter menu

### DIFF
--- a/src/modules/base/filterMenu/__tests__/filterMenu.test.js
+++ b/src/modules/base/filterMenu/__tests__/filterMenu.test.js
@@ -2533,6 +2533,47 @@ describe('Filter Menu', () => {
                     });
             });
 
+            it('close and open event, vertical variant', () => {
+                const closeHandler = jest.fn();
+                const openHandler = jest.fn();
+                element.addEventListener('close', closeHandler);
+                element.addEventListener('open', openHandler);
+                element.variant = 'vertical';
+                element.collapsible = true;
+
+                return Promise.resolve()
+                    .then(() => {
+                        const button = element.shadowRoot.querySelector(
+                            '[data-element-id="lightning-icon-toggle"]'
+                        );
+                        const div = element.shadowRoot.querySelector(
+                            '[data-element-id="div-vertical-list"]'
+                        );
+                        expect(div).toBeTruthy();
+
+                        button.click();
+                        expect(closeHandler).toHaveBeenCalled();
+                    })
+                    .then(() => {
+                        const button = element.shadowRoot.querySelector(
+                            '[data-element-id="lightning-icon-toggle"]'
+                        );
+                        const div = element.shadowRoot.querySelector(
+                            '[data-element-id="div-vertical-list"]'
+                        );
+                        expect(div).toBeFalsy();
+
+                        button.click();
+                        expect(openHandler).toHaveBeenCalled();
+                    })
+                    .then(() => {
+                        const div = element.shadowRoot.querySelector(
+                            '[data-element-id="div-vertical-list"]'
+                        );
+                        expect(div).toBeTruthy();
+                    });
+            });
+
             it('dropdown closes on blur', () => {
                 const handler = jest.fn();
                 element.addEventListener('close', handler);

--- a/src/modules/base/filterMenu/filterMenu.js
+++ b/src/modules/base/filterMenu/filterMenu.js
@@ -1666,16 +1666,7 @@ export default class FilterMenu extends LightningElement {
             this.dropdownVisible = !this.dropdownVisible;
             if (this.dropdownVisible) {
                 this.startPositioning();
-
-                /**
-                 * The event fired when the dropdown is opened.
-                 *
-                 * @event
-                 * @name open
-                 * @public
-                 * @bubbles
-                 */
-                this.dispatchEvent(new CustomEvent('open', { bubbles: true }));
+                this.dispatchOpen();
 
                 // update the bounding rect when the menu is toggled
                 this._boundingRect = this.getBoundingClientRect();
@@ -1686,16 +1677,7 @@ export default class FilterMenu extends LightningElement {
                 this.focusDropdown();
             } else {
                 this.stopPositioning();
-
-                /**
-                 * The event fired when the dropdown is closed.
-                 *
-                 * @event
-                 * @name close
-                 * @public
-                 * @bubbles
-                 */
-                this.dispatchEvent(new CustomEvent('close', { bubbles: true }));
+                this.dispatchClose();
                 this._previousScroll = undefined;
             }
         }
@@ -2011,6 +1993,21 @@ export default class FilterMenu extends LightningElement {
         );
     }
 
+    /**
+     * Dispatch the close event.
+     */
+    dispatchClose() {
+        /**
+         * The event fired when the dropdown is closed (horizontal variant) or the section is closed (vertical variant).
+         *
+         * @event
+         * @name close
+         * @public
+         * @bubbles
+         */
+        this.dispatchEvent(new CustomEvent('close', { bubbles: true }));
+    }
+
     dispatchLoadMore() {
         /**
          * The event fired when the end of a list is reached. It is only fired if the `enableInfiniteLoading` type attribute is present. In the horizontal variant, the `loadmore` event is triggered by a scroll to the end of the list. In the vertical variant, the `loadmore` event is triggered by a button clicked by the user.
@@ -2021,6 +2018,21 @@ export default class FilterMenu extends LightningElement {
          * @bubbles
          */
         this.dispatchEvent(new CustomEvent('loadmore', { bubbles: true }));
+    }
+
+    /**
+     * Dispatch the open event.
+     */
+    dispatchOpen() {
+        /**
+         * The event fired when the dropdown is opened (horizontal variant) or the section is opened (vertical variant).
+         *
+         * @event
+         * @name open
+         * @public
+         * @bubbles
+         */
+        this.dispatchEvent(new CustomEvent('open', { bubbles: true }));
     }
 
     /**
@@ -2062,5 +2074,11 @@ export default class FilterMenu extends LightningElement {
      */
     toggleSection() {
         this._closed = !this._closed;
+
+        if (this._closed) {
+            this.dispatchClose();
+        } else {
+            this.dispatchOpen();
+        }
     }
 }

--- a/src/modules/base/filterMenu/filterMenuVertical.html
+++ b/src/modules/base/filterMenu/filterMenuVertical.html
@@ -84,7 +84,10 @@
             No matches found
         </p>
 
-        <div class={computedVerticalListClass}>
+        <div
+            class={computedVerticalListClass}
+            data-element-id="div-vertical-list"
+        >
             <!-- List -->
             <template if:true={isList}>
                 <c-input-choice-set

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.js
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.js
@@ -390,7 +390,7 @@ export default class FilterMenuGroup extends LightningElement {
         const menuName = event.target.dataset.name;
 
         /**
-         * The event fired when a horizontal menu popover is closed.
+         * The event fired when a dropdown is closed (horizontal variant) or a section is closed (vertical variant).
          *
          * @event
          * @name close
@@ -438,7 +438,7 @@ export default class FilterMenuGroup extends LightningElement {
         const menuName = event.target.dataset.name;
 
         /**
-         * The event fired when a horizontal menu popover is opened.
+         * The event fired when a dropdown is opened (horizontal variant) or a section is opened (vertical variant).
          *
          * @event
          * @name open


### PR DESCRIPTION
<!-- Are you sure you're ready to open a pull request? -->
<!-- Checkout the list first: https://avonnicreator.atlassian.net/wiki/spaces/LDG/pages/2140766209/Can+I+open+a+pull+request -->
<!-- Then use this template to explain what you did: -->

### Features
**Filter Menu**
- Added support of `open` and `close` events in the vertical variant, if the menu is collapsible. The events will be fired when the collapsible section is opened or closed.
