### PR TITLE
[fix] (ABC-1286): Display time using locale in monthly calendar scheduler

### DIFF
--- a/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceCalendar.test.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/__tests__/primitiveSchedulerEventOccurrenceCalendar.test.js
@@ -226,7 +226,7 @@ describe('Primitive Scheduler Event Occurrence: calendar variants', () => {
                 '[data-element-id="span-time-label"]'
             );
             expect(leftLabel).toBeFalsy();
-            expect(time.textContent).toBe('03:45');
+            expect(time.textContent).toContain('3:45');
             expect(centerLabel.className).toBe(
                 'slds-truncate slds-grid avonni-scheduler__event-label_center slds-grid_vertical-align-center'
             );

--- a/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
+++ b/src/modules/base/primitiveSchedulerEventOccurrence/primitiveSchedulerEventOccurrence.js
@@ -1063,7 +1063,7 @@ export default class PrimitiveSchedulerEventOccurrence extends LightningElement 
     }
 
     get startTime() {
-        return this.from ? this.from.toFormat('HH:mm') : '';
+        return this.from ? this.from.toFormat('t') : '';
     }
 
     /**


### PR DESCRIPTION
### Fixes
**Scheduler**
- Fixed the time display in the monthly calendar, when the locale should be using 12-hour system.