### PR TITLE
[fix] (ABC-1204): Use event end date to set scheduler event colour

### DIFF
--- a/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceBase.test.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceBase.test.js
@@ -659,6 +659,47 @@ describe('Primitive Scheduler Event Occurrence: base', () => {
         });
     });
 
+    // to
+    it('Scheduler event occurence: class is added when the event is done', () => {
+        // Event is in the future
+        element.from = new Date().getTime() + 60000;
+        element.to = new Date().getTime() + 120000;
+
+        return Promise.resolve()
+            .then(() => {
+                const event = element.shadowRoot.querySelector(
+                    '[data-element-id="div-event-content"]'
+                );
+                expect(event.classList).not.toContain(
+                    'avonni-scheduler__event_past'
+                );
+
+                // Event is in the past
+                element.from = new Date().getTime() - 60000;
+                element.to = new Date().getTime() - 10000;
+            })
+            .then(() => {
+                const event = element.shadowRoot.querySelector(
+                    '[data-element-id="div-event-content"]'
+                );
+                expect(event.classList).toContain(
+                    'avonni-scheduler__event_past'
+                );
+
+                // Event is currently happening
+                element.from = new Date().getTime() - 60000;
+                element.to = new Date().getTime() + 120000;
+            })
+            .then(() => {
+                const event = element.shadowRoot.querySelector(
+                    '[data-element-id="div-event-content"]'
+                );
+                expect(event.classList).not.toContain(
+                    'avonni-scheduler__event_past'
+                );
+            });
+    });
+
     // x
     it('Scheduler event occurence: x', () => {
         element.x = 70;

--- a/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
@@ -758,7 +758,7 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
                     !this.displayAsDot && this.occurrence.startsInPreviousCell,
                 'avonni-scheduler__event_standalone-multi-day-ends-in-later-cell':
                     !this.displayAsDot && this.occurrence.endsInLaterCell,
-                'avonni-scheduler__event_past': this.from < Date.now()
+                'avonni-scheduler__event_past': this.to < Date.now()
             })
             .toString();
 


### PR DESCRIPTION
### Fixes
**Scheduler**
- Updated the events background transparency, so it is set to transparent only when the end date is passed, instead of the start date.