### PR TITLE
[feat] (ABC-1121): Visual Picker - If no Figure title specified, the image should still be displayed

### DIFF
--- a/src/modules/base/visualPicker/visualPicker.js
+++ b/src/modules/base/visualPicker/visualPicker.js
@@ -725,7 +725,8 @@ export default class VisualPicker extends LightningElement {
                 displayDescription ||
                 displayAvatar ||
                 hasTags ||
-                hasFields;
+                hasFields ||
+                (hasImg && !imgIsBackground);
 
             return {
                 key,


### PR DESCRIPTION
<!-- Are you sure you're ready to open a pull request? -->
<!-- Checkout the list first: https://avonnicreator.atlassian.net/wiki/spaces/LDG/pages/2140766209/Can+I+open+a+pull+request -->
<!-- Then use this template to explain what you did: -->

### Features
**Visual Picker**
- If present and no figure title is specified, the figure image will still be displayed


<!-- Don't forget to edit and remove what's unnecessary! -->
<!-- See the Release Notes for real examples: https://www.avonnicomponents.com/release-notes -->
