### PR TITLE
[feat] (ABC-1180): Show loading spinner on top of scheduler

### DIFF
--- a/src/modules/base/scheduler/scheduler.html
+++ b/src/modules/base/scheduler/scheduler.html
@@ -197,7 +197,6 @@
     </div>
 
     <div
-        if:false={isLoading}
         class="avonni-scheduler__wrapper"
         onscheduleclick={handleScheduleClick}
     >


### PR DESCRIPTION
### Fixes
**Scheduler**
- Prevented height change when `is-loading` is updated. The loading spinner will now be displayed on top of the scheduler, instead of replacing it.