### PR TITLE
[Feat](ABC-1139): Activity Timeline - Improve item date format attribute

### DIFF
--- a/src/modules/base/activityTimeline/__docs__/activityTimeline.jsdoc.js
+++ b/src/modules/base/activityTimeline/__docs__/activityTimeline.jsdoc.js
@@ -40,12 +40,6 @@
  * @property {string|number} smallContainerCols Number of columns on small container widths. Width is greater or equal to 480px. See `cols` for accepted values.
  * @property {string} variant The variant changes the appearance of the field. Accepted variants include standard, label-inline, label-hidden, and label-stacked.
  */
-/**
- * @typedef {Object} DateFormat
- * @name itemDateFormat
- * @property {string} format Name of the format. Valid values include 'standard', 'relative', 'preset' and 'custom'. For 'preset' and 'custom' use the 'value' attribute to specify the preset or custom format string to use.
- * @property {string} value If the format is 'preset', the name of the preset. If the format is 'custom', specifies the custom format string. See [Luxon's documentation](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) for accepted presets and custom format strings. If you want to insert text in the label, you need to escape it using single quote. For example, the format of "Jan 14 day shift" would be <code>"LLL dd 'day shift'"</code>. Defaults to 'LLLL dd, yyyy, t' custom format string. Defaults to 'DATE_MED' preset.
- */
 
 /**
  * @namespace stylingHooks

--- a/src/modules/base/activityTimeline/__docs__/activityTimeline.jsdoc.js
+++ b/src/modules/base/activityTimeline/__docs__/activityTimeline.jsdoc.js
@@ -40,6 +40,12 @@
  * @property {string|number} smallContainerCols Number of columns on small container widths. Width is greater or equal to 480px. See `cols` for accepted values.
  * @property {string} variant The variant changes the appearance of the field. Accepted variants include standard, label-inline, label-hidden, and label-stacked.
  */
+/**
+ * @typedef {Object} DateFormat
+ * @name itemDateFormat
+ * @property {string} format Name of the format. Valid values include 'standard', 'relative', 'preset' and 'custom'. For 'preset' and 'custom' use the 'value' attribute to specify the preset or custom format string to use.
+ * @property {string} value If the format is 'preset', the name of the preset. If the format is 'custom', specifies the custom format string. See [Luxon's documentation](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) for accepted presets and custom format strings. If you want to insert text in the label, you need to escape it using single quote. For example, the format of "Jan 14 day shift" would be <code>"LLL dd 'day shift'"</code>. Defaults to 'LLLL dd, yyyy, t' custom format string. Defaults to 'DATE_MED' preset.
+ */
 
 /**
  * @namespace stylingHooks

--- a/src/modules/base/activityTimeline/__docs__/activityTimeline.stories.js
+++ b/src/modules/base/activityTimeline/__docs__/activityTimeline.stories.js
@@ -221,9 +221,7 @@ export default {
             description:
                 "The date format to use for each item. See Luxon's documentation for accepted format. If you want to insert text in the label, you need to escape it using single quote.\n For example, the format of “Jan 14 day shift” would be “LLL dd 'day shift'\". ",
             table: {
-                defaultValue: {
-                    summary: { format: 'custom', custom: 'LLLL dd, yyyy, t' }
-                },
+                defaultValue: { summary: 'LLLL dd, yyyy, t' },
                 type: { summary: 'string' }
             }
         },

--- a/src/modules/base/activityTimeline/__docs__/activityTimeline.stories.js
+++ b/src/modules/base/activityTimeline/__docs__/activityTimeline.stories.js
@@ -79,7 +79,7 @@ export default {
             },
             options: ['left', 'right'],
             description:
-                'Position of the showMore button’s icon. Valid values include left and right. This attribute is only supported for the vertical orientation.',
+                "Position of the showMore button's icon. Valid values include left and right. This attribute is only supported for the vertical orientation.",
             table: {
                 type: { summary: 'string' },
                 defaultValue: { summary: 'left' },
@@ -219,9 +219,11 @@ export default {
                 type: 'text'
             },
             description:
-                "The date format to use for each item. See Luxon’s documentation for accepted format. If you want to insert text in the label, you need to escape it using single quote.\n For example, the format of “Jan 14 day shift” would be “LLL dd 'day shift'\". ",
+                "The date format to use for each item. See Luxon's documentation for accepted format. If you want to insert text in the label, you need to escape it using single quote.\n For example, the format of “Jan 14 day shift” would be “LLL dd 'day shift'\". ",
             table: {
-                defaultValue: { summary: 'LLLL dd, yyyy, t' },
+                defaultValue: {
+                    summary: { format: 'custom', custom: 'LLLL dd, yyyy, t' }
+                },
                 type: { summary: 'string' }
             }
         },

--- a/src/modules/base/activityTimeline/__tests__/activityTimeline.test.js
+++ b/src/modules/base/activityTimeline/__tests__/activityTimeline.test.js
@@ -141,7 +141,7 @@ describe('Activity Timeline', () => {
                 expect(spinner).toBeTruthy();
             });
     });
-    
+
     // fieldAttributes
     it('Activity Timeline: Field Attributes, cols', () => {
         element.fieldAttributes = { cols: 12, largeContainerCols: 4 };
@@ -154,18 +154,63 @@ describe('Activity Timeline', () => {
         });
     });
 
-    // itemDateFormat
+    // itemDateFormat: standard
     it('Activity timeline: itemDateFormat', () => {
         element.items = testItems;
         element.groupBy = 'week';
+
+        // Support string (deprecated)
         element.itemDateFormat = 'dd LLL yyyy';
 
-        return Promise.resolve().then(() => {
-            const timelineItems = element.shadowRoot.querySelector(
-                '[data-element-id="avonni-primitive-activity-timeline-item"]'
-            );
-            expect(timelineItems.dateFormat).toBe('dd LLL yyyy');
-        });
+        return Promise.resolve()
+            .then(() => {
+                const timelineItems = element.shadowRoot.querySelector(
+                    '[data-element-id="avonni-primitive-activity-timeline-item"]'
+                );
+                expect(timelineItems.dateFormat).toBe('dd LLL yyyy');
+
+                // Standard
+                element.itemDateFormat = { format: 'standard' };
+            })
+            .then(() => {
+                const timelineItems = element.shadowRoot.querySelector(
+                    '[data-element-id="avonni-primitive-activity-timeline-item"]'
+                );
+                expect(timelineItems.dateFormat).toBe('dd LLL yyyy');
+
+                // Relative
+                element.itemDateFormat = { format: 'relative' };
+            })
+            .then(() => {
+                const timelineItems = element.shadowRoot.querySelector(
+                    '[data-element-id="avonni-primitive-activity-timeline-item"]'
+                );
+                expect(timelineItems.dateFormat).toBe('dd LLL yyyy');
+
+                // Preset
+                element.itemDateFormat = {
+                    format: 'preset',
+                    preset: 'DATETIME_HUGE'
+                };
+            })
+            .then(() => {
+                const timelineItems = element.shadowRoot.querySelector(
+                    '[data-element-id="avonni-primitive-activity-timeline-item"]'
+                );
+                expect(timelineItems.dateFormat).toBe('dd LLL yyyy');
+
+                // Custom
+                element.itemDateFormat = {
+                    format: 'custom',
+                    custom: 'dd LLL yyyy'
+                };
+            })
+            .then(() => {
+                const timelineItems = element.shadowRoot.querySelector(
+                    '[data-element-id="avonni-primitive-activity-timeline-item"]'
+                );
+                expect(timelineItems.dateFormat).toBe('dd LLL yyyy');
+            });
     });
 
     // hideItemDate

--- a/src/modules/base/activityTimeline/__tests__/activityTimeline.test.js
+++ b/src/modules/base/activityTimeline/__tests__/activityTimeline.test.js
@@ -154,12 +154,10 @@ describe('Activity Timeline', () => {
         });
     });
 
-    // itemDateFormat: standard
+    // itemDateFormat
     it('Activity timeline: itemDateFormat', () => {
         element.items = testItems;
         element.groupBy = 'week';
-
-        // Support string (deprecated)
         element.itemDateFormat = 'dd LLL yyyy';
 
         return Promise.resolve()
@@ -170,46 +168,13 @@ describe('Activity Timeline', () => {
                 expect(timelineItems.dateFormat).toBe('dd LLL yyyy');
 
                 // Standard
-                element.itemDateFormat = { format: 'standard' };
+                element.itemDateFormat = 'DATETIME_MED';
             })
             .then(() => {
                 const timelineItems = element.shadowRoot.querySelector(
                     '[data-element-id="avonni-primitive-activity-timeline-item"]'
                 );
-                expect(timelineItems.dateFormat).toBe('dd LLL yyyy');
-
-                // Relative
-                element.itemDateFormat = { format: 'relative' };
-            })
-            .then(() => {
-                const timelineItems = element.shadowRoot.querySelector(
-                    '[data-element-id="avonni-primitive-activity-timeline-item"]'
-                );
-                expect(timelineItems.dateFormat).toBe('dd LLL yyyy');
-
-                // Preset
-                element.itemDateFormat = {
-                    format: 'preset',
-                    preset: 'DATETIME_HUGE'
-                };
-            })
-            .then(() => {
-                const timelineItems = element.shadowRoot.querySelector(
-                    '[data-element-id="avonni-primitive-activity-timeline-item"]'
-                );
-                expect(timelineItems.dateFormat).toBe('dd LLL yyyy');
-
-                // Custom
-                element.itemDateFormat = {
-                    format: 'custom',
-                    custom: 'dd LLL yyyy'
-                };
-            })
-            .then(() => {
-                const timelineItems = element.shadowRoot.querySelector(
-                    '[data-element-id="avonni-primitive-activity-timeline-item"]'
-                );
-                expect(timelineItems.dateFormat).toBe('dd LLL yyyy');
+                expect(timelineItems.dateFormat).toBe('DATETIME_MED');
             });
     });
 

--- a/src/modules/base/activityTimeline/__tests__/horizontalActivityTimeline.test.js
+++ b/src/modules/base/activityTimeline/__tests__/horizontalActivityTimeline.test.js
@@ -43,7 +43,6 @@ describe('Horizontal Activity Timeline', () => {
 
     it('Horizontal Activity Timeline: Default attributes', () => {
         expect(element._changeIntervalSizeMode).toBeFalsy();
-        expect(element._dateFormat).toBe('dd/MM/yyyy');
         expect(element._intervalDaysLength).toBe(15);
         expect(element._offsetAxis).toBe(16.5);
         expect(element._displayedItems).toMatchObject([]);

--- a/src/modules/base/activityTimeline/activityTimeline.js
+++ b/src/modules/base/activityTimeline/activityTimeline.js
@@ -5,6 +5,7 @@ import horizontalTimeline from './horizontalActivityTimeline.html';
 import verticalTimeline from './verticalActivityTimeline.html';
 import { classSet } from 'c/utils';
 import {
+    DATE_FORMAT_PRESETS,
     deepCopy,
     normalizeArray,
     normalizeBoolean,
@@ -39,7 +40,7 @@ const DEFAULT_FIELD_COLUMNS = {
     large: 4
 };
 const DEFAULT_HORIZONTAL_FIELD_VARIANT = 'label-inline';
-const DEFAULT_ITEM_DATE_FORMAT = 'LLLL dd, yyyy, t';
+const DEFAULT_ITEM_DATE_CUSTOM = 'LLLL dd, yyyy, t';
 const DEFAULT_ITEM_ICON_SIZE = 'small';
 const DEFAULT_LOAD_MORE_OFFSET = 20;
 const DEFAULT_LOCALE = 'en-GB';
@@ -57,6 +58,16 @@ const GROUP_BY_OPTIONS = {
 const ICON_SIZES = {
     valid: ['xx-small', 'x-small', 'small', 'medium', 'large'],
     default: 'medium'
+};
+
+const ITEM_DATE_FORMAT = {
+    default: 'standard',
+    valid: ['standard', 'relative', 'preset', 'custom']
+};
+
+const ITEM_DATE_PRESETS = {
+    default: 'DATE_MED',
+    valid: DATE_FORMAT_PRESETS
 };
 
 const ORIENTATIONS = {
@@ -149,7 +160,11 @@ export default class ActivityTimeline extends LightningElement {
     _hideItemDate = false;
     _iconSize = ICON_SIZES.default;
     _isLoading = false;
-    _itemDateFormat = DEFAULT_ITEM_DATE_FORMAT;
+    _itemDateFormat = {
+        custom: DEFAULT_ITEM_DATE_CUSTOM,
+        format: ITEM_DATE_FORMAT.default,
+        preset: ITEM_DATE_PRESETS.default
+    };
     _itemIconSize = DEFAULT_ITEM_ICON_SIZE;
     _items = [];
     _loadMoreOffset = DEFAULT_LOAD_MORE_OFFSET;
@@ -254,7 +269,7 @@ export default class ActivityTimeline extends LightningElement {
     }
 
     /**
-     * Position of the show less button’s icon. Valid values include left and right. This attribute is only supported for the vertical orientation.
+     * Position of the show less button's icon. Valid values include left and right. This attribute is only supported for the vertical orientation.
      * @type {string}
      * @default left
      * @public
@@ -272,7 +287,7 @@ export default class ActivityTimeline extends LightningElement {
     }
 
     /**
-     * Position of the show more button’s icon. Valid values include left and right. This attribute is only supported for the vertical orientation.
+     * Position of the show more button's icon. Valid values include left and right. This attribute is only supported for the vertical orientation.
      * @type {string}
      * @default left
      * @public
@@ -471,23 +486,46 @@ export default class ActivityTimeline extends LightningElement {
     }
 
     /**
-     * The date format to use for each item. See [Luxon’s documentation](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) for accepted format.
+     * The date format to use for each item. See [Luxon's documentation](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) for accepted format.
      * If you want to insert text in the label, you need to escape it using single quote.
      * For example, the format of "Jan 14 day shift" would be <code>"LLL dd 'day shift'"</code>.
      *
-     * @type {string}
-     * @default 'LLLL dd, yyyy, t'
+     * @type {string|object}
+     * @default {format: 'custom', custom: 'LLLL dd, yyyy, t'}
      * @public
      */
     @api
     get itemDateFormat() {
         return this._itemDateFormat;
     }
+
     set itemDateFormat(value) {
-        this._itemDateFormat =
-            value && typeof value === 'string'
-                ? value
-                : DEFAULT_ITEM_DATE_FORMAT;
+        if (typeof value === 'string') {
+            // Condition for backwards compatibility.
+            this._itemDateFormat = {
+                format: 'custom',
+                custom: value || DEFAULT_ITEM_DATE_CUSTOM
+            };
+        } else if (!value || typeof value !== 'object') {
+            this._itemDateFormat = {
+                format: 'custom',
+                custom: DEFAULT_ITEM_DATE_CUSTOM
+            };
+        } else {
+            this._itemDateFormat = {
+                custom: value.custom || DEFAULT_ITEM_DATE_CUSTOM,
+                format: normalizeString(value.format, {
+                    fallbackValue: ITEM_DATE_FORMAT.default,
+                    validValues: ITEM_DATE_FORMAT.valid
+                }),
+                preset: normalizeString(value.preset, {
+                    fallbackValue: ITEM_DATE_PRESETS.default,
+                    validValues: ITEM_DATE_PRESETS.valid,
+                    toLowerCase: false
+                })
+            };
+        }
+        console.log(this._itemDateFormat);
     }
 
     /**
@@ -670,13 +708,14 @@ export default class ActivityTimeline extends LightningElement {
         );
     }
 
-    /*
+    /**
      * Computed item date format.
-     * @type {string}
+     *
+     * @type {object}
      */
     get computedItemDateFormat() {
         if (this._hideItemDate) {
-            return '';
+            return null;
         }
         return this._itemDateFormat;
     }

--- a/src/modules/base/activityTimeline/activityTimeline.js
+++ b/src/modules/base/activityTimeline/activityTimeline.js
@@ -5,7 +5,6 @@ import horizontalTimeline from './horizontalActivityTimeline.html';
 import verticalTimeline from './verticalActivityTimeline.html';
 import { classSet } from 'c/utils';
 import {
-    DATE_FORMAT_PRESETS,
     deepCopy,
     normalizeArray,
     normalizeBoolean,
@@ -40,7 +39,7 @@ const DEFAULT_FIELD_COLUMNS = {
     large: 4
 };
 const DEFAULT_HORIZONTAL_FIELD_VARIANT = 'label-inline';
-const DEFAULT_ITEM_DATE_CUSTOM = 'LLLL dd, yyyy, t';
+const DEFAULT_ITEM_DATE_FORMAT = 'LLLL dd, yyyy, t';
 const DEFAULT_ITEM_ICON_SIZE = 'small';
 const DEFAULT_LOAD_MORE_OFFSET = 20;
 const DEFAULT_LOCALE = 'en-GB';
@@ -58,16 +57,6 @@ const GROUP_BY_OPTIONS = {
 const ICON_SIZES = {
     valid: ['xx-small', 'x-small', 'small', 'medium', 'large'],
     default: 'medium'
-};
-
-const ITEM_DATE_FORMAT = {
-    default: 'standard',
-    valid: ['standard', 'relative', 'preset', 'custom']
-};
-
-const ITEM_DATE_PRESETS = {
-    default: 'DATE_MED',
-    valid: DATE_FORMAT_PRESETS
 };
 
 const ORIENTATIONS = {
@@ -160,11 +149,7 @@ export default class ActivityTimeline extends LightningElement {
     _hideItemDate = false;
     _iconSize = ICON_SIZES.default;
     _isLoading = false;
-    _itemDateFormat = {
-        custom: DEFAULT_ITEM_DATE_CUSTOM,
-        format: ITEM_DATE_FORMAT.default,
-        preset: ITEM_DATE_PRESETS.default
-    };
+    _itemDateFormat = DEFAULT_ITEM_DATE_FORMAT;
     _itemIconSize = DEFAULT_ITEM_ICON_SIZE;
     _items = [];
     _loadMoreOffset = DEFAULT_LOAD_MORE_OFFSET;
@@ -486,12 +471,13 @@ export default class ActivityTimeline extends LightningElement {
     }
 
     /**
-     * The date format to use for each item. See [Luxon's documentation](https://moment.github.io/luxon/#/formatting?id=table-of-tokens) for accepted format.
-     * If you want to insert text in the label, you need to escape it using single quote.
+     * The date format to use for each item. Valid values include 'STANDARD', 'RELATIVE', the name of the preset or the custom format string.
+     * See Luxon's documentation for accepted [presets](https://moment.github.io/luxon/#/formatting?id=presets) and [custom format string tokens](https://moment.github.io/luxon/#/formatting?id=table-of-tokens).
+     * If you want to insert text in the label in a custom format string, you need to escape it using single quote.
      * For example, the format of "Jan 14 day shift" would be <code>"LLL dd 'day shift'"</code>.
      *
-     * @type {string|object}
-     * @default {format: 'custom', custom: 'LLLL dd, yyyy, t'}
+     * @type {string}
+     * @default 'LLLL dd, yyyy, t'
      * @public
      */
     @api
@@ -500,32 +486,8 @@ export default class ActivityTimeline extends LightningElement {
     }
 
     set itemDateFormat(value) {
-        if (typeof value === 'string') {
-            // Condition for backwards compatibility.
-            this._itemDateFormat = {
-                format: 'custom',
-                custom: value || DEFAULT_ITEM_DATE_CUSTOM
-            };
-        } else if (!value || typeof value !== 'object') {
-            this._itemDateFormat = {
-                format: 'custom',
-                custom: DEFAULT_ITEM_DATE_CUSTOM
-            };
-        } else {
-            this._itemDateFormat = {
-                custom: value.custom || DEFAULT_ITEM_DATE_CUSTOM,
-                format: normalizeString(value.format, {
-                    fallbackValue: ITEM_DATE_FORMAT.default,
-                    validValues: ITEM_DATE_FORMAT.valid
-                }),
-                preset: normalizeString(value.preset, {
-                    fallbackValue: ITEM_DATE_PRESETS.default,
-                    validValues: ITEM_DATE_PRESETS.valid,
-                    toLowerCase: false
-                })
-            };
-        }
-        console.log(this._itemDateFormat);
+        this._itemDateFormat =
+            typeof value === 'string' && (value || DEFAULT_ITEM_DATE_FORMAT);
     }
 
     /**

--- a/src/modules/base/activityTimeline/activityTimeline.js
+++ b/src/modules/base/activityTimeline/activityTimeline.js
@@ -673,7 +673,7 @@ export default class ActivityTimeline extends LightningElement {
     /**
      * Computed item date format.
      *
-     * @type {object}
+     * @type {string}
      */
     get computedItemDateFormat() {
         if (this._hideItemDate) {

--- a/src/modules/base/activityTimeline/horizontalActivityTimeline.js
+++ b/src/modules/base/activityTimeline/horizontalActivityTimeline.js
@@ -1,5 +1,5 @@
 import * as d3 from 'd3';
-import { dateTimeObjectFrom } from 'c/utilsPrivate';
+import { getFormattedDate } from 'c/utilsPrivate';
 import { createSVGIcon } from 'c/iconUtils';
 
 const AXIS_LABEL_WIDTH = 50.05;
@@ -7,7 +7,6 @@ const AXIS_TYPE = { timelineAxis: 'timeline-axis', scrollAxis: 'scroll-axis' };
 const BORDER_OFFSET = 0.5;
 const DEFAULT_ICON_NAME = 'empty';
 const DEFAULT_ICON_CATEGORY = 'standard';
-const DEFAULT_DATE_FORMAT = 'dd/MM/yyyy';
 const DEFAULT_NUBBIN_TOP_POSITION_PX = 24;
 const DEFAULT_INTERVAL_DAYS_LENGTH = 15;
 const DEFAULT_TIMELINE_AXIS_OFFSET = 16.5;
@@ -19,6 +18,10 @@ const DEFAULT_TOOLTIP_CLASSES =
     'avonni-horizontal-activity-timeline__popover slds-popover slds-popover_large slds-is-absolute slds-p-around_none';
 const DEFAULT_SCROLL_AXIS_TICKS_NUMBER = 12;
 const DISTANCE_BETWEEN_POPOVER_AND_ITEM = 15;
+const INTERVAL_DATE_FORMAT = {
+    format: 'custom',
+    custom: 'dd/MM/yyyy'
+};
 const INTERVAL_RECTANGLE_OFFSET_Y = 1.5;
 const MAX_LENGTH_TITLE_ITEM = 30;
 const MAX_ITEM_LENGTH = 230;
@@ -54,7 +57,6 @@ const Y_GAP_BETWEEN_ITEMS_SCROLL = 4;
 export class HorizontalActivityTimeline {
     // Horizontal view properties
     _changeIntervalSizeMode = false;
-    _dateFormat = DEFAULT_DATE_FORMAT;
     _displayedItems = [];
     _distanceBetweenDragAndMin;
     _intervalDaysLength = DEFAULT_INTERVAL_DAYS_LENGTH;
@@ -235,7 +237,10 @@ export class HorizontalActivityTimeline {
         if (!this._isResizingInterval) {
             this.setIntervalMaxDate();
         }
-        return this.convertDateToFormat(this._intervalMaxDate);
+        return this.convertDateToFormat(
+            this._intervalMaxDate,
+            INTERVAL_DATE_FORMAT
+        );
     }
 
     /**
@@ -244,7 +249,10 @@ export class HorizontalActivityTimeline {
      * @type {Date}
      */
     get intervalMinDate() {
-        return this.convertDateToFormat(this._intervalMinDate);
+        return this.convertDateToFormat(
+            this._intervalMinDate,
+            INTERVAL_DATE_FORMAT
+        );
     }
 
     /**
@@ -638,17 +646,19 @@ export class HorizontalActivityTimeline {
      * Convert a date to the correct format
      *
      * @param {Date} date
-     * @param {string} format
      * @returns string
      */
-    convertDateToFormat(date, format = this._dateFormat) {
+    convertDateToFormat(date, format) {
         if (this.isDateInvalid(date)) {
             return '';
         }
-        const dateTime = dateTimeObjectFrom(date, {
-            zone: this._activityTimeline.timezone
-        });
-        return dateTime.toFormat(format);
+        return getFormattedDate(
+            date,
+            {
+                zone: this._activityTimeline.timezone
+            },
+            format
+        );
     }
 
     /**

--- a/src/modules/base/activityTimeline/horizontalActivityTimeline.js
+++ b/src/modules/base/activityTimeline/horizontalActivityTimeline.js
@@ -18,10 +18,7 @@ const DEFAULT_TOOLTIP_CLASSES =
     'avonni-horizontal-activity-timeline__popover slds-popover slds-popover_large slds-is-absolute slds-p-around_none';
 const DEFAULT_SCROLL_AXIS_TICKS_NUMBER = 12;
 const DISTANCE_BETWEEN_POPOVER_AND_ITEM = 15;
-const INTERVAL_DATE_FORMAT = {
-    format: 'custom',
-    custom: 'dd/MM/yyyy'
-};
+const INTERVAL_DATE_FORMAT = 'dd/MM/yyyy';
 const INTERVAL_RECTANGLE_OFFSET_Y = 1.5;
 const MAX_LENGTH_TITLE_ITEM = 30;
 const MAX_ITEM_LENGTH = 230;

--- a/src/modules/base/activityTimeline/horizontalActivityTimeline.js
+++ b/src/modules/base/activityTimeline/horizontalActivityTimeline.js
@@ -643,6 +643,7 @@ export class HorizontalActivityTimeline {
      * Convert a date to the correct format
      *
      * @param {Date} date
+     * @param {string} format
      * @returns string
      */
     convertDateToFormat(date, format) {

--- a/src/modules/base/activityTimeline/verticalActivityTimeline.html
+++ b/src/modules/base/activityTimeline/verticalActivityTimeline.html
@@ -12,9 +12,15 @@
                     ></lightning-icon>
                 </div>
                 <div class="slds-media__body" if:true={title}>
-                    <h2 class="slds-truncate
-                    slds-section__title
-                    avonni-activity-timeline__title">{title}</h2>
+                    <h2
+                        class="
+                            slds-truncate
+                            slds-section__title
+                            avonni-activity-timeline__title
+                        "
+                    >
+                        {title}
+                    </h2>
                 </div>
             </div>
         </div>
@@ -124,8 +130,7 @@
                                     timezone={timezone}
                                     data-element-id="avonni-primitive-activity-timeline-item"
                                     data-name={item.name}
-                                >
-                                </c-primitive-activity-timeline-item>
+                                ></c-primitive-activity-timeline-item>
                             </li>
                         </template>
                     </ul>

--- a/src/modules/base/primitiveActivityTimelineItem/primitiveActivityTimelineItem.js
+++ b/src/modules/base/primitiveActivityTimelineItem/primitiveActivityTimelineItem.js
@@ -248,13 +248,22 @@ export default class PrimitiveActivityTimelineItem extends LightningElement {
         this._closed = normalizeBoolean(value);
     }
 
+    /**
+     * The date format to use for each item. Valid values include 'STANDARD', 'RELATIVE', the name of the preset or the custom format string.
+     * See Luxon's documentation for accepted [presets](https://moment.github.io/luxon/#/formatting?id=presets) and [custom format string tokens](https://moment.github.io/luxon/#/formatting?id=table-of-tokens).
+     * If you want to insert text in the label in a custom format string, you need to escape it using single quote.
+     * For example, the format of "Jan 14 day shift" would be <code>"LLL dd 'day shift'"</code>.
+     *
+     * @type {string}
+     * @public
+     */
     @api
     get dateFormat() {
         return this._dateFormat;
     }
 
     set dateFormat(value) {
-        this._dateFormat = value;
+        this._dateFormat = typeof value === 'string' ? value : null;
 
         if (this._connected) {
             this.formatDate();

--- a/src/modules/base/primitiveActivityTimelineItem/primitiveActivityTimelineItem.js
+++ b/src/modules/base/primitiveActivityTimelineItem/primitiveActivityTimelineItem.js
@@ -4,7 +4,8 @@ import {
     normalizeArray,
     normalizeString,
     deepCopy,
-    dateTimeObjectFrom
+    dateTimeObjectFrom,
+    getFormattedDate
 } from 'c/utilsPrivate';
 import { classSet } from 'c/utils';
 
@@ -232,7 +233,7 @@ export default class PrimitiveActivityTimelineItem extends LightningElement {
     }
 
     /**
-     * if true, close the section.
+     * If true, close the section.
      *
      * @public
      * @type {boolean}
@@ -247,21 +248,13 @@ export default class PrimitiveActivityTimelineItem extends LightningElement {
         this._closed = normalizeBoolean(value);
     }
 
-    /**
-     * The date format to use for the item. See {@link https://moment.github.io/luxon/#/formatting?id=table-of-tokens Luxon’s documentation} for accepted format.
-     * If you want to insert text in the label, you need to escape it using single quote.
-     * For example, the format of "Jan 14 day shift" would be <code>"LLL dd 'day shift'"</code>.
-     *
-     * @type {string}
-     * @public
-     */
     @api
     get dateFormat() {
         return this._dateFormat;
     }
 
     set dateFormat(value) {
-        this._dateFormat = typeof value === 'string' ? value : undefined;
+        this._dateFormat = value;
 
         if (this._connected) {
             this.formatDate();
@@ -526,7 +519,13 @@ export default class PrimitiveActivityTimelineItem extends LightningElement {
             this.formattedDate = '';
             return;
         }
-        this.formattedDate = date.toFormat(this.dateFormat);
+        this.formattedDate = getFormattedDate(
+            this.datetimeValue,
+            {
+                zone: this.timezone
+            },
+            this.dateFormat
+        );
     }
 
     /**

--- a/src/modules/base/utilsPrivate/dateTimeUtils.js
+++ b/src/modules/base/utilsPrivate/dateTimeUtils.js
@@ -259,22 +259,21 @@ const DATE_FORMAT_PRESETS = [
     'DATETIME_HUGE_WITH_SECONDS'
 ];
 
-const getFormattedDate = (date, dateOptions, { format, preset, custom }) => {
+const getFormattedDate = (date, dateOptions, format) => {
     const luxonDate = dateTimeObjectFrom(date, dateOptions);
     const luxonDateNow = dateTimeObjectFrom(Date.now(), dateOptions);
 
-    switch (format) {
-        case 'standard':
-            return getFormattedDateStandard(luxonDate, luxonDateNow);
-        case 'relative':
-            return getFormattedDateRelative(luxonDate, luxonDateNow);
-        case 'preset':
-            return luxonDate.toLocaleString(DateTime[preset]);
-        case 'custom':
-            return luxonDate.toFormat(custom);
-        default:
-            return getFormattedDateStandard(luxonDate, luxonDateNow);
+    if (format === 'STANDARD') {
+        return getFormattedDateStandard(luxonDate, luxonDateNow);
     }
+    if (format === 'RELATIVE') {
+        return getFormattedDateRelative(luxonDate, luxonDateNow);
+    }
+    if (DATE_FORMAT_PRESETS.includes(format)) {
+        return luxonDate.toLocaleString(DateTime[format]);
+    }
+
+    return luxonDate.toFormat(format);
 };
 
 function getFormattedDateRelative(luxonDate, luxonDateNow) {

--- a/src/modules/base/utilsPrivate/dateTimeUtils.js
+++ b/src/modules/base/utilsPrivate/dateTimeUtils.js
@@ -235,10 +235,69 @@ const formatDateFromStyle = (
     return formattedDate;
 };
 
+const DATE_FORMAT_PRESETS = [
+    'DATE_SHORT',
+    'DATE_MED',
+    'DATE_MED_WITH_WEEKDAY',
+    'DATE_FULL',
+    'DATE_HUGE',
+    'TIME_SIMPLE',
+    'TIME_WITH_SECONDS',
+    'TIME_WITH_SHORT_OFFSET',
+    'TIME_WITH_LONG_OFFSET',
+    'TIME_24_SIMPLE',
+    'TIME_24_WITH_SECONDS',
+    'TIME_24_WITH_SHORT_OFFSET',
+    'TIME_24_WITH_LONG_OFFSET',
+    'DATETIME_SHORT',
+    'DATETIME_MED',
+    'DATETIME_FULL',
+    'DATETIME_HUGE',
+    'DATETIME_SHORT_WITH_SECONDS',
+    'DATETIME_MED_WITH_SECONDS',
+    'DATETIME_FULL_WITH_SECONDS',
+    'DATETIME_HUGE_WITH_SECONDS'
+];
+
+const getFormattedDate = (date, dateOptions, { format, preset, custom }) => {
+    const luxonDate = dateTimeObjectFrom(date, dateOptions);
+    const luxonDateNow = dateTimeObjectFrom(Date.now(), dateOptions);
+
+    switch (format) {
+        case 'standard':
+            return getFormattedDateStandard(luxonDate, luxonDateNow);
+        case 'relative':
+            return getFormattedDateRelative(luxonDate, luxonDateNow);
+        case 'preset':
+            return luxonDate.toLocaleString(DateTime[preset]);
+        case 'custom':
+            return luxonDate.toFormat(custom);
+        default:
+            return getFormattedDateStandard(luxonDate, luxonDateNow);
+    }
+};
+
+function getFormattedDateRelative(luxonDate, luxonDateNow) {
+    const diff = luxonDate.diff(luxonDateNow).as('seconds');
+    const minuteInSeconds = 60;
+    if (Math.abs(diff) < minuteInSeconds) return 'now';
+    return luxonDate.toRelative();
+}
+
+function getFormattedDateStandard(luxonDate, luxonDateNow) {
+    if (luxonDate.hasSame(luxonDateNow, 'day'))
+        return `Today ${luxonDate.toFormat('h:mm a')}`;
+    if (luxonDate.hasSame(luxonDateNow.minus({ days: 1 }), 'day'))
+        return `Yesterday ${luxonDate.toFormat('h:mm a')}`;
+    return luxonDate.toFormat('LLL d, h:mm a');
+}
+
 export {
+    DATE_FORMAT_PRESETS,
     addToDate,
     dateTimeObjectFrom,
     formatDateFromStyle,
+    getFormattedDate,
     getStartOfWeek,
     getWeekday,
     getWeekNumber,

--- a/src/modules/base/utilsPrivate/utilsPrivate.js
+++ b/src/modules/base/utilsPrivate/utilsPrivate.js
@@ -55,8 +55,10 @@ export { ContentMutation } from './contentMutation';
 export { observePosition } from './observers';
 export { hasOnlyAllowedVideoIframes } from './videoUtils';
 export {
+    DATE_FORMAT_PRESETS,
     addToDate,
     dateTimeObjectFrom,
+    getFormattedDate,
     getStartOfWeek,
     getWeekday,
     formatDateFromStyle,


### PR DESCRIPTION
### Features
**Activity Timeline**
- Refactor of `itemDateFormat` attribute. In addition to a custom format string, you can now set it to 'STANDARD', 'RELATIVE' or use one of [luxon's format preset names](https://moment.github.io/luxon/#/formatting?id=presets)
