### PR TITLE
[fix](ABC-1324): Avatar Group - Issue "Show More" button with empty list of hidden items

### DIFF
--- a/src/modules/base/avatarGroup/avatarGroup.html
+++ b/src/modules/base/avatarGroup/avatarGroup.html
@@ -206,7 +206,7 @@
 
                 <!-- Hidden items -->
                 <div
-                    if:true={showHiddenItems}
+                    if:true={showHiddenItemsPopover}
                     class={hiddenListClass}
                     role="dialog"
                     aria-labelledby="show-more-label"

--- a/src/modules/base/avatarGroup/avatarGroup.js
+++ b/src/modules/base/avatarGroup/avatarGroup.js
@@ -768,6 +768,19 @@ export default class AvatarGroup extends LightningElement {
     }
 
     /**
+     * True if the show more button is visible and the popover is toggled.
+     *
+     * @type {boolean}
+     */
+    get showHiddenItemsPopover() {
+        return (
+            this.showMoreButton &&
+            this.showHiddenItems &&
+            this.hiddenItems.length > 0
+        );
+    }
+
+    /**
      * True if is loading, there is no show more button or the layout is not "list"
      *
      * @type {boolean}
@@ -1096,8 +1109,15 @@ export default class AvatarGroup extends LightningElement {
     }
 
     startPositioning() {
+        const popover = this.template.querySelector(
+            '[data-element-id="div-hidden-items-popover"]'
+        );
+        if (!popover) {
+            return;
+        }
+
         this._positioning = true;
-        return animationFrame()
+        animationFrame()
             .then(() => {
                 this.stopPositioning();
                 this._autoPosition = startPositioning(


### PR DESCRIPTION
<!-- Are you sure you're ready to open a pull request? -->
<!-- Checkout the list first: https://avonnicreator.atlassian.net/wiki/spaces/LDG/pages/2140766209/Can+I+open+a+pull+request -->
<!-- Then use this template to explain what you did: -->

### Fixes
**Avatar Group**
- Fixed issue with the "show more" popover not displaying correctly.

<!-- Don't forget to edit and remove what's unnecessary! -->
<!-- See the Release Notes for real examples: https://www.avonnicomponents.com/release-notes -->
