### PR TITLE
[fix](ABC-1174): Fix expandable section content taking up white space when closed

### DIFF
--- a/src/modules/base/expandableSection/expandableSection.css
+++ b/src/modules/base/expandableSection/expandableSection.css
@@ -194,3 +194,11 @@
     cursor: auto !important;
     border: none !important;
 }
+
+.avonni-expandable-section__content {
+    display: none;
+}
+
+.slds-is-open .avonni-expandable-section__content {
+    display: block;
+}

--- a/src/modules/base/expandableSection/expandableSection.html
+++ b/src/modules/base/expandableSection/expandableSection.html
@@ -47,7 +47,7 @@
                 </template>
             </button>
         </h3>
-        <div class="slds-section__content">
+        <div class="avonni-expandable-section__content slds-section__content">
             <slot></slot>
         </div>
     </div>


### PR DESCRIPTION
### Fix
**Expandable Section**
- Use `display:none` on the closed section content to fix white space problem.