### PR TITLE
[fix] (ABC-1230): Show card header if only the actions slot is filled

### DIFF
--- a/src/modules/base/card/card.js
+++ b/src/modules/base/card/card.js
@@ -374,6 +374,11 @@ export default class Card extends LightningElement {
     }
 
     get showHeader() {
-        return this.title || this.showTitleSlot || this.iconName;
+        return (
+            this.title ||
+            this.showTitleSlot ||
+            this.iconName ||
+            this.showActionsSlot
+        );
     }
 }


### PR DESCRIPTION
### Fixes
**Card**
- Updated the card so the header is visible when only the actions slot is filled.