### PR TITLE
[fix] (ABC-1098): Fix loading on scheduler available times update

### DIFF
--- a/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
+++ b/src/modules/base/primitiveSchedulerCalendar/primitiveSchedulerCalendar.js
@@ -195,6 +195,7 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
 
         if (this._connected) {
             this.initHeaders();
+            this._dayHeadersLoading = false;
         }
     }
 
@@ -216,6 +217,7 @@ export default class PrimitiveSchedulerCalendar extends ScheduleBase {
 
         if (this._connected) {
             this.initHeaders();
+            this._dayHeadersLoading = false;
         }
     }
 


### PR DESCRIPTION
### Fixes
**Scheduler**
- Removed the loading spinner that was not disappearing when the available time frames or months were updated, in the calendar display.