### PR TITLE
[fix] (ABC-1386): Fix select all nested children in filter menu

### DIFF
--- a/src/modules/base/filterMenu/nestedItemsUtils.js
+++ b/src/modules/base/filterMenu/nestedItemsUtils.js
@@ -29,7 +29,7 @@ function _selectChildren({ item, cascade, selectedItems }) {
         child.updateActions();
 
         if (cascade) {
-            _selectChildren({ item: child, selectedItems });
+            _selectChildren({ item: child, cascade, selectedItems });
         }
     });
 }


### PR DESCRIPTION
No changes compared to previous package version.