### PR TITLE
[feat](ABC-1320): Remove the bold label for Visual Picker and Vertical Visual Picker

### DIFF
--- a/src/modules/base/verticalVisualPicker/__docs__/verticalVisualPicker.jsdoc.js
+++ b/src/modules/base/verticalVisualPicker/__docs__/verticalVisualPicker.jsdoc.js
@@ -62,7 +62,7 @@
 /**
  * @memberof stylingHooks
  * @name --avonni-vertical-visual-picker-header-font-weight
- * @default 700
+ * @default 400
  * @type font
  */
 /**

--- a/src/modules/base/verticalVisualPicker/verticalVisualPicker.css
+++ b/src/modules/base/verticalVisualPicker/verticalVisualPicker.css
@@ -223,7 +223,7 @@
     color: var(--avonni-vertical-visual-picker-header-text-color, #3e3e3c);
     font-size: var(--avonni-vertical-visual-picker-header-font-size, 0.75rem);
     font-style: var(--avonni-vertical-visual-picker-header-font-style, normal);
-    font-weight: var(--avonni-vertical-visual-picker-header-font-weight, 700);
+    font-weight: var(--avonni-vertical-visual-picker-header-font-weight, 400);
 }
 
 /*-- title --*/

--- a/src/modules/base/visualPicker/__docs__/visualPicker.jsdoc.js
+++ b/src/modules/base/visualPicker/__docs__/visualPicker.jsdoc.js
@@ -83,12 +83,6 @@
  */
 /**
  * @memberof stylingHooks
- * @name --avonni-visual-picker-header-font-weight
- * @default 700
- * @type font
- */
-/**
- * @memberof stylingHooks
  * @name --avonni-visual-picker-header-font-style
  * @default normal
  * @type font
@@ -96,7 +90,7 @@
 /**
  * @memberof stylingHooks
  * @name --avonni-visual-picker-header-font-weight
- * @default 700
+ * @default 400
  * @type font
  */
 /**

--- a/src/modules/base/visualPicker/visualPicker.css
+++ b/src/modules/base/visualPicker/visualPicker.css
@@ -308,7 +308,7 @@
     color: var(--avonni-visual-picker-header-text-color, #3e3e3c);
     font-size: var(--avonni-visual-picker-header-font-size, 0.75rem);
     font-style: var(--avonni-visual-picker-header-font-style, normal);
-    font-weight: var(--avonni-visual-picker-header-font-weight, 700);
+    font-weight: var(--avonni-visual-picker-header-font-weight, 400);
 }
 
 /*-- title --*/


### PR DESCRIPTION
<!-- Are you sure you're ready to open a pull request? -->
<!-- Checkout the list first: https://avonnicreator.atlassian.net/wiki/spaces/LDG/pages/2140766209/Can+I+open+a+pull+request -->
<!-- Then use this template to explain what you did: -->

### Features
**Visual Picker**
- Fallback value for `--avonni-visual-picker-header-font-weight` is now 400 instead of 700.

**Vertical Visual Picker**
- Fallback value for `--avonni-vertical-visual-picker-header-font-weight` is now 400 instead of 700.


<!-- Don't forget to edit and remove what's unnecessary! -->
<!-- See the Release Notes for real examples: https://www.avonnicomponents.com/release-notes -->
