### PR TITLE
[Fix](ABC-1350): Combobox - Remove invalid input error after item deselect

### DIFF
--- a/src/modules/base/combobox/__docs__/combobox.stories.js
+++ b/src/modules/base/combobox/__docs__/combobox.stories.js
@@ -439,8 +439,9 @@ export default {
         selectedOptionsDirection: {
             name: 'selected-options-direction',
             control: {
-                type: 'text'
+                type: 'select'
             },
+            options: ['horizontal', 'vertical'],
             description:
                 'Direction of the selected options. Horizontally, the selected options will be displayed as pills. Vertically, the selected options will be displayed as a list.',
             table: {

--- a/src/modules/base/primitiveCombobox/primitiveCombobox.js
+++ b/src/modules/base/primitiveCombobox/primitiveCombobox.js
@@ -2192,7 +2192,11 @@ export default class PrimitiveCombobox extends LightningElement {
         if (!this.isMultiSelect && !selectedOption.selected) {
             this._unselectOption();
         }
-        selectedOption.selected = !selectedOption.selected;
+        if (!this.isMultiSelect && this.required && selectedOption.selected) {
+            selectedOption.selected = true;
+        } else {
+            selectedOption.selected = !selectedOption.selected;
+        }
 
         this._computeSelection();
 
@@ -2208,15 +2212,6 @@ export default class PrimitiveCombobox extends LightningElement {
                         (option) => option.value
                     );
                 }
-            }
-            if (
-                this.validity.valueMissing &&
-                !this.isMultiSelect &&
-                !selectedOption.selected
-            ) {
-                selectedOption.selected = true;
-                this.inputValue = selectedOption.label;
-                this.selectedOption = selectedOption;
             }
             this._updateDropdownMenuVisibility();
             return;


### PR DESCRIPTION
<!-- Are you sure you're ready to open a pull request? -->
<!-- Checkout the list first: https://avonnicreator.atlassian.net/wiki/spaces/LDG/pages/2140766209/Can+I+open+a+pull+request -->
<!-- Then use this template to explain what you did: -->

### Fixes
**Combobox**
- Removed invalid error after item deselect for `required` and non multi-select input.

<!-- Don't forget to edit and remove what's unnecessary! -->
<!-- See the Release Notes for real examples: https://www.avonnicomponents.com/release-notes -->
