### PR TITLE
[fix](ABC-1219): Fix spinner not showing properly when isLoading with no items

### DIFF
--- a/src/modules/base/activityTimeline/activityTimeline.js
+++ b/src/modules/base/activityTimeline/activityTimeline.js
@@ -796,6 +796,8 @@ export default class ActivityTimeline extends LightningElement {
                 this.isLoading,
             'avonni-activity-timeline__spinner':
                 this.items.length && this.isLoading && this.isShowButtonHidden,
+            'slds-p-around_xx-large':
+                !this.items.length && this.isLoading && this.isShowButtonHidden,
             'slds-show_inline-block':
                 this.isLoading && !this.isShowButtonHidden,
             'slds-m-top_small slds-m-bottom_small slds-m-left_small':


### PR DESCRIPTION
### Fixes
**Activity Timeline**
- Set enough space for spinner to show properly when component is loading with no items.
