### PR TITLE
[defaults] (ABC-1370): Remove min height of auto-positioned combobox

### DIFF
--- a/src/modules/base/primitiveCombobox/primitiveCombobox.js
+++ b/src/modules/base/primitiveCombobox/primitiveCombobox.js
@@ -1693,10 +1693,7 @@ export default class PrimitiveCombobox extends LightningElement {
             },
             autoFlip: true,
             alignWidth: true,
-            autoShrinkHeight: true,
-            minHeight:
-                // Same configuration as lightning-combobox
-                this._visibleOptions.length < 3 ? '2.25rem' : '6.75rem'
+            autoShrinkHeight: true
         });
     }
 


### PR DESCRIPTION
### Fixes
**Combobox**
- Removed the minimum height of the dropdown when it is auto-positioned.