### PR TITLE
[fix] (ABC-1109): Allow milliseconds in scheduler time frames

### DIFF
--- a/src/modules/base/scheduler/__tests__/scheduler.test.js
+++ b/src/modules/base/scheduler/__tests__/scheduler.test.js
@@ -252,14 +252,14 @@ describe('Scheduler', () => {
     // available-time-frames
     it('Scheduler: availableTimeFrames, agenda display', () => {
         element.selectedDisplay = 'agenda';
-        element.availableTimeFrames = ['12:50-16:00', '08:09-10:04'];
+        element.availableTimeFrames = ['12:50-16:00:00.000', '08:09-10:04'];
 
         return Promise.resolve().then(() => {
             const agenda = element.shadowRoot.querySelector(
                 '[data-element-id="avonni-primitive-scheduler-agenda"]'
             );
             expect(agenda.availableTimeFrames).toEqual([
-                '12:50-16:00',
+                '12:50-16:00:00.000',
                 '08:09-10:04'
             ]);
         });

--- a/src/modules/base/utilsPrivate/dateTimeUtils.js
+++ b/src/modules/base/utilsPrivate/dateTimeUtils.js
@@ -79,8 +79,8 @@ const intervalFrom = (start, end) => {
  * @returns {object} Object with three possible keys: valid, start and end.
  */
 const parseTimeFrame = (timeFrame, options) => {
-    const startMatch = timeFrame.match(/^([0-9:]+)-/);
-    const endMatch = timeFrame.match(/-([0-9:]+)$/);
+    const startMatch = timeFrame.match(/^([0-9:]+(\.\d+)?)-/);
+    const endMatch = timeFrame.match(/-([0-9:]+(\.\d+)?)$/);
 
     if (!startMatch || !endMatch) {
         console.error(


### PR DESCRIPTION
<!-- Are you sure you're ready to open a pull request? -->
<!-- Checkout the list first: https://avonnicreator.atlassian.net/wiki/spaces/LDG/pages/2140766209/Can+I+open+a+pull+request -->
<!-- Then use this template to explain what you did: -->

### Fixes
**Scheduler**
- Broadened the accepted formats for available time frames, to accept times including milliseconds.

<!-- Don't forget to edit and remove what's unnecessary! -->
<!-- See the Release Notes for real examples: https://www.avonnicomponents.com/release-notes -->
