### PR TITLE
[fix] (ABC-1145): Fix scheduler calendar multi day events display

### DIFF
--- a/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
@@ -1539,7 +1539,7 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
         const headerCells = this.headerCells.xAxis;
         const { to, cellWidth } = this;
         const isOneCellLength =
-            this.referenceLine || !this.spansOnMoreThanOneDay || this.isAllDay;
+            this.referenceLine || !this.spansOnMoreThanOneDay;
 
         if ((isOneCellLength || !headerCells) && this.hostElement) {
             // The event should span on one cell


### PR DESCRIPTION
### Fixes
**Scheduler**
- Fixed the span of multi-day events, in the monthly calendar display. When the events had the key `allDay`, they were only spanning on one cell.
