### PR TITLE
[fix] (ABC-1099): Stop propagation of picker change in date time picker

### DIFF
--- a/src/modules/base/dateTimePicker/dateTimePicker.js
+++ b/src/modules/base/dateTimePicker/dateTimePicker.js
@@ -1338,6 +1338,7 @@ export default class DateTimePicker extends LightningElement {
      * Handles the onchange event of the lightning-input to change the date.
      */
     handleDateChange(event) {
+        event.stopPropagation();
         const value = event.detail.value;
         if (!value || typeof value !== 'string') {
             // Prevent unselection of a date


### PR DESCRIPTION
### Fixes
**Date Time Picker**
- Prevented the propagation of an invalid change event, when the user navigated using the date picker.
