### PR TITLE
[fix] (ABC-1337): Avoid error if tooltip is destroyed before init

### DIFF
--- a/src/modules/base/tooltipLibrary/tooltipLibrary.js
+++ b/src/modules/base/tooltipLibrary/tooltipLibrary.js
@@ -423,9 +423,10 @@ export class Tooltip {
         this.hide();
         this.removeAllListeners();
 
-        const previousValue = target
-            .getAttribute(ARIA_DESCRIBEDBY)
-            .replace(`${this._element().id}`, '');
+        let previousValue = target.getAttribute(ARIA_DESCRIBEDBY);
+        if (previousValue) {
+            previousValue = previousValue.replace(`${this._element().id}`, '');
+        }
         const ariaDescribedBy = normalizeAriaAttribute([previousValue]);
         if (ariaDescribedBy) {
             target.setAttribute(ARIA_DESCRIBEDBY, ariaDescribedBy);


### PR DESCRIPTION
No changes compared to previous package version.