### PR TITLE
[feat] (ABC-1181): Replace layout styling hooks by grow and shrink properties

### DIFF
--- a/jest-mock/components/base/layoutItem/layoutItem.js
+++ b/jest-mock/components/base/layoutItem/layoutItem.js
@@ -2,11 +2,13 @@ import { LightningElement, api } from 'lwc';
 
 export default class LayoutItem extends LightningElement {
     @api alignmentBump;
+    @api grow;
     @api largeContainerOrder;
     @api largeContainerSize;
     @api mediumContainerOrder;
     @api mediumContainerSize;
     @api order;
+    @api shrink;
     @api size;
     @api smallContainerOrder;
     @api smallContainerSize;

--- a/src/modules/base/dateTimePicker/dateTimePicker.css
+++ b/src/modules/base/dateTimePicker/dateTimePicker.css
@@ -1,12 +1,3 @@
-.avonni-date-time-picker__flex-col {
-    --avonni-layout-item-layout-flex-shrink: 1;
-    --avonni-layout-item-layout-flex-grow: 1;
-}
-
-.avonni-date-time-picker__no-grow-col {
-    --avonni-layout-item-layout-flex-grow: 0;
-}
-
 .avonni-date-time-picker__toolbar {
     --avonni-layout-items-spacing-inline-between: 1.5rem;
 }

--- a/src/modules/base/dateTimePicker/dateTimePicker.html
+++ b/src/modules/base/dateTimePicker/dateTimePicker.html
@@ -5,7 +5,8 @@
         data-element-id="avonni-layout-toolbar"
     >
         <c-layout-item
-            class="slds-p-right_small avonni-date-time-picker__flex-col"
+            class="slds-p-right_small"
+            grow="1"
             size="12"
             medium-container-size="auto"
         >
@@ -22,7 +23,7 @@
                         data-element-id="avonni-avatar"
                     ></c-avatar>
                 </c-layout-item>
-                <c-layout-item class="avonni-date-time-picker__flex-col">
+                <c-layout-item grow="1">
                     <!-- Input label -->
                     <p
                         if:false={hideLabel}
@@ -193,9 +194,9 @@
                             key={day.date.ts}
                             class="
                                 slds-text-align_center
-                                avonni-date-time-picker__flex-col
                                 slds-has-flexi-truncate
                             "
+                            grow="1"
                             size={day.size}
                         >
                             <button
@@ -257,7 +258,7 @@
             ></c-calendar>
         </c-layout-item>
 
-        <c-layout-item class="avonni-date-time-picker__flex-col">
+        <c-layout-item grow="1">
             <template if:true={entirePeriodIsDisabled}>
                 <p if:true={isMonthly} class="slds-text-align_right">
                     No available time slots for this period.
@@ -275,10 +276,8 @@
                     <c-layout-item
                         if:true={day.show}
                         key={day.key}
-                        class="
-                            slds-text-align_center
-                            avonni-date-time-picker__flex-col
-                        "
+                        class="slds-text-align_center"
+                        grow="1"
                         data-element-id="div-day"
                     >
                         <c-layout
@@ -288,13 +287,13 @@
                             <!-- Day label -->
                             <c-layout-item
                                 if:true={day.label}
-                                aria-selected={day.selected}
-                                data-today={day.isToday}
                                 class="
                                     avonni-date-time-picker__day-label
-                                    avonni-date-time-picker__flex-col
                                     slds-p-around_medium
                                 "
+                                aria-selected={day.selected}
+                                grow="1"
+                                data-today={day.isToday}
                             >
                                 {day.label}
                             </c-layout-item>
@@ -325,11 +324,7 @@
                                             ></lightning-formatted-date-time>
                                         </c-layout-item>
 
-                                        <c-layout-item
-                                            class="
-                                                avonni-date-time-picker__flex-col
-                                            "
-                                        >
+                                        <c-layout-item grow="1">
                                             <c-layout multiple-rows>
                                                 <template
                                                     for:each={time.times}
@@ -389,9 +384,6 @@
                                 <template if:false={isTimeline}>
                                     <c-layout-item
                                         if:true={time.show}
-                                        class="
-                                            avonni-date-time-picker__no-grow-col
-                                        "
                                         key={time.startTimeISO}
                                         size="calc(100% / 3 - 8px)"
                                         small-container-size="calc(25% - 8px)"

--- a/src/modules/base/layout/__docs__/layout.stories.js
+++ b/src/modules/base/layout/__docs__/layout.stories.js
@@ -3,18 +3,6 @@ import { Layout } from '../__examples__/layout';
 export default {
     title: 'Example/Layout',
     argTypes: {
-        columnGap: {
-            name: 'column-gap',
-            control: {
-                type: 'text'
-            },
-            description:
-                'Space between columns of items, given as a number of pixels, or as a valid CSS length. If an item has an alignment bump, the gap in this direction will be half the given size.',
-            table: {
-                type: { summary: 'string|number' },
-                defaultValue: { summary: '0' }
-            }
-        },
         direction: {
             control: {
                 type: 'select'
@@ -52,18 +40,6 @@ export default {
                 defaultValue: { summary: 'false' }
             }
         },
-        rowGap: {
-            name: 'row-gap',
-            control: {
-                type: 'text'
-            },
-            description:
-                'Space between rows of items, given as a number of pixels, or as a valid CSS length. Only used if `multiple-rows` is true. If an item has an alignment bump, the gap in this direction will be half the given size.',
-            table: {
-                type: { summary: 'string|number' },
-                defaultValue: { summary: '0' }
-            }
-        },
         verticalAlign: {
             name: 'vertical-align',
             control: {
@@ -79,11 +55,9 @@ export default {
         }
     },
     args: {
-        columnGap: 0,
         direction: 'row',
         horizontalAlign: 'start',
         multipleRows: false,
-        rowGap: 0,
         verticalAlign: 'stretch'
     }
 };

--- a/src/modules/base/layout/__examples__/layout.js
+++ b/src/modules/base/layout/__examples__/layout.js
@@ -3,19 +3,15 @@ import Component from '../../storybookWrappers/layout/layout';
 customElements.define('ac-layout', Component.CustomElementConstructor);
 
 export const Layout = ({
-    columnGap,
     direction,
     horizontalAlign,
     multipleRows,
-    rowGap,
     verticalAlign
 }) => {
     const element = document.createElement('ac-layout');
-    element.columnGap = columnGap;
     element.direction = direction;
     element.horizontalAlign = horizontalAlign;
     element.multipleRows = multipleRows;
-    element.rowGap = rowGap;
     element.verticalAlign = verticalAlign;
     return element;
 };

--- a/src/modules/base/layoutItem/__tests__/layoutItem.test.js
+++ b/src/modules/base/layoutItem/__tests__/layoutItem.test.js
@@ -15,117 +15,166 @@ describe('Layout Item', () => {
         });
     });
 
-    it('Default attributes', () => {
-        document.body.appendChild(element);
-        expect(element.alignmentBump).toBeUndefined();
-        expect(element.largeContainerOrder).toBeUndefined();
-        expect(element.largeContainerSize).toBeUndefined();
-        expect(element.mediumContainerOrder).toBeUndefined();
-        expect(element.mediumContainerSize).toBeUndefined();
-        expect(element.order).toBeUndefined();
-        expect(element.size).toBeUndefined();
-        expect(element.smallContainerOrder).toBeUndefined();
-        expect(element.smallContainerSize).toBeUndefined();
-    });
-
     /*
      * ------------------------------------------------------------
      *  ATTRIBUTES
      * -------------------------------------------------------------
      */
-
-    // alignment-bump
-    it('Layout Item: alignmentBump = left', () => {
-        document.body.appendChild(element);
-        element.alignmentBump = 'left';
-        expect(element.shadowRoot.host.classList).toContain(
-            'slds-col_bump-left'
-        );
-    });
-
-    it('Layout Item: alignmentBump = right', () => {
-        document.body.appendChild(element);
-        element.alignmentBump = 'right';
-        expect(element.shadowRoot.host.classList).toContain(
-            'slds-col_bump-right'
-        );
-    });
-
-    it('Layout Item: alignmentBump = top', () => {
-        document.body.appendChild(element);
-        element.alignmentBump = 'top';
-        expect(element.shadowRoot.host.classList).toContain(
-            'slds-col_bump-top'
-        );
-    });
-
-    it('Layout Item: alignmentBump = bottom', () => {
-        document.body.appendChild(element);
-        element.alignmentBump = 'bottom';
-        expect(element.shadowRoot.host.classList).toContain(
-            'slds-col_bump-bottom'
-        );
-    });
-
-    // Container orders
-    it('Layout Item: container orders', () => {
-        let setContainerSize;
-        element.addEventListener('privatelayoutitemconnected', (event) => {
-            setContainerSize = event.detail.callbacks.setContainerSize;
+    describe('Attributes', () => {
+        it('Default attributes', () => {
+            document.body.appendChild(element);
+            expect(element.alignmentBump).toBeUndefined();
+            expect(element.grow).toBe(0);
+            expect(element.largeContainerOrder).toBeUndefined();
+            expect(element.largeContainerSize).toBeUndefined();
+            expect(element.mediumContainerOrder).toBeUndefined();
+            expect(element.mediumContainerSize).toBeUndefined();
+            expect(element.order).toBeUndefined();
+            expect(element.shrink).toBe(1);
+            expect(element.size).toBeUndefined();
+            expect(element.smallContainerOrder).toBeUndefined();
+            expect(element.smallContainerSize).toBeUndefined();
         });
-        document.body.appendChild(element);
-        expect(element.shadowRoot.host.style.order).toBe('0');
 
-        element.largeContainerOrder = 3;
-        element.mediumContainerOrder = 2;
-        element.smallContainerOrder = 1;
-        element.order = 6;
+        // alignment-bump
+        describe('Alignment bump', () => {
+            it('alignmentBump = left', () => {
+                document.body.appendChild(element);
+                element.alignmentBump = 'left';
+                expect(element.shadowRoot.host.classList).toContain(
+                    'slds-col_bump-left'
+                );
+            });
 
-        expect(element.shadowRoot.host.style.order).toBe('6');
-        setContainerSize('large');
-        expect(element.shadowRoot.host.style.order).toBe('3');
-        setContainerSize('medium');
-        expect(element.shadowRoot.host.style.order).toBe('2');
-        setContainerSize('small');
-        expect(element.shadowRoot.host.style.order).toBe('1');
-    });
+            it('alignmentBump = right', () => {
+                document.body.appendChild(element);
+                element.alignmentBump = 'right';
+                expect(element.shadowRoot.host.classList).toContain(
+                    'slds-col_bump-right'
+                );
+            });
 
-    it('Layout Item: container orders inheritance', () => {
-        let setContainerSize;
-        element.addEventListener('privatelayoutitemconnected', (event) => {
-            setContainerSize = event.detail.callbacks.setContainerSize;
+            it('alignmentBump = top', () => {
+                document.body.appendChild(element);
+                element.alignmentBump = 'top';
+                expect(element.shadowRoot.host.classList).toContain(
+                    'slds-col_bump-top'
+                );
+            });
+
+            it('alignmentBump = bottom', () => {
+                document.body.appendChild(element);
+                element.alignmentBump = 'bottom';
+                expect(element.shadowRoot.host.classList).toContain(
+                    'slds-col_bump-bottom'
+                );
+            });
         });
-        document.body.appendChild(element);
-        setContainerSize('large');
-        expect(element.shadowRoot.host.style.order).toBe('0');
 
-        element.order = 6;
-        expect(element.shadowRoot.host.style.order).toBe('6');
-        element.largeContainerOrder = 3;
-        expect(element.shadowRoot.host.style.order).toBe('3');
-    });
+        // Container orders
+        describe('Container orders', () => {
+            it('container orders', () => {
+                let setContainerSize;
+                element.addEventListener(
+                    'privatelayoutitemconnected',
+                    (event) => {
+                        setContainerSize =
+                            event.detail.callbacks.setContainerSize;
+                    }
+                );
+                document.body.appendChild(element);
+                expect(element.shadowRoot.host.style.order).toBe('0');
 
-    // Container sizes
-    it('Layout Item: container sizes', () => {
-        let setContainerSize;
-        element.addEventListener('privatelayoutitemconnected', (event) => {
-            setContainerSize = event.detail.callbacks.setContainerSize;
+                element.largeContainerOrder = 3;
+                element.mediumContainerOrder = 2;
+                element.smallContainerOrder = 1;
+                element.order = 6;
+
+                expect(element.shadowRoot.host.style.order).toBe('6');
+                setContainerSize('large');
+                expect(element.shadowRoot.host.style.order).toBe('3');
+                setContainerSize('medium');
+                expect(element.shadowRoot.host.style.order).toBe('2');
+                setContainerSize('small');
+                expect(element.shadowRoot.host.style.order).toBe('1');
+            });
+
+            it('Inheritance', () => {
+                let setContainerSize;
+                element.addEventListener(
+                    'privatelayoutitemconnected',
+                    (event) => {
+                        setContainerSize =
+                            event.detail.callbacks.setContainerSize;
+                    }
+                );
+                document.body.appendChild(element);
+                setContainerSize('large');
+                expect(element.shadowRoot.host.style.order).toBe('0');
+
+                element.order = 6;
+                expect(element.shadowRoot.host.style.order).toBe('6');
+                element.largeContainerOrder = 3;
+                expect(element.shadowRoot.host.style.order).toBe('3');
+            });
         });
-        document.body.appendChild(element);
-        expect(element.shadowRoot.host.style.flexBasis).toBe('auto');
 
-        element.largeContainerSize = '3';
-        element.mediumContainerSize = 12;
-        element.smallContainerSize = 'auto';
-        element.size = '4rem';
+        // Container sizes
+        it('container sizes', () => {
+            let setContainerSize;
+            element.addEventListener('privatelayoutitemconnected', (event) => {
+                setContainerSize = event.detail.callbacks.setContainerSize;
+            });
+            document.body.appendChild(element);
+            expect(element.shadowRoot.host.style.flexBasis).toBe('auto');
 
-        expect(element.shadowRoot.host.style.flexBasis).toBe('4rem');
-        setContainerSize('large');
-        expect(element.shadowRoot.host.style.flexBasis).toBe('25%');
-        setContainerSize('medium');
-        expect(element.shadowRoot.host.style.flexBasis).toBe('100%');
-        setContainerSize('small');
-        expect(element.shadowRoot.host.style.flexBasis).toBe('auto');
+            element.largeContainerSize = '3';
+            element.mediumContainerSize = 12;
+            element.smallContainerSize = 'auto';
+            element.size = '4rem';
+
+            expect(element.shadowRoot.host.style.flexBasis).toBe('4rem');
+            setContainerSize('large');
+            expect(element.shadowRoot.host.style.flexBasis).toBe('25%');
+            setContainerSize('medium');
+            expect(element.shadowRoot.host.style.flexBasis).toBe('100%');
+            setContainerSize('small');
+            expect(element.shadowRoot.host.style.flexBasis).toBe('auto');
+        });
+
+        describe('Grow', () => {
+            it('Ignore invalid value', () => {
+                document.body.appendChild(element);
+                element.grow = -3;
+                expect(element.shadowRoot.host.style.flexGrow).toBe('0');
+
+                element.grow = 'some text';
+                expect(element.shadowRoot.host.style.flexGrow).toBe('0');
+            });
+
+            it('Applied to the host', () => {
+                document.body.appendChild(element);
+                element.grow = 3;
+                expect(element.shadowRoot.host.style.flexGrow).toBe('3');
+            });
+        });
+
+        describe('Shrink', () => {
+            it('Ignore invalid value', () => {
+                document.body.appendChild(element);
+                element.shrink = -3;
+                expect(element.shadowRoot.host.style.flexShrink).toBe('0');
+
+                element.shrink = 'some text';
+                expect(element.shadowRoot.host.style.flexShrink).toBe('0');
+            });
+
+            it('Applied to the host', () => {
+                document.body.appendChild(element);
+                element.shrink = 3;
+                expect(element.shadowRoot.host.style.flexShrink).toBe('3');
+            });
+        });
     });
 
     /*
@@ -133,41 +182,42 @@ describe('Layout Item', () => {
      *  EVENTS
      * -------------------------------------------------------------
      */
+    describe('Events', () => {
+        // Connected and disconnected event
+        it('connected and disconnected events', () => {
+            const connectedHandler = jest.fn();
+            const disconnectedHandler = jest.fn();
+            element.addEventListener(
+                'privatelayoutitemconnected',
+                connectedHandler
+            );
+            element.addEventListener(
+                'privatelayoutitemdisconnected',
+                disconnectedHandler
+            );
+            document.body.appendChild(element);
 
-    // Connected and disconnected event
-    it('Layout Item: connected and disconnected events', () => {
-        const connectedHandler = jest.fn();
-        const disconnectedHandler = jest.fn();
-        element.addEventListener(
-            'privatelayoutitemconnected',
-            connectedHandler
-        );
-        element.addEventListener(
-            'privatelayoutitemdisconnected',
-            disconnectedHandler
-        );
-        document.body.appendChild(element);
+            expect(connectedHandler).toHaveBeenCalled();
+            const connectedCall = connectedHandler.mock.calls[0][0];
+            expect(connectedCall.detail.name).toBeTruthy();
+            expect(typeof connectedCall.detail.name).toBe('string');
+            expect(
+                connectedCall.detail.callbacks.setContainerSize
+            ).toBeInstanceOf(Function);
+            expect(connectedCall.bubbles).toBeTruthy();
+            expect(connectedCall.composed).toBeFalsy();
+            expect(connectedCall.cancelable).toBeFalsy();
 
-        expect(connectedHandler).toHaveBeenCalled();
-        const connectedCall = connectedHandler.mock.calls[0][0];
-        expect(connectedCall.detail.name).toBeTruthy();
-        expect(typeof connectedCall.detail.name).toBe('string');
-        expect(connectedCall.detail.callbacks.setContainerSize).toBeInstanceOf(
-            Function
-        );
-        expect(connectedCall.bubbles).toBeTruthy();
-        expect(connectedCall.composed).toBeFalsy();
-        expect(connectedCall.cancelable).toBeFalsy();
-
-        while (document.body.firstChild) {
-            document.body.removeChild(document.body.firstChild);
-        }
-        expect(disconnectedHandler).toHaveBeenCalled();
-        const disconnectedCall = connectedHandler.mock.calls[0][0];
-        expect(disconnectedCall.detail.name).toBeTruthy();
-        expect(typeof disconnectedCall.detail.name).toBe('string');
-        expect(disconnectedCall.bubbles).toBeTruthy();
-        expect(disconnectedCall.composed).toBeFalsy();
-        expect(disconnectedCall.cancelable).toBeFalsy();
+            while (document.body.firstChild) {
+                document.body.removeChild(document.body.firstChild);
+            }
+            expect(disconnectedHandler).toHaveBeenCalled();
+            const disconnectedCall = connectedHandler.mock.calls[0][0];
+            expect(disconnectedCall.detail.name).toBeTruthy();
+            expect(typeof disconnectedCall.detail.name).toBe('string');
+            expect(disconnectedCall.bubbles).toBeTruthy();
+            expect(disconnectedCall.composed).toBeFalsy();
+            expect(disconnectedCall.cancelable).toBeFalsy();
+        });
     });
 });

--- a/src/modules/base/layoutItem/layoutItem.css
+++ b/src/modules/base/layoutItem/layoutItem.css
@@ -3,6 +3,4 @@
     padding-right: var(--avonni-layout-item-spacing-inline-end, 0);
     padding-top: var(--avonni-layout-item-spacing-block-start, 0);
     padding-bottom: var(--avonni-layout-item-spacing-block-end, 0);
-    flex-grow: var(--avonni-layout-item-layout-flex-grow, 0);
-    flex-shrink: var(--avonni-layout-item-layout-flex-shrink, 1);
 }

--- a/src/modules/base/layoutItem/layoutItem.js
+++ b/src/modules/base/layoutItem/layoutItem.js
@@ -12,6 +12,8 @@ const CONTAINER_WIDTHS = {
     valid: ['default', 'small', 'medium', 'large']
 };
 
+const DEFAULT_GROW = 0;
+const DEFAULT_SHRINK = 1;
 const DEFAULT_SIZE = 'auto';
 
 /**
@@ -23,11 +25,13 @@ const DEFAULT_SIZE = 'auto';
  */
 export default class LayoutItem extends LightningElement {
     _alignmentBump = ALIGNMENT_BUMPS.default;
+    _grow = DEFAULT_GROW;
     _largeContainerOrder;
     _largeContainerSize;
     _mediumContainerOrder;
     _mediumContainerSize;
     _order;
+    _shrink = DEFAULT_SHRINK;
     _size;
     _smallContainerOrder;
     _smallContainerSize;
@@ -108,6 +112,29 @@ export default class LayoutItem extends LightningElement {
             fallbackValue: ALIGNMENT_BUMPS.default,
             validValues: ALIGNMENT_BUMPS.valid
         });
+
+        if (this._connected) {
+            this.updateClassAndStyle();
+        }
+    }
+
+    /**
+     * Positive number representing the grow factor of the column, which specifies how much of the layout's remaining space should be assigned to the item's.
+     *
+     * @type {number}
+     * @default 0
+     * @public
+     */
+    @api
+    get grow() {
+        return this._grow;
+    }
+    set grow(value) {
+        const normalizedNumber = parseFloat(value);
+        this._grow =
+            isNaN(normalizedNumber) || normalizedNumber < 0
+                ? DEFAULT_GROW
+                : normalizedNumber;
 
         if (this._connected) {
             this.updateClassAndStyle();
@@ -212,6 +239,29 @@ export default class LayoutItem extends LightningElement {
         const normalizedNumber = parseInt(value, 10);
         this._order = isNaN(normalizedNumber) ? 0 : normalizedNumber;
         this._orders.default = this.order;
+
+        if (this._connected) {
+            this.updateClassAndStyle();
+        }
+    }
+
+    /**
+     * Positive number representing the shrink factor of the column. If the size of all the items is larger than the size of the layout, items shrink to fit according to this factor.
+     *
+     * @type {number}
+     * @default 1
+     * @public
+     */
+    @api
+    get shrink() {
+        return this._shrink;
+    }
+    set shrink(value) {
+        const normalizedNumber = parseFloat(value);
+        this._shrink =
+            isNaN(normalizedNumber) || normalizedNumber < 0
+                ? DEFAULT_GROW
+                : normalizedNumber;
 
         if (this._connected) {
             this.updateClassAndStyle();
@@ -355,7 +405,8 @@ export default class LayoutItem extends LightningElement {
             'slds-col_bump-bottom': this.alignmentBump === 'bottom'
         });
 
-        this.template.host.style.flexBasis = this.getCurrentValue(this._sizes);
+        const flexBasis = this.getCurrentValue(this._sizes);
+        this.template.host.style.flex = `${this.grow} ${this.shrink} ${flexBasis}`;
         this.template.host.style.order = this.getCurrentValue(this._orders);
     }
 }

--- a/src/modules/base/storybookWrappers/layout/layout.html
+++ b/src/modules/base/storybookWrappers/layout/layout.html
@@ -1,11 +1,9 @@
 <template>
     <div class="slds-box slds-p-around_none">
         <c-layout
-            column-gap={columnGap}
             direction={direction}
             horizontal-align={horizontalAlign}
             multiple-rows={multipleRows}
-            row-gap={rowGap}
             vertical-align={verticalAlign}
         >
             <c-layout-item
@@ -16,9 +14,9 @@
                 style="background: #eae4e9"
                 ><div class="slds-p-around_medium">Responsive sizes 1</div>
             </c-layout-item>
-            <c-layout-item grow="1" style="background: #fff1e6"
+            <c-layout-item grow="1" shrink="0" style="background: #fff1e6"
                 ><div class="slds-p-around_medium">
-                    Growing item
+                    Growing and unshrinkable item
                 </div></c-layout-item
             >
             <c-layout-item
@@ -44,7 +42,7 @@
             >
             <c-layout-item size="200px" style="background: #bee1e6"
                 ><div class="slds-p-around_medium">
-                    Fized size
+                    Fixed size
                 </div></c-layout-item
             >
         </c-layout>

--- a/src/modules/base/storybookWrappers/layout/layout.js
+++ b/src/modules/base/storybookWrappers/layout/layout.js
@@ -1,10 +1,8 @@
 import { LightningElement, api } from 'lwc';
 
 export default class Layout extends LightningElement {
-    @api columnGap;
     @api direction;
     @api horizontalAlign;
     @api multipleRows;
-    @api rowGap;
     @api verticalAlign;
 }


### PR DESCRIPTION
> Remove any mention to `--avonni-layout-item-layout-flex-grow` and `--avonni-layout-item-layout-flex-shrink` from the release notes.

### Features
**Layout Item**
- Added `grow` and `shrink` attributes.