### PR TITLE
[fix] (ABC-1262): Prevent error when combobox option value is empty

### DIFF
--- a/src/modules/base/primitiveCombobox/primitiveCombobox.js
+++ b/src/modules/base/primitiveCombobox/primitiveCombobox.js
@@ -1689,6 +1689,7 @@ export default class PrimitiveCombobox extends LightningElement {
     getOption(value, options = this.options) {
         let option = options.find((opt) => {
             return (
+                opt.value &&
                 (value || value === 0) &&
                 opt.value.toString() === value.toString()
             );


### PR DESCRIPTION
No changes compared to previous package version.