### PR TITLE
[fix] (ABC-1251): Prevent focus on previous calendar month's date

### DIFF
--- a/src/modules/base/calendar/__tests__/calendar.test.js
+++ b/src/modules/base/calendar/__tests__/calendar.test.js
@@ -123,13 +123,16 @@ describe('Calendar', () => {
 
     // Focus Date
     it('Calendar: focusDate', () => {
-        element.value = '05/12/2022';
+        element.value = new Date(2022, 8, 5);
 
         return Promise.resolve().then(() => {
-            const day8 = element.shadowRoot.querySelector('td[data-date="8"]');
+            const date = new Date(2022, 8, 8);
+            const day8 = element.shadowRoot.querySelector(
+                `td[data-full-date="${date.getTime()}"]`
+            );
             const spy8 = jest.spyOn(day8, 'focus');
 
-            element.focusDate(new Date(2022, 7, 8));
+            element.focusDate(date);
             jest.runAllTimers();
 
             expect(spy8).toHaveBeenCalled();

--- a/src/modules/base/calendar/calendar.js
+++ b/src/modules/base/calendar/calendar.js
@@ -623,7 +623,7 @@ export default class Calendar extends LightningElement {
         // if a date was previously selected or focused, focus the same date in this month.
         let selectedMonthDate, rovingDate;
         if (this._focusDate) {
-            rovingDate = this._focusDate.day;
+            rovingDate = this._focusDate.ts;
             selectedMonthDate = this.displayDate.set({
                 day: this._focusDate.day
             }).ts;
@@ -634,7 +634,7 @@ export default class Calendar extends LightningElement {
 
         requestAnimationFrame(() => {
             const rovingFocusDate = this.template.querySelector(
-                `[data-element-id="td"][data-date="${rovingDate}"]`
+                `[data-element-id="td"][data-full-date="${rovingDate}"]`
             );
             const selectedDates = this.template.querySelectorAll(
                 '[data-selected="true"]'


### PR DESCRIPTION
### Fixes
**Calendar**
- Prevented focus on previous month's date, when the current month's focused date has the same number (for example focusing the 28th of June when the date that should be focused is the 28th of July).