### PR TITLE
[Feat](ABC-1244): Combobox - Prevents the dropdown menu from closing if isMultiSelect is true

### DIFF
--- a/src/modules/base/primitiveCombobox/primitiveCombobox.js
+++ b/src/modules/base/primitiveCombobox/primitiveCombobox.js
@@ -1751,6 +1751,19 @@ export default class PrimitiveCombobox extends LightningElement {
     }
 
     /**
+     * Updates the visibility of the dropdown menu. If multi-select, prevents the dropdown menu from closing.
+     */
+    updateDropdownMenuVisibility() {
+        if (this.isMultiSelect) {
+            this.computedGroups = [...this.computedGroups];
+        } else {
+            this.close();
+            this.dispatchClose();
+        }
+        this.focus();
+    }
+
+    /**
      * Position the fixed actions and add their height to the listbox padding, to leave room for them in their original position.
      */
     updateFixedActionsHeight() {
@@ -2118,9 +2131,7 @@ export default class PrimitiveCombobox extends LightningElement {
                     );
                 }
             }
-            this.close();
-            this.dispatchClose();
-            this.focus();
+            this.updateDropdownMenuVisibility();
             return;
         }
 
@@ -2135,9 +2146,7 @@ export default class PrimitiveCombobox extends LightningElement {
 
         const action = selectedOption.selected ? 'select' : 'unselect';
         this.dispatchChange(action, selectedOption.levelPath);
-        this.close();
-        this.dispatchClose();
-        this.focus();
+        this.updateDropdownMenuVisibility();
     }
 
     /**


### PR DESCRIPTION
<!-- Are you sure you're ready to open a pull request? -->
<!-- Checkout the list first: https://avonnicreator.atlassian.net/wiki/spaces/LDG/pages/2140766209/Can+I+open+a+pull+request -->
<!-- Then use this template to explain what you did: -->

### Features
**Combobox**
- Prevents the dropdown menu from closing if `isMultiSelect` is set to true.

<!-- Don't forget to edit and remove what's unnecessary! -->
<!-- See the Release Notes for real examples: https://www.avonnicomponents.com/release-notes -->
