### PR TITLE
[fix] (ABC-1144): Prevent scheduler loading for identical new time span

### DIFF
--- a/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
+++ b/src/modules/base/primitiveSchedulerTimeline/primitiveSchedulerTimeline.js
@@ -2,6 +2,7 @@ import { api, track } from 'lwc';
 import {
     addToDate,
     deepCopy,
+    equal,
     normalizeArray,
     normalizeString
 } from 'c/utilsPrivate';
@@ -208,9 +209,10 @@ export default class PrimitiveSchedulerTimeline extends ScheduleBase {
         return super.timeSpan;
     }
     set timeSpan(value) {
+        const previousTimeSpan = deepCopy(this.timeSpan);
         super.timeSpan = value;
 
-        if (this._connected) {
+        if (this._connected && !equal(previousTimeSpan, this.timeSpan)) {
             this.initHeaders();
         }
     }


### PR DESCRIPTION
### Fixes
**Scheduler**
- Prevented the timeline display from loading indefinitely when a time span identical to the current one is passed to the scheduler.