### PR TITLE
[feat] (ABC-1102): Improve date format of all day events in scheduler

### DIFF
--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -367,6 +367,7 @@
                 <div class="slds-grid slds-wrap slds-gutters_x-small">
                     <template for:each={detailPopoverFields} for:item="field">
                         <div
+                            if:false={field.isHidden}
                             key={field.key}
                             class="
                                 slds-col

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -2223,8 +2223,10 @@ export default class Scheduler extends LightningElement {
 
             this.detailPopoverFields = this.eventsDisplayFields.map((field) => {
                 const { type, label, variant } = field;
+                const { allDay } = this.selection.event;
                 const eventData = this.selection.event.data;
                 const occurrenceData = this.selection.occurrence;
+                let isHidden = false;
                 let value =
                     occurrenceData[field.value] || eventData[field.value];
 
@@ -2233,7 +2235,13 @@ export default class Scheduler extends LightningElement {
                     field.value === 'resourceNames' && Array.isArray(value);
                 if (isDate) {
                     value = this.createDate(value);
-                    value = value.toFormat(this.dateFormat);
+                    const format = allDay ? 'DD' : this.dateFormat;
+                    value = value.toFormat(format);
+                    isHidden =
+                        field.value === 'to' &&
+                        allDay &&
+                        occurrenceData.endOfTo.ts ===
+                            occurrenceData.from.endOf('day').ts;
                 } else if (isResources) {
                     value = value
                         .map((res) => {
@@ -2249,6 +2257,7 @@ export default class Scheduler extends LightningElement {
 
                 return {
                     key: generateUUID(),
+                    isHidden,
                     label,
                     type: isDate ? 'text' : type,
                     value,


### PR DESCRIPTION
### Features
**Scheduler**
- Added a fixed format for all day events dates, in the event details popover. If the `from` or the `to` keys are present in the event display fields, and the selected event is "all day", the from and to dates will be displayed in the format "Nov. 14, 2023", without the time. If the event only spans on one day, only the from date will be displayed.
