### PR TITLE
[feat] (ABC-1104): Improve support of scheduler event dates

### DIFF
--- a/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
+++ b/src/modules/base/primitiveSchedulerAgenda/primitiveSchedulerAgenda.js
@@ -448,7 +448,7 @@ export default class PrimitiveSchedulerAgenda extends ScheduleBase {
      * @returns {string} Formatted time describing the event duration.
      */
     formatTime(event, from, to) {
-        if (event.referenceLine) {
+        if (event.referenceLine || from.ts === to.ts) {
             return from.toFormat('t');
         } else if (isAllDay(event, from, to)) {
             return 'All Day';

--- a/src/modules/base/primitiveSchedulerCalendar/__tests__/primitiveSchedulerCalendar.test.js
+++ b/src/modules/base/primitiveSchedulerCalendar/__tests__/primitiveSchedulerCalendar.test.js
@@ -779,7 +779,7 @@ describe('Primitive Scheduler Calendar', () => {
                     const from = DateTime.fromJSDate(original.from);
                     const to = original.to
                         ? DateTime.fromJSDate(original.to)
-                        : from.endOf('day');
+                        : from;
                     const resourceName = original.resourceNames
                         ? original.resourceNames[0]
                         : undefined;
@@ -933,9 +933,10 @@ describe('Primitive Scheduler Calendar', () => {
                     const from = original.allDay
                         ? fromDateTime.startOf('day')
                         : fromDateTime;
-                    const to = original.to
+                    let to = original.to
                         ? DateTime.fromJSDate(original.to)
-                        : from.endOf('day');
+                        : fromDateTime;
+                    to = original.allDay ? to.endOf('day') : to;
                     const resourceName = original.resourceNames
                         ? original.resourceNames[0]
                         : undefined;

--- a/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
@@ -1221,7 +1221,7 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
             length += this.getOffsetStart(cellEnd, cellSize);
             if (this.referenceLine) return;
 
-            if (cellEnd > to) {
+            if (cellEnd > to && from.ts !== to.ts) {
                 // If the event ends before the end of the first column
                 // remove the appropriate length of the first column
                 length -= this.getOffsetEnd(cellEnd, cellSize, to);

--- a/src/modules/base/primitiveSchedulerTimeline/__tests__/primitiveSchedulerTimeline.test.js
+++ b/src/modules/base/primitiveSchedulerTimeline/__tests__/primitiveSchedulerTimeline.test.js
@@ -458,7 +458,7 @@ describe('Primitive Scheduler Timeline', () => {
                         : original.resourceNames[0];
                     const from = DateTime.fromJSDate(original.from);
                     const to = original.referenceLine
-                        ? from.endOf('day').ts
+                        ? from.ts
                         : original.to.getTime();
                     expect(event.color).toBe(original.color);
                     expect(event.disabled).toBe(original.disabled || false);

--- a/src/modules/base/scheduler/__docs__/data.js
+++ b/src/modules/base/scheduler/__docs__/data.js
@@ -1,5 +1,3 @@
-
-
 const start = new Date(2021, 11, 13, 8);
 
 const columns = [
@@ -296,6 +294,7 @@ const events = [
         resourceNames: ['Jung'],
         name: 'research',
         title: 'Research',
+        dateFormat: 'DD',
         from: new Date(2021, 11, 13, 9),
         to: new Date(2021, 11, 14, 12)
     },
@@ -410,6 +409,7 @@ const eventsWithExtraKeys = [
         resourceNames: ['Jung'],
         name: 'research',
         title: 'Research',
+        dateFormat: 'DD',
         from: new Date(2021, 11, 13, 9),
         to: new Date(2021, 11, 14, 12),
         office: 'Montreal, QC',
@@ -543,6 +543,7 @@ const eventsWithLabels = [
         resourceNames: ['Jung'],
         name: 'research',
         title: 'Research',
+        dateFormat: 'DD',
         from: new Date(2021, 11, 13, 9),
         to: new Date(2021, 11, 14, 12),
         labels: {

--- a/src/modules/base/scheduler/__docs__/scheduler.jsdoc.js
+++ b/src/modules/base/scheduler/__docs__/scheduler.jsdoc.js
@@ -28,6 +28,7 @@
  * @property {boolean} allDay If true, the event will be applied to the whole day(s). Defaults to false.
  * @property {string} color Custom color for the event. If present, it will overwrite the default color.
  * It has to be a Hexadecimal or an RGB color. For example `#3A7D44` or `rgb(58, 125, 68)`.
+ * @property {string} dateFormat Custom date format for the event. If present, it will overwrite the default `date-format`.
  * @property {(Date|number|string)} from Required. Start of the event. It can be a Date object, timestamp, or an ISO8601 formatted string.
  * @property {object} labels Custom labels for the event. If present, it will overwrite the default `event-labels`.
  * @property {string} name Required. Unique name for the event.

--- a/src/modules/base/scheduler/__examples__/agenda/agenda.js
+++ b/src/modules/base/scheduler/__examples__/agenda/agenda.js
@@ -37,6 +37,7 @@ export default class SchedulerAgenda extends LightningElement {
             resourceNames: ['Jung'],
             name: 'research',
             title: 'Research',
+            dateFormat: 'DD',
             from: new Date(2021, 11, 13, 9),
             to: new Date(2021, 11, 14, 12)
         },

--- a/src/modules/base/scheduler/__examples__/availableAndDisabledTimes/availableAndDisabledTimes.js
+++ b/src/modules/base/scheduler/__examples__/availableAndDisabledTimes/availableAndDisabledTimes.js
@@ -59,6 +59,7 @@ export default class SchedulerAvailableAndDisabledTimes extends LightningElement
             resourceNames: ['Jung'],
             name: 'research',
             title: 'Research',
+            dateFormat: 'DD',
             from: new Date(2021, 11, 13, 9),
             to: new Date(2021, 11, 14, 12)
         },

--- a/src/modules/base/scheduler/__examples__/calendar/calendar.js
+++ b/src/modules/base/scheduler/__examples__/calendar/calendar.js
@@ -37,6 +37,7 @@ export default class SchedulerCalendar extends LightningElement {
             resourceNames: ['Jung'],
             name: 'research',
             title: 'Research',
+            dateFormat: 'DD',
             from: new Date(2021, 11, 13, 9),
             to: new Date(2021, 11, 14, 12)
         },

--- a/src/modules/base/scheduler/__examples__/labels/labels.js
+++ b/src/modules/base/scheduler/__examples__/labels/labels.js
@@ -25,6 +25,7 @@ export default class SchedulerLabels extends LightningElement {
             resourceNames: ['Jung'],
             name: 'research',
             title: 'Research',
+            dateFormat: 'DD',
             from: new Date(2021, 11, 13, 9),
             to: new Date(2021, 11, 14, 12),
             labels: {

--- a/src/modules/base/scheduler/__examples__/readOnly/readOnly.js
+++ b/src/modules/base/scheduler/__examples__/readOnly/readOnly.js
@@ -33,6 +33,7 @@ export default class SchedulerReadOnly extends LightningElement {
             resourceNames: ['Jung'],
             name: 'research',
             title: 'Research',
+            dateFormat: 'DD',
             from: new Date(2021, 11, 13, 9),
             to: new Date(2021, 11, 14, 12)
         },

--- a/src/modules/base/scheduler/__examples__/verticalTimeline/verticalTimeline.js
+++ b/src/modules/base/scheduler/__examples__/verticalTimeline/verticalTimeline.js
@@ -40,6 +40,7 @@ export default class SchedulerVerticalTimeline extends LightningElement {
             resourceNames: ['Jung'],
             name: 'research',
             title: 'Research',
+            dateFormat: 'DD',
             from: new Date(2021, 11, 13, 9),
             to: new Date(2021, 11, 14, 12)
         },

--- a/src/modules/base/scheduler/__tests__/scheduler.test.js
+++ b/src/modules/base/scheduler/__tests__/scheduler.test.js
@@ -920,7 +920,7 @@ describe('Scheduler', () => {
             });
     });
 
-    it('Scheduler: eventsDisplayFields auto format of the all day event dates', () => {
+    it('Scheduler: eventsDisplayFields, use the custom event date format', () => {
         const from = DateTime.fromJSDate(new Date(2023, 1, 21));
         const to = DateTime.fromMillis(new Date(2023, 1, 22) - 1);
         element.dateFormat = 'dd, LL yyyy, TT';
@@ -932,6 +932,7 @@ describe('Scheduler', () => {
                 name: 'event-2',
                 resourceNames: [RESOURCES[0].name, RESOURCES[1].name],
                 from: new Date(2023, 1, 21, 15),
+                dateFormat: 'DD',
                 allDay: true
             }
         ];
@@ -977,6 +978,7 @@ describe('Scheduler', () => {
                                     RESOURCES[0].name,
                                     RESOURCES[1].name
                                 ],
+                                dateFormat: 'DD',
                                 from: new Date(2023, 1, 21, 15),
                                 allDay: true
                             }

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -2235,7 +2235,7 @@ export default class Scheduler extends LightningElement {
                     field.value === 'resourceNames' && Array.isArray(value);
                 if (isDate) {
                     value = this.createDate(value);
-                    const format = allDay ? 'DD' : this.dateFormat;
+                    const format = eventData.dateFormat || this.dateFormat;
                     value = value.toFormat(format);
                     isHidden =
                         field.value === 'to' &&

--- a/src/modules/base/scheduler/scheduler.js
+++ b/src/modules/base/scheduler/scheduler.js
@@ -1834,6 +1834,18 @@ export default class Scheduler extends LightningElement {
         this.showRecurrenceDialog = false;
     }
 
+    isFieldHiddenFromDetailPopover(fieldName) {
+        if (fieldName !== 'to') {
+            return false;
+        }
+        const allDay = this.selection.event.allDay;
+        const occurrence = this.selection.occurrence;
+        const spansOnWholeDay =
+            allDay && occurrence.endOfTo.ts === occurrence.from.endOf('day').ts;
+        const hasNoDuration = occurrence.from.ts === occurrence.to.ts;
+        return spansOnWholeDay || hasNoDuration;
+    }
+
     /**
      * Normalize the given date to be on the first day of the month.
      *
@@ -2223,7 +2235,6 @@ export default class Scheduler extends LightningElement {
 
             this.detailPopoverFields = this.eventsDisplayFields.map((field) => {
                 const { type, label, variant } = field;
-                const { allDay } = this.selection.event;
                 const eventData = this.selection.event.data;
                 const occurrenceData = this.selection.occurrence;
                 let isHidden = false;
@@ -2237,11 +2248,7 @@ export default class Scheduler extends LightningElement {
                     value = this.createDate(value);
                     const format = eventData.dateFormat || this.dateFormat;
                     value = value.toFormat(format);
-                    isHidden =
-                        field.value === 'to' &&
-                        allDay &&
-                        occurrenceData.endOfTo.ts ===
-                            occurrenceData.from.endOf('day').ts;
+                    isHidden = this.isFieldHiddenFromDetailPopover(field.value);
                 } else if (isResources) {
                     value = value
                         .map((res) => {

--- a/src/modules/base/schedulerUtils/dateComputations.js
+++ b/src/modules/base/schedulerUtils/dateComputations.js
@@ -299,7 +299,7 @@ const containsAllowedDateTimes = (
             computedUnit,
             span
         );
-        return firstAllowedTime < end;
+        return firstAllowedTime <= end;
     }
 
     return true;

--- a/src/modules/base/schedulerUtils/event.js
+++ b/src/modules/base/schedulerUtils/event.js
@@ -271,8 +271,10 @@ export default class SchedulerEvent {
 
         if (this.allDay && to) {
             to = to.endOf('day');
-        } else if (this.from && (this.allDay || to < this.from)) {
+        } else if (this.from && this.allDay) {
             to = this.from.endOf('day');
+        } else if (this.from && to < this.from) {
+            to = dateTimeObjectFrom(this.from.ts);
         }
 
         return !this.schedulerEnd || this.recurrence || to < this.schedulerEnd

--- a/src/modules/base/schedulerUtils/event.js
+++ b/src/modules/base/schedulerUtils/event.js
@@ -274,7 +274,7 @@ export default class SchedulerEvent {
         } else if (this.from && this.allDay) {
             to = this.from.endOf('day');
         } else if (this.from && to < this.from) {
-            to = dateTimeObjectFrom(this.from.ts);
+            to = this.createDate(this.from.ts);
         }
 
         return !this.schedulerEnd || this.recurrence || to < this.schedulerEnd


### PR DESCRIPTION
### Fixes
**Scheduler**
- Added a `dateFormat` key to the events.
- Updated the display of the events that only have a `from` date. Their end date is now the same as their starting date.
