### PR TITLE
[feat] (ABC-1101):  Visual Picker - If no title, description and tags, remove the overlay background

### DIFF
--- a/src/modules/base/visualPicker/visualPicker.css
+++ b/src/modules/base/visualPicker/visualPicker.css
@@ -87,6 +87,8 @@
 }
 
 .avonni-visual-picker__figure-image-background
+    .avonni-visual-picker__figure-body-container,
+.avonni-visual-picker__figure-image-overlay
     .avonni-visual-picker__figure-body-container {
     position: absolute;
     left: 0;
@@ -108,24 +110,8 @@
 
 .avonni-visual-picker__figure-image-overlay
     .avonni-visual-picker__figure-body-container {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-image: var(
-        --avonni-visual-picker-overlay-background,
-        linear-gradient(
-            0deg,
-            rgba(0, 0, 0, 0.7) 0%,
-            rgba(0, 0, 0, 0.55) 75%,
-            rgba(0, 0, 0, 0) 100%
-        )
-    );
-    margin: 0 0.3rem 0.3rem 0.3rem;
     opacity: 0;
     transition: opacity 0.5s ease-in-out;
-    height: fit-content;
-    max-height: 100%;
 }
 
 .avonni-visual-picker__figure-image-overlay:hover

--- a/src/modules/base/visualPicker/visualPicker.css
+++ b/src/modules/base/visualPicker/visualPicker.css
@@ -56,6 +56,14 @@
     position: relative;
 }
 
+.avonni-visual-picker__height
+    .avonni-visual-picker__items_responsive_image-fields:has(.avonni-visual-picker__figure-image-center-container) {
+    display: flex;
+    flex: 0 1 100%;
+    flex-direction: column;
+    position: relative;
+}
+
 .avonni-visual-picker__height .avonni-visual-picker__items:not(:empty) {
     padding-top: 0.25rem;
 }
@@ -68,6 +76,11 @@
 
 .avonni-visual-picker__items_responsive_image {
     overflow: hidden;
+}
+
+.avonni-visual-picker__items_responsive_image-fields
+    .avonni-visual-picker__item-fields-container {
+    flex: 1;
 }
 
 .avonni-visual-picker__figure-image-background

--- a/src/modules/base/visualPicker/visualPicker.html
+++ b/src/modules/base/visualPicker/visualPicker.html
@@ -86,6 +86,7 @@
                                         </div>
                                         <!-- Figure Body -->
                                         <div
+                                            if:true={item.hasBodyContent}
                                             style={item.computedBodyLayoutStyle}
                                             class="
                                                 avonni-visual-picker__figure-body-container

--- a/src/modules/base/visualPicker/visualPicker.js
+++ b/src/modules/base/visualPicker/visualPicker.js
@@ -720,6 +720,13 @@ export default class VisualPicker extends LightningElement {
             const computedBodyContentBottomClass =
                 this.computeVisualPickerItemsClass(imgIsBottom);
 
+            const hasBodyContent =
+                displayTitle ||
+                displayDescription ||
+                displayAvatar ||
+                hasTags ||
+                hasFields;
+
             return {
                 key,
                 itemTitle,
@@ -758,6 +765,7 @@ export default class VisualPicker extends LightningElement {
                 tags,
                 hasHiddenTags,
                 hasTags,
+                hasBodyContent,
                 layoutIsHorizontal,
                 computedBodyLayoutStyle,
                 computedImageLayoutStyle,

--- a/src/modules/base/visualPicker/visualPicker.js
+++ b/src/modules/base/visualPicker/visualPicker.js
@@ -714,11 +714,11 @@ export default class VisualPicker extends LightningElement {
             );
             const computedBodyClass = this.computeBodyClass(imgIsBackground);
             const computedBodyContentTopClass =
-                this.computeVisualPickerItemsClass(imgIsTop);
+                this.computeVisualPickerItemsClass(imgIsTop, false);
             const computedBodyContentCenterClass =
-                this.computeVisualPickerItemsClass(imgIsCenter);
+                this.computeVisualPickerItemsClass(imgIsCenter, hasFields);
             const computedBodyContentBottomClass =
-                this.computeVisualPickerItemsClass(imgIsBottom);
+                this.computeVisualPickerItemsClass(imgIsBottom, false);
 
             const hasBodyContent =
                 displayTitle ||
@@ -1178,19 +1178,22 @@ export default class VisualPicker extends LightningElement {
     }
 
     /**
-     * Compute visual picker items class styling based on size attributes and presence of image.
+     * Compute visual picker items class styling based on size attributes and presence of image and fields.
      *
      * @param {boolean} hasImg
+     * @param {boolean} hasFields
      * @type {string}
      */
-    computeVisualPickerItemsClass(hasImg) {
+    computeVisualPickerItemsClass(hasImg, hasFields) {
         return classSet('slds-has-flexi-truncate')
             .add({
                 'avonni-visual-picker__items':
                     this.size !== 'responsive' ||
                     (this.size === 'responsive' && !hasImg),
                 'avonni-visual-picker__items_responsive_image':
-                    this.size === 'responsive' && hasImg
+                    this.size === 'responsive' && hasImg,
+                'avonni-visual-picker__items_responsive_image-fields':
+                    this.size === 'responsive' && hasImg && hasFields
             })
             .toString();
     }


### PR DESCRIPTION
<!-- Are you sure you're ready to open a pull request? -->
<!-- Checkout the list first: https://avonnicreator.atlassian.net/wiki/spaces/LDG/pages/2140766209/Can+I+open+a+pull+request -->
<!-- Then use this template to explain what you did: -->


### Fixes
**Visual Picker**
- Fixed an issue with fields not being displayed properly if the size is responsive

### Features
**Visual Picker**
- Removed overlay background if the content of the item is empty

<!-- Don't forget to edit and remove what's unnecessary! -->
<!-- See the Release Notes for real examples: https://www.avonnicomponents.com/release-notes -->
