### PR TITLE
[fix] (ABC-1237): Prevent nested card from being styled by their parent

### DIFF
--- a/src/modules/base/card/card.css
+++ b/src/modules/base/card/card.css
@@ -162,7 +162,7 @@ article.avonni-card {
 }
 
 .avonni-card__body-container:not(.avonni-card__media-left, .avonni-card__media-right)
-    .avonni-card__media-container {
+    > .avonni-card__media-container {
     width: 100%;
 }
 


### PR DESCRIPTION
### Fixes
**Card**
- Fixed nested cards spacing from being affected by their parent, when nested inside another card.