### PR TITLE
[fix] (ABC-1111): Allow space character in combobox search

### DIFF
--- a/src/modules/base/primitiveCombobox/primitiveCombobox.js
+++ b/src/modules/base/primitiveCombobox/primitiveCombobox.js
@@ -1872,8 +1872,14 @@ export default class PrimitiveCombobox extends LightningElement {
                 case 'Spacebar':
                 case 'Enter':
                     this.handleHighlightedOptionClick(event);
-                    // Prevent the browser scrollbar from scrolling down
-                    event.preventDefault();
+
+                    if (
+                        !this.allowSearch &&
+                        (event.key === ' ' || event.key === 'Spacebar')
+                    ) {
+                        // Prevent the browser scrollbar from scrolling down
+                        event.preventDefault();
+                    }
                     break;
                 case 'Escape':
                     this.close();


### PR DESCRIPTION
### Fixes
**Combobox**
- Fixed the search to allow for the space character.

<!-- Don't forget to edit and remove what's unnecessary! -->
<!-- See the Release Notes for real examples: https://www.avonnicomponents.com/release-notes -->
