### PR TITLE
[feat] (ABC-1455): Avatar - Entity styling hooks

### DIFF
--- a/src/modules/base/avatar/__docs__/avatar.jsdoc.js
+++ b/src/modules/base/avatar/__docs__/avatar.jsdoc.js
@@ -207,6 +207,50 @@
  */
 /**
  * @memberof stylingHooks
+ * @name --avonni-avatar-entity-border-radius
+ * @default 0
+ * @type dimension
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-avatar-entity-border-color
+ * @default transparent
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-avatar-entity-border-style
+ * @default none
+ * @type styling
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-avatar-entity-border-size
+ * @default 0
+ * @type sizing
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-avatar-entity-background-color
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-avatar-entity-foreground-color
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-avatar-entity-foreground-color-utility
+ * @type color
+ */
+/**
+ * @memberof stylingHooks
+ * @name --avonni-avatar-entity-image-object-fit
+ * @type string
+ */
+/**
+ * @memberof stylingHooks
  * @name --avonni-avatar-entity-initials-text-color
  * @default #ffffff
  * @type color

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.css
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.css
@@ -479,7 +479,7 @@
     font-weight: var(--avonni-avatar-entity-initials-text-font-weight, 400);
     border-radius: var(--avonni-avatar-entity-border-radius, 0);
     border-color: var(--avonni-avatar-entity-border-color, transparent);
-    border-style: var(--avonni-avatar-entity-border-style, none);
+    border-style: var(--avonni-avatar-entity-border-style, solid);
     border-width: var(--avonni-avatar-entity-border-size, 0);
     background-color: var(--avonni-avatar-entity-background-color, transparent);
 }

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.css
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.css
@@ -475,15 +475,42 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--avonni-avatar-entity-initials-text-color, #ffffff);
     font-style: var(--avonni-avatar-entity-initials-text-font-style, normal);
     font-weight: var(--avonni-avatar-entity-initials-text-font-weight, 400);
+    border-radius: var(--avonni-avatar-entity-border-radius, 0);
+    border-color: var(--avonni-avatar-entity-border-color, transparent);
+    border-style: var(--avonni-avatar-entity-border-style, none);
+    border-width: var(--avonni-avatar-entity-border-size, 0);
+    background-color: var(--avonni-avatar-entity-background-color, transparent);
+}
+
+.avonni-avatar__entity_circle {
+    border-radius: var(
+        --avonni-avatar-entity-border-radius,
+        var(--lwc-borderRadiusCircle, 50%)
+    );
+}
+
+.avonni-avatar__entity-image {
+    height: 100%;
+    width: 100%;
+    object-fit: var(--avonni-avatar-entity-image-object-fit, cover);
+}
+
+.avonni-avatar__entity-initials {
+    color: var(--avonni-avatar-entity-initials-text-color, #ffffff);
 }
 
 /* Makes the icon size change with its container's */
 .avonni-avatar__entity-icon {
     display: flex;
     width: inherit;
+    --slds-c-icon-color-foreground: var(
+        --avonni-avatar-entity-foreground-color
+    );
+    --slds-c-icon-color-foreground-default: var(
+        --avonni-avatar-entity-foreground-color-utility
+    );
 }
 
 .avonni-avatar_xx-small .avonni-avatar__entity,

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.html
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.html
@@ -92,18 +92,17 @@
         <!-- Entity -->
         <div if:true={showEntity} class={computedEntityClass}>
             <!-- Image -->
-            <div if:true={entitySrc}>
-                <img
-                    class="avonni-avatar__entity-image"
-                    alt={entityTitle}
-                    src={entitySrc}
-                    title={entityTitle}
-                    onerror={handleImageError}
-                />
-            </div>
+            <img
+                if:true={entitySrc}
+                class="avonni-avatar__entity-image"
+                alt={entityTitle}
+                src={entitySrc}
+                title={entityTitle}
+                onerror={handleImageError}
+            />
             <!-- Initials -->
             <abbr
-                if:true={entityInitials}
+                if:true={showEntityInitials}
                 class={computedEntityInitialsClass}
                 aria-hidden="true"
                 title={entityTitle}

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.html
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.html
@@ -92,13 +92,16 @@
         <!-- Entity -->
         <div if:true={showEntity} class={computedEntityClass}>
             <!-- Image -->
-            <img
-                if:true={entitySrc}
-                alt={entityTitle}
-                src={entitySrc}
-                title={entityTitle}
-                onerror={handleImageError}
-            />
+            <div>
+                <img
+                    if:true={entitySrc}
+                    class="avonni-avatar__entity-image"
+                    alt={entityTitle}
+                    src={entitySrc}
+                    title={entityTitle}
+                    onerror={handleImageError}
+                />
+            </div>
             <!-- Initials -->
             <abbr
                 if:true={entityInitials}

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.html
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.html
@@ -92,9 +92,8 @@
         <!-- Entity -->
         <div if:true={showEntity} class={computedEntityClass}>
             <!-- Image -->
-            <div>
+            <div if:true={entitySrc}>
                 <img
-                    if:true={entitySrc}
                     class="avonni-avatar__entity-image"
                     alt={entityTitle}
                     src={entitySrc}

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.js
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.js
@@ -385,6 +385,10 @@ export default class PrimitiveAvatar extends LightningElement {
         return !this.entitySrc && !this.entityInitials;
     }
 
+    get showEntityInitials() {
+        return !this.entitySrc && this.entityInitials;
+    }
+
     get showIcon() {
         return !this._src && !this.initials;
     }

--- a/src/modules/base/primitiveAvatar/primitiveAvatar.js
+++ b/src/modules/base/primitiveAvatar/primitiveAvatar.js
@@ -344,7 +344,7 @@ export default class PrimitiveAvatar extends LightningElement {
     }
 
     get computedEntityInitialsClass() {
-        return classSet('slds-avatar__initials')
+        return classSet('slds-avatar__initials avonni-avatar__entity-initials')
             .add(computeSldsClass(this.entityIconName))
             .toString();
     }
@@ -410,11 +410,11 @@ export default class PrimitiveAvatar extends LightningElement {
             : '';
 
         this.computedEntityClass = classSet(
-            `avonni-avatar slds-current-color avonni-avatar__entity slds-icon-${iconCategory}-${iconName}`
+            `avonni-avatar avonni-avatar__entity slds-icon-${iconCategory}-${iconName}`
         )
             .add(`avonni-avatar_${entityPosition}`)
             .add({
-                'slds-avatar_circle': entityVariant === 'circle'
+                'avonni-avatar__entity_circle': entityVariant === 'circle'
             });
     }
 


### PR DESCRIPTION
### Features
**Avatar**
- Added styling hooks for the `entity`.
    - `--avonni-avatar-entity-border-radius`
    - `--avonni-avatar-entity-border-color`
    - `--avonni-avatar-entity-border-style`
    - `--avonni-avatar-entity-border-size`
    - `--avonni-avatar-entity-background-color`
    - `--avonni-avatar-entity-foreground-color`
    - `--avonni-avatar-entity-foreground-color-utility`
    - `--avonni-avatar-entity-image-object-fit`

### Fixes
**Avatar**
- Fixed the `entity` variant not changing the `border-radius` of the `entity`
- Disabled simultaneous display of an `image` and `initials` within the `entity`.
