### PR TITLE
[fix] (ABC-1330): Fix button menu width when items have an icon

### DIFF
--- a/src/modules/base/buttonMenu/buttonMenu.css
+++ b/src/modules/base/buttonMenu/buttonMenu.css
@@ -68,6 +68,7 @@
 
 .avonni-button-menu__dropdown {
     max-width: var(--avonni-button-menu-dropdown-max-width, 20rem);
+    width: max-content;
 }
 
 .avonni-button-menu__dropdown-gap-cover {


### PR DESCRIPTION
### Fixes
**Button Menu**
- Fixed issue with dropdown width when it contained lightning items with icons. The issue was present in the Salesforce platform starting with the Spring'25 release.
