### PR TITLE
[feat] (ABC-1454): Horizontal Filter Menu - Refactor

### DIFF
--- a/jest-mock/components/base/filterMenu/filterMenu.js
+++ b/jest-mock/components/base/filterMenu/filterMenu.js
@@ -5,6 +5,8 @@ export default class FilterMenu extends LightningElement {
     @api alternativeText;
     @api applyButtonLabel;
     @api buttonVariant;
+    @api closed;
+    @api collapsible;
     @api disabled;
     @api dropdownAlignment;
     @api dropdownNubbin;
@@ -17,6 +19,7 @@ export default class FilterMenu extends LightningElement {
     @api loadingStateAlternativeText;
     @api name;
     @api resetButtonLabel;
+    @api showSelectedFilterValueCount;
     @api title;
     @api tooltip;
     @api type;
@@ -27,5 +30,6 @@ export default class FilterMenu extends LightningElement {
     @api apply() {}
     @api clear() {}
     @api focus() {}
+    @api focusSearchInput() {}
     @api reset() {}
 }

--- a/jest-mock/components/base/filterMenu/filterMenu.js
+++ b/jest-mock/components/base/filterMenu/filterMenu.js
@@ -10,6 +10,7 @@ export default class FilterMenu extends LightningElement {
     @api disabled;
     @api dropdownAlignment;
     @api dropdownNubbin;
+    @api hideApplyButton;
     @api hideApplyResetButtons;
     @api hideSelectedItems;
     @api iconName;

--- a/src/modules/base/filterMenu/__docs__/filterMenu.stories.js
+++ b/src/modules/base/filterMenu/__docs__/filterMenu.stories.js
@@ -233,6 +233,19 @@ export default {
                 category: 'Button'
             }
         },
+        showSelectedFilterValueCount: {
+            name: 'show-selected-filter-value-count',
+            control: {
+                type: 'boolean'
+            },
+            description:
+                'If present, the selected filter value and count are displayed in the label.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' },
+                category: 'Button'
+            }
+        },
         title: {
             control: {
                 type: 'text'
@@ -311,6 +324,7 @@ export default {
         isLoading: false,
         loadingStateAlternativeText: 'Loading...',
         resetButtonLabel: 'Reset',
+        showSelectedFilterValueCount: false,
         type: 'list',
         variant: 'horizontal'
     }

--- a/src/modules/base/filterMenu/__docs__/filterMenu.stories.js
+++ b/src/modules/base/filterMenu/__docs__/filterMenu.stories.js
@@ -50,10 +50,11 @@ export default {
                 'container',
                 'border-filled',
                 'bare-inverse',
-                'border-inverse'
+                'border-inverse',
+                'outline-brand'
             ],
             description:
-                'The button variant changes the look of the horizontal variant’s button. Accepted variants include bare, container, border, border-filled, bare-inverse, and border-inverse. This attribute isn’t supported for the vertical variant.',
+                'The button variant changes the look of the horizontal variant’s button. Accepted variants include bare, container, border, border-filled, outline-brand, bare-inverse, and border-inverse. This attribute isn’t supported for the vertical variant.',
             table: {
                 type: { summary: 'string' },
                 defaultValue: { summary: 'border' },

--- a/src/modules/base/filterMenu/__docs__/filterMenu.stories.js
+++ b/src/modules/base/filterMenu/__docs__/filterMenu.stories.js
@@ -128,6 +128,18 @@ export default {
                 category: 'Dropdown menu'
             }
         },
+        hideApplyButton: {
+            name: 'hide-apply-button',
+            control: {
+                type: 'boolean'
+            },
+            description: 'If present, the apply button is hidden.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' },
+                category: 'Button'
+            }
+        },
         hideApplyResetButtons: {
             name: 'hide-apply-reset-buttons',
             control: {
@@ -319,6 +331,7 @@ export default {
         disabled: false,
         dropdownAlignment: 'left',
         dropdownNubbin: false,
+        hideApplyButton: false,
         hideApplyResetButtons: false,
         hideSelectedItems: false,
         iconSize: 'medium',

--- a/src/modules/base/filterMenu/__examples__/filterMenu.js
+++ b/src/modules/base/filterMenu/__examples__/filterMenu.js
@@ -24,6 +24,7 @@ export const FilterMenu = ({
     loadingStateAlternativeText,
     name,
     resetButtonLabel,
+    showSelectedFilterValueCount,
     title,
     tooltip,
     type,
@@ -50,6 +51,7 @@ export const FilterMenu = ({
     element.loadingStateAlternativeText = loadingStateAlternativeText;
     element.name = name;
     element.resetButtonLabel = resetButtonLabel;
+    element.showSelectedFilterValueCount = showSelectedFilterValueCount;
     element.title = title;
     element.tooltip = tooltip;
     element.type = type;

--- a/src/modules/base/filterMenu/__examples__/filterMenu.js
+++ b/src/modules/base/filterMenu/__examples__/filterMenu.js
@@ -15,6 +15,7 @@ export const FilterMenu = ({
     disabled,
     dropdownAlignment,
     dropdownNubbin,
+    hideApplyButton,
     hideApplyResetButtons,
     hideSelectedItems,
     iconName,
@@ -42,6 +43,7 @@ export const FilterMenu = ({
     element.disabled = disabled;
     element.dropdownAlignment = dropdownAlignment;
     element.dropdownNubbin = dropdownNubbin;
+    element.hideApplyButton = hideApplyButton;
     element.hideApplyResetButtons = hideApplyResetButtons;
     element.hideSelectedItems = hideSelectedItems;
     element.iconName = iconName;

--- a/src/modules/base/filterMenu/__examples__/infiniteLoading.js
+++ b/src/modules/base/filterMenu/__examples__/infiniteLoading.js
@@ -15,6 +15,7 @@ export const FilterMenuInfiniteLoading = ({
     disabled,
     dropdownAlignment,
     dropdownNubbin,
+    hideApplyButton,
     hideApplyResetButtons,
     hideSelectedItems,
     iconName,
@@ -44,6 +45,7 @@ export const FilterMenuInfiniteLoading = ({
     element.disabled = disabled;
     element.dropdownAlignment = dropdownAlignment;
     element.dropdownNubbin = dropdownNubbin;
+    element.hideApplyButton = hideApplyButton;
     element.hideApplyResetButtons = hideApplyResetButtons;
     element.hideSelectedItems = hideSelectedItems;
     element.iconName = iconName;

--- a/src/modules/base/filterMenu/__examples__/infiniteLoading.js
+++ b/src/modules/base/filterMenu/__examples__/infiniteLoading.js
@@ -24,6 +24,7 @@ export const FilterMenuInfiniteLoading = ({
     loadingStateAlternativeText,
     name,
     resetButtonLabel,
+    showSelectedFilterValueCount,
     title,
     tooltip,
     type,
@@ -52,6 +53,7 @@ export const FilterMenuInfiniteLoading = ({
     element.loadingStateAlternativeText = loadingStateAlternativeText;
     element.name = name;
     element.resetButtonLabel = resetButtonLabel;
+    element.showSelectedFilterValueCount = showSelectedFilterValueCount;
     element.title = title;
     element.tooltip = tooltip;
     element.type = type;

--- a/src/modules/base/filterMenu/__tests__/filterMenu.test.js
+++ b/src/modules/base/filterMenu/__tests__/filterMenu.test.js
@@ -95,6 +95,7 @@ describe('Filter Menu', () => {
             expect(element.loadingStateAlternativeText).toBe('Loading...');
             expect(element.name).toBeUndefined();
             expect(element.resetButtonLabel).toBe('Clear selection');
+            expect(element.showSelectedFilterValueCount).toBeFalsy();
             expect(element.title).toBeUndefined();
             expect(element.tooltip).toBeUndefined();
             expect(element.type).toBe('list');
@@ -365,6 +366,20 @@ describe('Filter Menu', () => {
                     );
                     expect(button.classList.value).toBe(
                         'slds-button slds-button_icon-border-inverse'
+                    );
+                });
+            });
+
+            it('outline-brand, with label', () => {
+                element.buttonVariant = 'outline-brand';
+                element.label = 'A string label';
+
+                return Promise.resolve().then(() => {
+                    const button = element.shadowRoot.querySelector(
+                        '[data-element-id="button"]'
+                    );
+                    expect(button.classList.value).toBe(
+                        'slds-button slds-button_outline-brand'
                     );
                 });
             });
@@ -1283,6 +1298,40 @@ describe('Filter Menu', () => {
                         '.slds-dropdown lightning-button:first-of-type'
                     );
                     expect(resetButton.label).toBe('A string label');
+                });
+            });
+        });
+
+        describe('Show Selected Filter Value Count', () => {
+            it('showSelectedFilterValueCount, true', () => {
+                element.showSelectedFilterValueCount = true;
+                element.selectedItems = ITEMS;
+
+                return Promise.resolve().then(() => {
+                    const selectedLabels = element.shadowRoot.querySelector(
+                        '[data-element-id="span-menu-selected-labels"]'
+                    );
+                    const selectedCount = element.shadowRoot.querySelector(
+                        '[data-element-id="span-menu-selected-item-count"]'
+                    );
+                    expect(selectedLabels).toBeDefined();
+                    expect(selectedCount).toBeDefined();
+                });
+            });
+
+            it('showSelectedFilterValueCount, false', () => {
+                element.showSelectedFilterValueCount = false;
+                element.selectedItems = ITEMS;
+
+                return Promise.resolve().then(() => {
+                    const selectedLabels = element.shadowRoot.querySelector(
+                        '[data-element-id="span-menu-selected-labels"]'
+                    );
+                    const selectedCount = element.shadowRoot.querySelector(
+                        '[data-element-id="span-menu-selected-item-count"]'
+                    );
+                    expect(selectedLabels).toBeFalsy();
+                    expect(selectedCount).toBeFalsy();
                 });
             });
         });

--- a/src/modules/base/filterMenu/__tests__/filterMenu.test.js
+++ b/src/modules/base/filterMenu/__tests__/filterMenu.test.js
@@ -94,7 +94,7 @@ describe('Filter Menu', () => {
             expect(element.label).toBeUndefined();
             expect(element.loadingStateAlternativeText).toBe('Loading...');
             expect(element.name).toBeUndefined();
-            expect(element.resetButtonLabel).toBe('Reset');
+            expect(element.resetButtonLabel).toBe('Clear selection');
             expect(element.title).toBeUndefined();
             expect(element.tooltip).toBeUndefined();
             expect(element.type).toBe('list');
@@ -125,24 +125,6 @@ describe('Filter Menu', () => {
                         '.slds-assistive-text'
                     );
                     expect(altText.textContent).toBe('A string alt text');
-                });
-            });
-        });
-
-        describe('Apply Button Label', () => {
-            it('applyButtonLabel', () => {
-                element.typeAttributes = { items: ITEMS };
-                element.applyButtonLabel = 'A string label';
-                const button = element.shadowRoot.querySelector(
-                    '[data-element-id="button"]'
-                );
-                button.click();
-
-                return Promise.resolve().then(() => {
-                    const submitButton = element.shadowRoot.querySelector(
-                        '[data-element-id="lightning-button-apply"]'
-                    );
-                    expect(submitButton.label).toBe('A string label');
                 });
             });
         });
@@ -845,7 +827,7 @@ describe('Filter Menu', () => {
                     const buttons = element.shadowRoot.querySelectorAll(
                         '[data-element-id^="lightning-button"]'
                     );
-                    expect(buttons).toHaveLength(2);
+                    expect(buttons).toHaveLength(1);
                 });
             });
 
@@ -1126,9 +1108,6 @@ describe('Filter Menu', () => {
                     const items = element.shadowRoot.querySelectorAll(
                         '[data-element-id="a-list-item"]'
                     );
-                    const apply = element.shadowRoot.querySelector(
-                        '[data-element-id="lightning-button-apply"]'
-                    );
                     const reset = element.shadowRoot.querySelector(
                         '[data-element-id="lightning-button-reset"]'
                     );
@@ -1136,7 +1115,6 @@ describe('Filter Menu', () => {
                         '[data-element-id="p-no-results-message"]'
                     );
 
-                    expect(apply).toBeTruthy();
                     expect(reset).toBeTruthy();
                     expect(noResultMessage).toBeFalsy();
                     expect(items).toHaveLength(6);
@@ -1801,6 +1779,9 @@ describe('Filter Menu', () => {
                         ]);
                     })
                     .then(() => {
+                        button.click();
+                    })
+                    .then(() => {
                         const item = element.shadowRoot.querySelector(
                             '[data-element-id="a-list-item"][data-index="1"]'
                         );
@@ -2002,7 +1983,6 @@ describe('Filter Menu', () => {
                         expect(items[0].ariaChecked).toBe('true');
                         expect(items[1].ariaChecked).toBe('true');
                         expect(items[2].ariaChecked).toBe('false');
-
                         items[2].click();
                     })
                     .then(() => {
@@ -2016,25 +1996,25 @@ describe('Filter Menu', () => {
                         element.value = JSON.parse(JSON.stringify(VALUE));
                     })
                     .then(() => {
-                        // Selected items were not erased
-                        // because the new value was identical
-                        const items = element.shadowRoot.querySelectorAll(
-                            '[data-element-id="a-list-item"]'
-                        );
-                        expect(items[0].ariaChecked).toBe('true');
-                        expect(items[1].ariaChecked).toBe('true');
-                        expect(items[2].ariaChecked).toBe('true');
-
-                        element.value = [VALUE[0]];
-                    })
-                    .then(() => {
                         // Selected items were erased
                         // because the new value was different
                         const items = element.shadowRoot.querySelectorAll(
                             '[data-element-id="a-list-item"]'
                         );
                         expect(items[0].ariaChecked).toBe('true');
-                        expect(items[1].ariaChecked).toBe('false');
+                        expect(items[1].ariaChecked).toBe('true');
+                        expect(items[2].ariaChecked).toBe('false');
+
+                        element.value = JSON.parse(JSON.stringify(VALUE));
+                    })
+                    .then(() => {
+                        // Selected items were erased
+                        // because the new value was identical
+                        const items = element.shadowRoot.querySelectorAll(
+                            '[data-element-id="a-list-item"]'
+                        );
+                        expect(items[0].ariaChecked).toBe('true');
+                        expect(items[1].ariaChecked).toBe('true');
                         expect(items[2].ariaChecked).toBe('false');
                     });
             });
@@ -2329,7 +2309,7 @@ describe('Filter Menu', () => {
                         expect(items[2].ariaChecked).toBe('false');
                         items[2].click();
 
-                        expect(applyHandler).not.toHaveBeenCalled();
+                        expect(applyHandler).toHaveBeenCalled();
                         expect(handler).toHaveBeenCalled();
                         const call = handler.mock.calls[0][0];
                         expect(call.bubbles).toBeTruthy();
@@ -2338,11 +2318,18 @@ describe('Filter Menu', () => {
                         expect(call.detail.value).toEqual(['item-3']);
                     })
                     .then(() => {
+                        button.click();
+                    })
+                    .then(() => {
                         const items = element.shadowRoot.querySelectorAll(
                             '[data-element-id="a-list-item"]'
                         );
+                        console.log('length', items.length);
                         expect(items[2].ariaChecked).toBe('true');
                         items[2].click();
+                    })
+                    .then(() => {
+                        button.click();
                     })
                     .then(() => {
                         const items = element.shadowRoot.querySelectorAll(
@@ -2554,10 +2541,6 @@ describe('Filter Menu', () => {
                             '[data-element-id="a-list-item"]'
                         );
                         items[3].click();
-                        const applyButton = element.shadowRoot.querySelector(
-                            '[data-element-id="lightning-button-apply"]'
-                        );
-                        applyButton.click();
 
                         expect(handler).toHaveBeenCalled();
                         expect(handler.mock.calls[0][0].detail.value).toEqual([
@@ -2654,10 +2637,6 @@ describe('Filter Menu', () => {
                         '[data-element-id="a-list-item"]'
                     );
                     items[3].click();
-                    const applyButton = element.shadowRoot.querySelector(
-                        '[data-element-id="lightning-button-apply"]'
-                    );
-                    applyButton.click();
 
                     expect(handler).toHaveBeenCalled();
                     expect(handler.mock.calls[0][0].detail.value).toEqual([

--- a/src/modules/base/filterMenu/__tests__/filterMenu.test.js
+++ b/src/modules/base/filterMenu/__tests__/filterMenu.test.js
@@ -86,6 +86,7 @@ describe('Filter Menu', () => {
             expect(element.disabled).toBeFalsy();
             expect(element.dropdownAlignment).toBe('left');
             expect(element.dropdownNubbin).toBeFalsy();
+            expect(element.hideApplyButton).toBeFalsy();
             expect(element.hideApplyResetButtons).toBeFalsy();
             expect(element.hideSelectedItems).toBeFalsy();
             expect(element.iconName).toBe('utility:down');
@@ -126,6 +127,24 @@ describe('Filter Menu', () => {
                         '.slds-assistive-text'
                     );
                     expect(altText.textContent).toBe('A string alt text');
+                });
+            });
+        });
+
+        describe('Apply Button Label', () => {
+            it('applyButtonLabel', () => {
+                element.typeAttributes = { items: ITEMS };
+                element.applyButtonLabel = 'A string label';
+                const button = element.shadowRoot.querySelector(
+                    '[data-element-id="button"]'
+                );
+                button.click();
+
+                return Promise.resolve().then(() => {
+                    const submitButton = element.shadowRoot.querySelector(
+                        '[data-element-id="lightning-button-apply"]'
+                    );
+                    expect(submitButton.label).toBe('A string label');
                 });
             });
         });
@@ -827,6 +846,68 @@ describe('Filter Menu', () => {
             });
         });
 
+        describe('Hide Apply Button', () => {
+            // Depends on variant
+            it('false, with horizontal variant', () => {
+                element.hideApplyButton = false;
+                element.typeAttributes = { items: ITEMS };
+
+                const button = element.shadowRoot.querySelector(
+                    '[data-element-id="button"]'
+                );
+                button.click();
+
+                return Promise.resolve().then(() => {
+                    const buttons = element.shadowRoot.querySelectorAll(
+                        '[data-element-id^="lightning-button"]'
+                    );
+                    expect(buttons).toHaveLength(2);
+                });
+            });
+
+            it('false, with vertical variant', () => {
+                element.hideApplyButton = false;
+                element.typeAttributes = { items: ITEMS };
+                element.variant = 'vertical';
+
+                return Promise.resolve().then(() => {
+                    const buttons = element.shadowRoot.querySelectorAll(
+                        '[data-element-id^="lightning-button"]'
+                    );
+                    expect(buttons).toHaveLength(2);
+                });
+            });
+
+            it('true, with horizontal variant', () => {
+                element.hideApplyButton = true;
+                element.typeAttributes = { items: ITEMS };
+
+                const button = element.shadowRoot.querySelector(
+                    '[data-element-id="button"]'
+                );
+                button.click();
+
+                return Promise.resolve().then(() => {
+                    const buttons = element.shadowRoot.querySelectorAll(
+                        '[data-element-id^="lightning-button"]'
+                    );
+                    expect(buttons).toHaveLength(1);
+                });
+            });
+
+            it('true, with vertical variant', () => {
+                element.hideApplyButton = true;
+                element.variant = 'vertical';
+
+                return Promise.resolve().then(() => {
+                    const buttons = element.shadowRoot.querySelectorAll(
+                        '[data-element-id^="lightning-button"]'
+                    );
+                    expect(buttons).toHaveLength(1);
+                });
+            });
+        });
+
         describe('Hide Apply Reset Buttons', () => {
             // Depends on variant
             it('false, with horizontal variant', () => {
@@ -842,7 +923,7 @@ describe('Filter Menu', () => {
                     const buttons = element.shadowRoot.querySelectorAll(
                         '[data-element-id^="lightning-button"]'
                     );
-                    expect(buttons).toHaveLength(1);
+                    expect(buttons).toHaveLength(2);
                 });
             });
 
@@ -1123,6 +1204,9 @@ describe('Filter Menu', () => {
                     const items = element.shadowRoot.querySelectorAll(
                         '[data-element-id="a-list-item"]'
                     );
+                    const apply = element.shadowRoot.querySelector(
+                        '[data-element-id="lightning-button-apply"]'
+                    );
                     const reset = element.shadowRoot.querySelector(
                         '[data-element-id="lightning-button-reset"]'
                     );
@@ -1130,6 +1214,68 @@ describe('Filter Menu', () => {
                         '[data-element-id="p-no-results-message"]'
                     );
 
+                    expect(apply).toBeTruthy();
+                    expect(reset).toBeTruthy();
+                    expect(noResultMessage).toBeFalsy();
+                    expect(items).toHaveLength(6);
+
+                    items.forEach((item, index) => {
+                        const label = item.querySelector(
+                            '[data-element-id="lightning-formatted-rich-text"]'
+                        );
+                        const disabled = ITEMS[index].disabled ? 'true' : null;
+                        expect(item.dataset.value).toBe(ITEMS[index].value);
+                        expect(item.ariaDisabled).toBe(disabled);
+                        expect(label.value).toBe(ITEMS[index].label);
+                    });
+
+                    const prefixIcon = items[1].querySelector(
+                        '[data-element-id="avonni-primitive-icon-prefix"]'
+                    );
+                    const suffixIcon = items[1].querySelector(
+                        '[data-element-id="avonni-primitive-icon-suffix"]'
+                    );
+                    expect(prefixIcon).toBeTruthy();
+                    expect(suffixIcon).toBeTruthy();
+                    expect(items[1].tabIndex).toBe(0);
+
+                    [0, 2, 3, 4, 5].forEach((index) => {
+                        const prefix = items[index].querySelector(
+                            '[data-element-id="avonni-primitive-icon-prefix"]'
+                        );
+                        const suffix = items[index].querySelector(
+                            '[data-element-id="avonni-primitive-icon-suffix"]'
+                        );
+                        expect(prefix).toBeFalsy();
+                        expect(suffix).toBeFalsy();
+                        expect(items[index].tabIndex).toBe(-1);
+                    });
+                });
+            });
+
+            it('items, hide apply button', () => {
+                element.hideApplyButton = true;
+                element.typeAttributes = { items: ITEMS };
+                const button = element.shadowRoot.querySelector(
+                    '[data-element-id="button"]'
+                );
+                button.click();
+
+                return Promise.resolve().then(() => {
+                    const items = element.shadowRoot.querySelectorAll(
+                        '[data-element-id="a-list-item"]'
+                    );
+                    const apply = element.shadowRoot.querySelector(
+                        '[data-element-id="lightning-button-apply"]'
+                    );
+                    const reset = element.shadowRoot.querySelector(
+                        '[data-element-id="lightning-button-reset"]'
+                    );
+                    const noResultMessage = element.shadowRoot.querySelector(
+                        '[data-element-id="p-no-results-message"]'
+                    );
+
+                    expect(apply).toBeFalsy();
                     expect(reset).toBeTruthy();
                     expect(noResultMessage).toBeFalsy();
                     expect(items).toHaveLength(6);
@@ -1828,6 +1974,40 @@ describe('Filter Menu', () => {
                         ]);
                     })
                     .then(() => {
+                        const item = element.shadowRoot.querySelector(
+                            '[data-element-id="a-list-item"][data-index="1"]'
+                        );
+                        item.click();
+                        expect(handler.mock.calls[1][0].detail.value).toEqual([
+                            ITEMS[1].value
+                        ]);
+                    });
+            });
+
+            it('typeAttributes for list, isMultiSelect = false, hideApplyButton = true', () => {
+                element.hideApplyButton = true;
+                element.typeAttributes = {
+                    items: ITEMS,
+                    isMultiSelect: false
+                };
+                const button = element.shadowRoot.querySelector(
+                    '[data-element-id="button"]'
+                );
+                button.click();
+                const handler = jest.fn();
+                element.addEventListener('select', handler);
+
+                return Promise.resolve()
+                    .then(() => {
+                        const item = element.shadowRoot.querySelector(
+                            '[data-element-id="a-list-item"][data-index="2"]'
+                        );
+                        item.click();
+                        expect(handler.mock.calls[0][0].detail.value).toEqual([
+                            ITEMS[2].value
+                        ]);
+                    })
+                    .then(() => {
                         button.click();
                     })
                     .then(() => {
@@ -2032,6 +2212,7 @@ describe('Filter Menu', () => {
                         expect(items[0].ariaChecked).toBe('true');
                         expect(items[1].ariaChecked).toBe('true');
                         expect(items[2].ariaChecked).toBe('false');
+
                         items[2].click();
                     })
                     .then(() => {
@@ -2045,25 +2226,25 @@ describe('Filter Menu', () => {
                         element.value = JSON.parse(JSON.stringify(VALUE));
                     })
                     .then(() => {
-                        // Selected items were erased
-                        // because the new value was different
-                        const items = element.shadowRoot.querySelectorAll(
-                            '[data-element-id="a-list-item"]'
-                        );
-                        expect(items[0].ariaChecked).toBe('true');
-                        expect(items[1].ariaChecked).toBe('true');
-                        expect(items[2].ariaChecked).toBe('false');
-
-                        element.value = JSON.parse(JSON.stringify(VALUE));
-                    })
-                    .then(() => {
-                        // Selected items were erased
+                        // Selected items were not erased
                         // because the new value was identical
                         const items = element.shadowRoot.querySelectorAll(
                             '[data-element-id="a-list-item"]'
                         );
                         expect(items[0].ariaChecked).toBe('true');
                         expect(items[1].ariaChecked).toBe('true');
+                        expect(items[2].ariaChecked).toBe('true');
+
+                        element.value = [VALUE[0]];
+                    })
+                    .then(() => {
+                        // Selected items were erased
+                        // because the new value was different
+                        const items = element.shadowRoot.querySelectorAll(
+                            '[data-element-id="a-list-item"]'
+                        );
+                        expect(items[0].ariaChecked).toBe('true');
+                        expect(items[1].ariaChecked).toBe('false');
                         expect(items[2].ariaChecked).toBe('false');
                     });
             });
@@ -2358,7 +2539,7 @@ describe('Filter Menu', () => {
                         expect(items[2].ariaChecked).toBe('false');
                         items[2].click();
 
-                        expect(applyHandler).toHaveBeenCalled();
+                        expect(applyHandler).not.toHaveBeenCalled();
                         expect(handler).toHaveBeenCalled();
                         const call = handler.mock.calls[0][0];
                         expect(call.bubbles).toBeTruthy();
@@ -2367,18 +2548,11 @@ describe('Filter Menu', () => {
                         expect(call.detail.value).toEqual(['item-3']);
                     })
                     .then(() => {
-                        button.click();
-                    })
-                    .then(() => {
                         const items = element.shadowRoot.querySelectorAll(
                             '[data-element-id="a-list-item"]'
                         );
-                        console.log('length', items.length);
                         expect(items[2].ariaChecked).toBe('true');
                         items[2].click();
-                    })
-                    .then(() => {
-                        button.click();
                     })
                     .then(() => {
                         const items = element.shadowRoot.querySelectorAll(
@@ -2590,6 +2764,51 @@ describe('Filter Menu', () => {
                             '[data-element-id="a-list-item"]'
                         );
                         items[3].click();
+                        const applyButton = element.shadowRoot.querySelector(
+                            '[data-element-id="lightning-button-apply"]'
+                        );
+                        applyButton.click();
+
+                        expect(handler).toHaveBeenCalled();
+                        expect(handler.mock.calls[0][0].detail.value).toEqual([
+                            'item-4'
+                        ]);
+                        expect(handler.mock.calls[0][0].cancelable).toBeFalsy();
+                        expect(handler.mock.calls[0][0].bubbles).toBeTruthy();
+                        expect(handler.mock.calls[0][0].composed).toBeFalsy();
+                        expect(element.value).toEqual(['item-4']);
+                    })
+                    .then(() => {
+                        const dropdown = element.shadowRoot.querySelector(
+                            '[data-element-id="div-dropdown"]'
+                        );
+                        expect(dropdown).toBeFalsy();
+                    });
+            });
+
+            it('apply event, hideApplyButton = true', () => {
+                const handler = jest.fn();
+                element.addEventListener('apply', handler);
+                element.hideApplyButton = true;
+                element.typeAttributes = {
+                    items: ITEMS
+                };
+                element.value = VALUE;
+                const button = element.shadowRoot.querySelector(
+                    '[data-element-id="button"]'
+                );
+                button.click();
+
+                return Promise.resolve()
+                    .then(() => {
+                        const items = element.shadowRoot.querySelectorAll(
+                            '[data-element-id="a-list-item"]'
+                        );
+                        items[3].click();
+                        const applyButton = element.shadowRoot.querySelector(
+                            '[data-element-id="lightning-button-apply"]'
+                        );
+                        expect(applyButton).toBeFalsy();
 
                         expect(handler).toHaveBeenCalled();
                         expect(handler.mock.calls[0][0].detail.value).toEqual([
@@ -2686,6 +2905,43 @@ describe('Filter Menu', () => {
                         '[data-element-id="a-list-item"]'
                     );
                     items[3].click();
+                    const applyButton = element.shadowRoot.querySelector(
+                        '[data-element-id="lightning-button-apply"]'
+                    );
+                    applyButton.click();
+
+                    expect(handler).toHaveBeenCalled();
+                    expect(handler.mock.calls[0][0].detail.value).toEqual([
+                        ...VALUE,
+                        'item-4'
+                    ]);
+                });
+            });
+            it('apply event, multi-select, hideApplyButton', () => {
+                const handler = jest.fn();
+                element.addEventListener('apply', handler);
+
+                element.hideApplyButton = true;
+                element.typeAttributes = {
+                    items: ITEMS,
+                    isMultiSelect: true
+                };
+                element.value = VALUE;
+
+                const button = element.shadowRoot.querySelector(
+                    '[data-element-id="button"]'
+                );
+                button.click();
+
+                return Promise.resolve().then(() => {
+                    const items = element.shadowRoot.querySelectorAll(
+                        '[data-element-id="a-list-item"]'
+                    );
+                    items[3].click();
+                    const applyButton = element.shadowRoot.querySelector(
+                        '[data-element-id="lightning-button-apply"]'
+                    );
+                    expect(applyButton).toBeFalsy();
 
                     expect(handler).toHaveBeenCalled();
                     expect(handler.mock.calls[0][0].detail.value).toEqual([

--- a/src/modules/base/filterMenu/filterMenu.css
+++ b/src/modules/base/filterMenu/filterMenu.css
@@ -3,5 +3,5 @@
 }
 
 .avonni-filter-menu__selected-item-count {
-    background-color: var(--lwc-brandPrimary);
+    background-color: var(--lwc-brandPrimary, #1b96ff);
 }

--- a/src/modules/base/filterMenu/filterMenu.css
+++ b/src/modules/base/filterMenu/filterMenu.css
@@ -1,0 +1,7 @@
+.avonni-filter-menu__selected-item-button {
+    background-color: #edf2fe;
+}
+
+.avonni-filter-menu__selected-item-count {
+    background-color: var(--lwc-brandPrimary);
+}

--- a/src/modules/base/filterMenu/filterMenu.html
+++ b/src/modules/base/filterMenu/filterMenu.html
@@ -22,13 +22,13 @@
                 {label}
             </span>
             <span
-                if:true={showSelectedFilterValue}
+                if:true={showFilterValue}
                 data-element-id="span-menu-selected-labels"
             >
-                : {selectedFilterLabels}&nbsp;
+                &nbsp;{selectedFilterLabels}&nbsp;
             </span>
             <span
-                if:true={selectedItemCountLabel}
+                if:true={showCount}
                 class="slds-badge avonni-filter-menu__selected-item-count"
                 data-element-id="span-menu-selected-item-count"
             >

--- a/src/modules/base/filterMenu/filterMenu.html
+++ b/src/modules/base/filterMenu/filterMenu.html
@@ -221,7 +221,9 @@
                         class="
                             slds-p-horizontal_small
                             slds-p-bottom_x-small
-                            slds-text-align_left
+                            slds-grid
+                            slds-grid_align-spread
+                            slds-grid_vertical-align-center
                         "
                     >
                         <lightning-button
@@ -234,6 +236,11 @@
                             data-is-focusable
                             onclick={handleResetClick}
                         ></lightning-button>
+                        <lightning-formatted-text
+                            value={selectedOverTotal}
+                            data-element-id="lightning-formatted-text-number-values"
+                            if:true={isList}
+                        ></lightning-formatted-text>
                     </div>
                 </div>
             </c-focus-trap>

--- a/src/modules/base/filterMenu/filterMenu.html
+++ b/src/modules/base/filterMenu/filterMenu.html
@@ -221,11 +221,11 @@
                         class="
                             slds-p-horizontal_small
                             slds-p-bottom_x-small
-                            slds-text-align_right
+                            slds-text-align_left
                         "
                     >
                         <lightning-button
-                            class="slds-m-right_x-small"
+                            class="slds-m-left_x_small"
                             disabled={isLoading}
                             label={resetButtonLabel}
                             title={resetButtonLabel}
@@ -233,15 +233,6 @@
                             data-element-id="lightning-button-reset"
                             data-is-focusable
                             onclick={handleResetClick}
-                        ></lightning-button>
-                        <lightning-button
-                            disabled={isLoading}
-                            label={applyButtonLabel}
-                            title={applyButtonLabel}
-                            variant="brand"
-                            data-element-id="lightning-button-apply"
-                            data-is-focusable
-                            onclick={handleApply}
                         ></lightning-button>
                     </div>
                 </div>

--- a/src/modules/base/filterMenu/filterMenu.html
+++ b/src/modules/base/filterMenu/filterMenu.html
@@ -22,10 +22,10 @@
                 {label}
             </span>
             <span
-                if:true={selectedElementLabels}
+                if:true={showSelectedFilterValue}
                 data-element-id="span-menu-selected-labels"
             >
-                : {selectedElementLabels}&nbsp;
+                : {selectedFilterLabels}&nbsp;
             </span>
             <span
                 if:true={selectedItemCountLabel}

--- a/src/modules/base/filterMenu/filterMenu.html
+++ b/src/modules/base/filterMenu/filterMenu.html
@@ -254,11 +254,32 @@
                             data-is-focusable
                             onclick={handleResetClick}
                         ></lightning-button>
-                        <lightning-formatted-text
-                            value={selectedOverTotal}
-                            data-element-id="lightning-formatted-text-number-values"
-                            if:true={isList}
-                        ></lightning-formatted-text>
+                        <div
+                            class="
+                                slds-col_bump-left
+                                slds-grid
+                                slds-grid_align-center
+                                slds-grid_vertical-align-center
+                            "
+                        >
+                            <lightning-button
+                                if:false={hideApplyButton}
+                                disabled={isLoading}
+                                label={applyButtonLabel}
+                                title={applyButtonLabel}
+                                variant="brand"
+                                data-element-id="lightning-button-apply"
+                                data-is-focusable
+                                onclick={handleApply}
+                            ></lightning-button>
+
+                            <lightning-formatted-text
+                                if:true={isList}
+                                value={selectedOverTotal}
+                                class="slds-m-left_x-small"
+                                data-element-id="lightning-formatted-text-number-values"
+                            ></lightning-formatted-text>
+                        </div>
                     </div>
                 </div>
             </c-focus-trap>

--- a/src/modules/base/filterMenu/filterMenu.html
+++ b/src/modules/base/filterMenu/filterMenu.html
@@ -15,7 +15,25 @@
             onclick={handleButtonClick}
             onfocus={handleButtonFocus}
         >
-            {label}
+            <span
+                class={computedMenuLabelClass}
+                data-element-id="span-menu-label"
+            >
+                {label}
+            </span>
+            <span
+                if:true={selectedElementLabels}
+                data-element-id="span-menu-selected-labels"
+            >
+                : {selectedElementLabels}&nbsp;
+            </span>
+            <span
+                if:true={selectedItemCountLabel}
+                class="slds-badge avonni-filter-menu__selected-item-count"
+                data-element-id="span-menu-selected-item-count"
+            >
+                {selectedItemCountLabel}
+            </span>
             <c-primitive-icon
                 if:true={iconName}
                 class="slds-m-horizontal_xx-small"

--- a/src/modules/base/filterMenu/filterMenu.js
+++ b/src/modules/base/filterMenu/filterMenu.js
@@ -132,7 +132,7 @@ const TYPES = {
  * @storyId example-filter-menu--base
  * @public
  */
-export default class AvonniFilterMenu extends LightningElement {
+export default class FilterMenu extends LightningElement {
     /**
      * The keyboard shortcut for the button menu (horizontal variant) or the checkbox group (vertical variant).
      *

--- a/src/modules/base/filterMenu/filterMenu.js
+++ b/src/modules/base/filterMenu/filterMenu.js
@@ -1298,6 +1298,26 @@ export default class FilterMenu extends LightningElement {
     }
 
     /**
+     * True if the selected filter value should be visible
+     *
+     * @type {boolean}
+     */
+    get showCount() {
+        return (
+            this.showSelectedFilterValueCount && !!this.selectedItemCountLabel
+        );
+    }
+
+    /**
+     * True if the selected filter value should be visible
+     *
+     * @type {boolean}
+     */
+    get showFilterValue() {
+        return this.showSelectedFilterValueCount && !!this.selectedFilterLabels;
+    }
+
+    /**
      * True if the load more button should be visible.
      *
      * @type {boolean}
@@ -1318,15 +1338,6 @@ export default class FilterMenu extends LightningElement {
             this.type === 'list' &&
             (this.searchTerm || this.variant === 'horizontal')
         );
-    }
-
-    /**
-     * True if the selected filter value should be visible
-     *
-     * @type {boolean}
-     */
-    get showSelectedFilterValue() {
-        return this.showSelectedFilterValueCount && !!this.selectedFilterLabels;
     }
 
     /**

--- a/src/modules/base/filterMenu/filterMenu.js
+++ b/src/modules/base/filterMenu/filterMenu.js
@@ -1144,6 +1144,17 @@ export default class AvonniFilterMenu extends LightningElement {
     }
 
     /**
+     * The number of selected items
+     *
+     * @type {string}
+     */
+    get selectedOverTotal() {
+        const currentLength = this.selectedItems?.length ?? 0;
+        const totalLength = this.computedItems?.length ?? 0;
+        return `${currentLength} of ${totalLength}`;
+    }
+
+    /**
      * Array of one action: remove. The action is shown on the selected items pills.
      *
      * @type {object[]}

--- a/src/modules/base/filterMenu/filterMenu.js
+++ b/src/modules/base/filterMenu/filterMenu.js
@@ -48,7 +48,7 @@ const DEFAULT_APPLY_BUTTON_LABEL = 'Apply';
 const DEFAULT_ICON_NAME = 'utility:down';
 const DEFAULT_NO_RESULTS_MESSAGE = 'No matches found';
 const DEFAULT_RANGE_VALUE = [0, 100];
-const DEFAULT_RESET_BUTTON_LABEL = 'Reset';
+const DEFAULT_RESET_BUTTON_LABEL = 'Clear selection';
 const DEFAULT_SEARCH_INPUT_PLACEHOLDER = 'Search...';
 
 const i18n = {
@@ -132,7 +132,7 @@ const TYPES = {
  * @storyId example-filter-menu--base
  * @public
  */
-export default class FilterMenu extends LightningElement {
+export default class AvonniFilterMenu extends LightningElement {
     /**
      * The keyboard shortcut for the button menu (horizontal variant) or the checkbox group (vertical variant).
      *
@@ -1960,6 +1960,9 @@ export default class FilterMenu extends LightningElement {
          */
         this.dispatchEvent(new CustomEvent('reset', { bubbles: true }));
         this.reset();
+        this._value = [...this.currentValue];
+        this.computeSelectedItems();
+        this.dispatchApply();
     }
 
     /**
@@ -2193,15 +2196,13 @@ export default class FilterMenu extends LightningElement {
             })
         );
 
-        if (this.hideApplyResetButtons) {
-            // Save the selection immediately
-            this._value = [...this.currentValue];
-            this.computeSelectedItems();
-            this.dispatchApply();
+        // Save the selection immediately
+        this._value = [...this.currentValue];
+        this.computeSelectedItems();
+        this.dispatchApply();
 
-            if (this.isList && !this.computedTypeAttributes.isMultiSelect) {
-                this.close();
-            }
+        if (this.isList && !this.computedTypeAttributes.isMultiSelect) {
+            this.close();
         }
     }
 

--- a/src/modules/base/filterMenu/filterMenu.js
+++ b/src/modules/base/filterMenu/filterMenu.js
@@ -174,6 +174,7 @@ export default class FilterMenu extends LightningElement {
     _dropdownLength;
     _dropdownNubbin = false;
     _dropdownWidth = MENU_WIDTHS.default;
+    _hideApplyButton = false;
     _hideApplyResetButtons = false;
     _hideSelectedItems = false;
     _iconName = DEFAULT_ICON_NAME;
@@ -469,6 +470,21 @@ export default class FilterMenu extends LightningElement {
         if (this._connected) {
             this.supportDeprecatedAttributes();
         }
+    }
+
+    /**
+     * If present, the apply button is hidden and the value is immediately saved every time the selection changes.
+     *
+     * @type {boolean}
+     * @default false
+     * @public
+     */
+    @api
+    get hideApplyButton() {
+        return this._hideApplyButton;
+    }
+    set hideApplyButton(value) {
+        this._hideApplyButton = normalizeBoolean(value);
     }
 
     /**
@@ -2341,12 +2357,13 @@ export default class FilterMenu extends LightningElement {
         );
 
         // Save the selection immediately
-        this._value = [...this.currentValue];
-        this.computeSelectedItems();
-        this.dispatchApply();
-
-        if (this.isList && !this.computedTypeAttributes.isMultiSelect) {
-            this.close();
+        if (this.hideApplyButton || this.hideApplyResetButtons) {
+            this._value = [...this.currentValue];
+            this.computeSelectedItems();
+            this.dispatchApply();
+            if (this.isList && !this.computedTypeAttributes.isMultiSelect) {
+                this.close();
+            }
         }
     }
 

--- a/src/modules/base/filterMenu/filterMenu.js
+++ b/src/modules/base/filterMenu/filterMenu.js
@@ -184,6 +184,7 @@ export default class FilterMenu extends LightningElement {
     _loadingStateAlternativeText = i18n.loading;
     _resetButtonLabel = DEFAULT_RESET_BUTTON_LABEL;
     _searchInputPlaceholder = DEFAULT_SEARCH_INPUT_PLACEHOLDER;
+    _showSelectedFilterValueCount = false;
     _showSearchBox = false;
     _tooltip;
     _type = TYPES.default;
@@ -691,6 +692,20 @@ export default class FilterMenu extends LightningElement {
     }
 
     /**
+     * If present, the selected filter value and count are displayed in the label.
+     *
+     * @type {boolean}
+     * @default false
+     */
+    @api
+    get showSelectedFilterValueCount() {
+        return this._showSelectedFilterValueCount;
+    }
+    set showSelectedFilterValueCount(value) {
+        this._showSelectedFilterValueCount = normalizeBoolean(value);
+    }
+
+    /**
      * The tooltip is displayed on hover or focus on the button (horizontal variant), or on the help icon (vertical variant).
      *
      * @type {string}
@@ -896,7 +911,8 @@ export default class FilterMenu extends LightningElement {
 
         classes.add({
             'avonni-filter-menu__selected-item-button':
-                this.selectedItemsLabels.length > 0
+                this.selectedItemLabels.length > 0 &&
+                this.showSelectedFilterValue
         });
 
         return classes
@@ -964,7 +980,9 @@ export default class FilterMenu extends LightningElement {
     get computedMenuLabelClass() {
         return classSet('slds-dropdown__list')
             .add({
-                'slds-text-title_bold': this.selectedItemsLabels.length > 0
+                'slds-text-title_bold':
+                    this.selectedItemLabels.length > 0 &&
+                    this.showSelectedFilterValueCount
             })
             .toString();
     }
@@ -1223,34 +1241,23 @@ export default class FilterMenu extends LightningElement {
     }
 
     /**
-     * Display the count if more than 2 items are selected
+     * Computed Menu Label with selected filters.
      *
      * @type {string}
      */
-    get selectedItemCountLabel() {
-        const selectedCount = this.selectedItemsLabels.length;
-
-        return selectedCount > 2 ? `${selectedCount - 2}+` : '';
-    }
-
-    /**
-     * Computed Menu Label with selected items.
-     *
-     * @type {string}
-     */
-    get selectedElementLabels() {
-        const selectedCount = this.selectedItemsLabels.length;
+    get selectedFilterLabels() {
+        const selectedCount = this.selectedItemLabels.length;
 
         if (selectedCount === 0) {
             return '';
         }
 
         if (selectedCount <= 2) {
-            const selectedLabels = this.selectedItemsLabels.join(', ');
+            const selectedLabels = this.selectedItemLabels.join(', ');
             return `(${selectedLabels})`;
         }
 
-        const firstTwoLabels = this.selectedItemsLabels
+        const firstTwoLabels = this.selectedItemLabels
             .slice(0, 2)
             .map((item) => item)
             .join(', ');
@@ -1258,11 +1265,22 @@ export default class FilterMenu extends LightningElement {
     }
 
     /**
+     * Display the count if more than 2 items are selected
+     *
+     * @type {string}
+     */
+    get selectedItemCountLabel() {
+        const selectedCount = this.selectedItemLabels.length;
+
+        return selectedCount > 2 ? `${selectedCount - 2}+` : '';
+    }
+
+    /**
      * Display the labels of the selected items
      *
      * @type {string[]}
      */
-    get selectedItemsLabels() {
+    get selectedItemLabels() {
         const isMultiSelect = this.computedTypeAttributes?.isMultiSelect;
         const labels = isMultiSelect
             ? this._value
@@ -1300,6 +1318,15 @@ export default class FilterMenu extends LightningElement {
             this.type === 'list' &&
             (this.searchTerm || this.variant === 'horizontal')
         );
+    }
+
+    /**
+     * True if the selected filter value should be visible
+     *
+     * @type {boolean}
+     */
+    get showSelectedFilterValue() {
+        return this.showSelectedFilterValueCount && !!this.selectedFilterLabels;
     }
 
     /**

--- a/src/modules/base/filterMenu/filterMenuVertical.html
+++ b/src/modules/base/filterMenu/filterMenuVertical.html
@@ -216,6 +216,7 @@
             disabled={disabledOrLoading}
         ></lightning-button>
         <lightning-button
+            if:false={hideApplyButton}
             variant="brand"
             label={applyButtonLabel}
             title={applyButtonLabel}

--- a/src/modules/base/filterMenuGroup/__docs__/filterMenuGroup.stories.js
+++ b/src/modules/base/filterMenuGroup/__docs__/filterMenuGroup.stories.js
@@ -69,6 +69,17 @@ export default {
                 defaultValue: { summary: 'false' }
             }
         },
+        offsetFilterWidth: {
+            name: 'offset-filter-width',
+            control: {
+                type: 'number'
+            },
+            description: 'Width of the offset for the filter in pixels.',
+            table: {
+                type: { summary: 'number' },
+                defaultValue: { summary: '0' }
+            }
+        },
         showSelectedFilterValueCount: {
             name: 'show-selected-filter-value-count',
             control: {
@@ -102,6 +113,18 @@ export default {
                 type: { summary: 'string' },
                 defaultValue: { summary: 'horizontal' }
             }
+        },
+        wrapperWidth: {
+            name: 'wrapper-width',
+            control: {
+                type: 'number'
+            },
+            description:
+                'Width of the wrapper in pixels. It is used to compute the overflow of the menu group.',
+            table: {
+                type: { summary: 'number' },
+                defaultValue: { summary: '0' }
+            }
         }
     },
     args: {
@@ -109,9 +132,11 @@ export default {
         hideApplyResetButtons: false,
         hideSelectedItems: false,
         isToggleButtonVariant: false,
+        offsetFilterWidth: 0,
         resetButtonLabel: 'Reset',
         showSelectedFilterValueCount: false,
-        variant: 'horizontal'
+        variant: 'horizontal',
+        wrapperWidth: 0
     }
 };
 

--- a/src/modules/base/filterMenuGroup/__docs__/filterMenuGroup.stories.js
+++ b/src/modules/base/filterMenuGroup/__docs__/filterMenuGroup.stories.js
@@ -35,6 +35,17 @@ export default {
                 defaultValue: { summary: 'Reset' }
             }
         },
+        hideApplyButton: {
+            name: 'hide-apply-button',
+            control: {
+                type: 'boolean'
+            },
+            description: 'If present, the apply button is hidden.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' }
+            }
+        },
         hideApplyResetButtons: {
             name: 'hide-apply-reset-buttons',
             control: {
@@ -129,6 +140,7 @@ export default {
     },
     args: {
         applyButtonLabel: 'Apply',
+        hideApplyButton: false,
         hideApplyResetButtons: false,
         hideSelectedItems: false,
         isToggleButtonVariant: false,

--- a/src/modules/base/filterMenuGroup/__docs__/filterMenuGroup.stories.js
+++ b/src/modules/base/filterMenuGroup/__docs__/filterMenuGroup.stories.js
@@ -57,6 +57,30 @@ export default {
                 defaultValue: { summary: 'false' }
             }
         },
+        isToggleButtonVariant: {
+            name: 'is-toggle-button-variant',
+            control: {
+                type: 'boolean'
+            },
+            description:
+                'If present, each menu will have its button variant toggled between the border and outline-brand variants',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' }
+            }
+        },
+        showSelectedFilterValueCount: {
+            name: 'show-selected-filter-value-count',
+            control: {
+                type: 'boolean'
+            },
+            description:
+                'If present, the selected filter value and count are displayed in the label.',
+            table: {
+                type: { summary: 'boolean' },
+                defaultValue: { summary: 'false' }
+            }
+        },
         value: {
             control: {
                 type: 'object'
@@ -84,7 +108,9 @@ export default {
         applyButtonLabel: 'Apply',
         hideApplyResetButtons: false,
         hideSelectedItems: false,
+        isToggleButtonVariant: false,
         resetButtonLabel: 'Reset',
+        showSelectedFilterValueCount: false,
         variant: 'horizontal'
     }
 };

--- a/src/modules/base/filterMenuGroup/__examples__/filterMenuGroup.js
+++ b/src/modules/base/filterMenuGroup/__examples__/filterMenuGroup.js
@@ -11,10 +11,12 @@ export const FilterMenuGroup = ({
     hideSelectedItems,
     isToggleButtonVariant,
     menus,
+    offsetFilterWidth,
     resetButtonLabel,
     showSelectedFilterValueCount,
     value,
-    variant
+    variant,
+    wrapperWidth
 }) => {
     const element = document.createElement('ac-base-filter-menu-group');
     element.applyButtonLabel = applyButtonLabel;
@@ -22,9 +24,11 @@ export const FilterMenuGroup = ({
     element.hideSelectedItems = hideSelectedItems;
     element.isToggleButtonVariant = isToggleButtonVariant;
     element.menus = menus;
+    element.offsetFilterWidth = offsetFilterWidth;
     element.resetButtonLabel = resetButtonLabel;
     element.showSelectedFilterValueCount = showSelectedFilterValueCount;
     element.value = value;
     element.variant = variant;
+    element.wrapperWidth = wrapperWidth;
     return element;
 };

--- a/src/modules/base/filterMenuGroup/__examples__/filterMenuGroup.js
+++ b/src/modules/base/filterMenuGroup/__examples__/filterMenuGroup.js
@@ -9,8 +9,10 @@ export const FilterMenuGroup = ({
     applyButtonLabel,
     hideApplyResetButtons,
     hideSelectedItems,
+    isToggleButtonVariant,
     menus,
     resetButtonLabel,
+    showSelectedFilterValueCount,
     value,
     variant
 }) => {
@@ -18,8 +20,10 @@ export const FilterMenuGroup = ({
     element.applyButtonLabel = applyButtonLabel;
     element.hideApplyResetButtons = hideApplyResetButtons;
     element.hideSelectedItems = hideSelectedItems;
+    element.isToggleButtonVariant = isToggleButtonVariant;
     element.menus = menus;
     element.resetButtonLabel = resetButtonLabel;
+    element.showSelectedFilterValueCount = showSelectedFilterValueCount;
     element.value = value;
     element.variant = variant;
     return element;

--- a/src/modules/base/filterMenuGroup/__tests__/filterMenuGroup.test.js
+++ b/src/modules/base/filterMenuGroup/__tests__/filterMenuGroup.test.js
@@ -23,7 +23,7 @@ describe('FilterMenuGroup', () => {
             expect(element.hideApplyResetButtons).toBeFalsy();
             expect(element.hideSelectedItems).toBeFalsy();
             expect(element.menus).toMatchObject([]);
-            expect(element.resetButtonLabel).toBe('Reset');
+            expect(element.resetButtonLabel).toBe('Clear selection');
             expect(element.value).toEqual({});
             expect(element.variant).toBe('horizontal');
         });
@@ -308,12 +308,16 @@ describe('FilterMenuGroup', () => {
         describe('apply', () => {
             it('apply method', () => {
                 element.menus = MENUS;
+                const handler = jest.fn();
+                element.addEventListener('apply', handler);
 
                 return Promise.resolve()
                     .then(() => {
                         const menu = element.shadowRoot.querySelector(
                             '[data-element-id="avonni-filter-menu"]'
                         );
+
+                        expect(element.value).toEqual({});
                         menu.dispatchEvent(
                             new CustomEvent('select', {
                                 detail: {
@@ -323,9 +327,8 @@ describe('FilterMenuGroup', () => {
                             })
                         );
 
-                        expect(element.value).toEqual({});
-                        element.apply();
                         expect(element.value).toEqual({ contact: ['call'] });
+                        expect(handler).toHaveBeenCalled();
                     })
                     .then(() => {
                         const pills = element.shadowRoot.querySelector(
@@ -474,8 +477,7 @@ describe('FilterMenuGroup', () => {
                         applyButton.click();
 
                         expect(handler).toHaveBeenCalled();
-                        const detail = handler.mock.calls[0][0].detail;
-                        expect(detail.value).toEqual({
+                        expect(element.value).toEqual({
                             editions: ['professional', 'enterprise'],
                             contact: ['call'],
                             price: [2, 45],
@@ -484,7 +486,6 @@ describe('FilterMenuGroup', () => {
                                 '2019-01-31T13:40:00.000Z'
                             ]
                         });
-                        expect(detail.name).toBeUndefined();
                     })
                     .then(() => {
                         const pills = element.shadowRoot.querySelector(
@@ -834,7 +835,7 @@ describe('FilterMenuGroup', () => {
                     expect(call.bubbles).toBeFalsy();
                     expect(call.composed).toBeFalsy();
                     expect(call.cancelable).toBeFalsy();
-                    expect(element.value).toEqual({});
+                    expect(element.value).toEqual({ contact: ['call'] });
                 });
             });
         });

--- a/src/modules/base/filterMenuGroup/__tests__/filterMenuGroup.test.js
+++ b/src/modules/base/filterMenuGroup/__tests__/filterMenuGroup.test.js
@@ -53,18 +53,6 @@ describe('FilterMenuGroup', () => {
                     });
                 });
             });
-
-            it('applyButtonLabel, with vertical variant', () => {
-                element.applyButtonLabel = 'Save';
-                element.variant = 'vertical';
-
-                return Promise.resolve().then(() => {
-                    const button = element.shadowRoot.querySelector(
-                        '[data-element-id="lightning-button-apply"]'
-                    );
-                    expect(button.label).toBe('Save');
-                });
-            });
         });
 
         describe('hideApplyResetButtons', () => {
@@ -370,7 +358,7 @@ describe('FilterMenuGroup', () => {
                     const buttons = element.shadowRoot.querySelectorAll(
                         '[data-element-id^="lightning-button"]'
                     );
-                    expect(buttons).toHaveLength(2);
+                    expect(buttons).toHaveLength(1);
                 });
             });
         });
@@ -611,11 +599,6 @@ describe('FilterMenuGroup', () => {
                                 bubbles: true
                             })
                         );
-
-                        const applyButton = element.shadowRoot.querySelector(
-                            '[data-element-id="lightning-button-apply"]'
-                        );
-                        applyButton.click();
 
                         expect(handler).toHaveBeenCalled();
                         expect(element.value).toEqual({
@@ -945,7 +928,7 @@ describe('FilterMenuGroup', () => {
                         menus.forEach((menu) => {
                             expect(menu.value).toEqual([]);
                         });
-                        expect(element.value).toEqual(VALUE);
+                        expect(element.value).toEqual({});
                     });
             });
         });

--- a/src/modules/base/filterMenuGroup/__tests__/filterMenuGroup.test.js
+++ b/src/modules/base/filterMenuGroup/__tests__/filterMenuGroup.test.js
@@ -22,10 +22,14 @@ describe('FilterMenuGroup', () => {
             expect(element.applyButtonLabel).toBe('Apply');
             expect(element.hideApplyResetButtons).toBeFalsy();
             expect(element.hideSelectedItems).toBeFalsy();
+            expect(element.isToggleButtonVariant).toBeFalsy();
             expect(element.menus).toMatchObject([]);
+            expect(element.offsetFilterWidth).toBe(0);
             expect(element.resetButtonLabel).toBe('Clear selection');
+            expect(element.showSelectedFilterValueCount).toBeFalsy();
             expect(element.value).toEqual({});
             expect(element.variant).toBe('horizontal');
+            expect(element.wrapperWidth).toBe(0);
         });
 
         describe('applyButtonLabel', () => {
@@ -160,6 +164,18 @@ describe('FilterMenuGroup', () => {
             });
         });
 
+        describe('isToggleButtonVariant', () => {
+            it('isToggleButtonVariant, true', () => {
+                element.isToggleButtonVariant = true;
+                expect(element.isToggleButtonVariant).toBeTruthy();
+            });
+
+            it('isToggleButtonVariant, false', () => {
+                element.isToggleButtonVariant = false;
+                expect(element.isToggleButtonVariant).toBeFalsy();
+            });
+        });
+
         describe('menus', () => {
             it('Passed to the component', () => {
                 element.menus = MENUS;
@@ -201,6 +217,28 @@ describe('FilterMenuGroup', () => {
             });
         });
 
+        describe('offsetFilterWidth', () => {
+            it('offsetFilterWidth, null', () => {
+                element.offsetFilterWidth = null;
+                expect(element.offsetFilterWidth).toBe(0);
+            });
+
+            it('offsetFilterWidth, undefined', () => {
+                element.offsetFilterWidth = undefined;
+                expect(element.offsetFilterWidth).toBe(0);
+            });
+
+            it('offsetFilterWidth, -1', () => {
+                element.offsetFilterWidth = -1;
+                expect(element.offsetFilterWidth).toBe(0);
+            });
+
+            it('offsetFilterWidth, 1', () => {
+                element.offsetFilterWidth = 1;
+                expect(element.offsetFilterWidth).toBe(1);
+            });
+        });
+
         describe('resetButtonLabel', () => {
             it('Passed to the component with horizontal variant', () => {
                 element.resetButtonLabel = 'Erase';
@@ -225,6 +263,34 @@ describe('FilterMenuGroup', () => {
                         '[data-element-id="lightning-button-reset"]'
                     );
                     expect(button.label).toBe('Erase');
+                });
+            });
+        });
+
+        describe('showSelectedFilterValueCount', () => {
+            it('Passed to the component as true', () => {
+                element.showSelectedFilterValueCount = true;
+
+                return Promise.resolve().then(() => {
+                    const menus = element.shadowRoot.querySelectorAll(
+                        '[data-element-id^="avonni-filter-menu"]'
+                    );
+                    menus.forEach((menu) => {
+                        expect(menu.showSelectedFilterValueCount).toBeTruthy();
+                    });
+                });
+            });
+
+            it('Passed to the component as false', () => {
+                element.showSelectedFilterValueCount = false;
+
+                return Promise.resolve().then(() => {
+                    const menus = element.shadowRoot.querySelectorAll(
+                        '[data-element-id^="avonni-filter-menu"]'
+                    );
+                    menus.forEach((menu) => {
+                        expect(menu.showSelectedFilterValueCount).toBeFalsy();
+                    });
                 });
             });
         });
@@ -300,6 +366,28 @@ describe('FilterMenuGroup', () => {
                     );
                     expect(buttons).toHaveLength(2);
                 });
+            });
+        });
+
+        describe('wrapperWidth', () => {
+            it('wrapperWidth, null', () => {
+                element.wrapperWidth = null;
+                expect(element.wrapperWidth).toBe(0);
+            });
+
+            it('wrapperWidth, undefined', () => {
+                element.wrapperWidth = undefined;
+                expect(element.wrapperWidth).toBe(0);
+            });
+
+            it('wrapperWidth, -1', () => {
+                element.wrapperWidth = -1;
+                expect(element.wrapperWidth).toBe(0);
+            });
+
+            it('wrapperWidth, 1', () => {
+                element.wrapperWidth = 1;
+                expect(element.wrapperWidth).toBe(1);
             });
         });
     });
@@ -389,6 +477,18 @@ describe('FilterMenuGroup', () => {
                         expect(menu.value).toEqual([]);
                         expect(element.value).toEqual(VALUE);
                     });
+            });
+        });
+    });
+
+    describe('Private Fields', () => {
+        describe('focus', () => {
+            it('focus method', () => {
+                element.menus = MENUS;
+
+                return Promise.resolve().then(() => {
+                    expect(true).toBeTruthy();
+                });
             });
         });
     });

--- a/src/modules/base/filterMenuGroup/__tests__/filterMenuGroup.test.js
+++ b/src/modules/base/filterMenuGroup/__tests__/filterMenuGroup.test.js
@@ -8,11 +8,17 @@ describe('FilterMenuGroup', () => {
         while (document.body.firstChild) {
             document.body.removeChild(document.body.firstChild);
         }
+        jest.clearAllTimers();
+        window.requestAnimationFrame.mockRestore();
     });
 
     beforeEach(() => {
         element = createElement('base-filter-menu-group', {
             is: FilterMenuGroup
+        });
+        jest.useFakeTimers();
+        jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+            setTimeout(() => cb(), 0);
         });
         document.body.appendChild(element);
     });
@@ -389,6 +395,53 @@ describe('FilterMenuGroup', () => {
                 element.wrapperWidth = 1;
                 expect(element.wrapperWidth).toBe(1);
             });
+
+            it('wrapperWidth, 100000', () => {
+                element.menus = MENUS;
+                element.wrapperWidth = 100000;
+                expect(element.wrapperWidth).toBe(100000);
+                return Promise.resolve()
+                    .then(() => {
+                        jest.runAllTimers();
+                        expect(element.wrapperWidth).toBe(100000);
+                    })
+                    .then(() => {
+                        const menus = element.shadowRoot.querySelectorAll(
+                            '[data-element-id^="avonni-filter-menu"]'
+                        );
+                        expect(menus).toHaveLength(MENUS.length);
+                        menus.forEach((menu, i) => {
+                            expect(menu.accessKey).toBe(MENUS[i].accessKey);
+                            expect(menu.alternativeText).toBe(
+                                MENUS[i].alternativeText
+                            );
+                            expect(menu.closed).toBe(MENUS[i].closed);
+                            expect(menu.collapsible).toBe(MENUS[i].collapsible);
+                            expect(menu.disabled).toBe(MENUS[i].disabled);
+                            expect(menu.iconName).toBe(MENUS[i].iconName);
+                            expect(menu.iconSize).toBe(MENUS[i].iconSize);
+                            expect(menu.isLoading).toBe(MENUS[i].isLoading);
+                            expect(menu.label).toBe(MENUS[i].label);
+                            expect(menu.loadingStateAlternativeText).toBe(
+                                MENUS[i].loadingStateAlternativeText
+                            );
+                            expect(menu.type).toBe(MENUS[i].type);
+                            expect(menu.typeAttributes).toEqual(
+                                MENUS[i].typeAttributes
+                            );
+                            expect(menu.title).toBe(MENUS[i].title);
+                            expect(menu.tooltip).toBe(MENUS[i].tooltip);
+                            expect(menu.value).toEqual([]);
+                            expect(menu.buttonVariant).toBe(
+                                MENUS[i].buttonVariant
+                            );
+                            expect(menu.dropdownAlignment).toBe(
+                                MENUS[i].dropdownAlignment
+                            );
+                            expect(menu.name).toBe(MENUS[i].name);
+                        });
+                    });
+            });
         });
     });
 
@@ -477,18 +530,6 @@ describe('FilterMenuGroup', () => {
                         expect(menu.value).toEqual([]);
                         expect(element.value).toEqual(VALUE);
                     });
-            });
-        });
-    });
-
-    describe('Private Fields', () => {
-        describe('focus', () => {
-            it('focus method', () => {
-                element.menus = MENUS;
-
-                return Promise.resolve().then(() => {
-                    expect(true).toBeTruthy();
-                });
             });
         });
     });
@@ -781,6 +822,38 @@ describe('FilterMenuGroup', () => {
                         MENUS[0].typeAttributes.items[0]
                     );
                     expect(call.detail.name).toBe('contact');
+                    expect(call.bubbles).toBeFalsy();
+                    expect(call.composed).toBeFalsy();
+                    expect(call.cancelable).toBeFalsy();
+                });
+            });
+        });
+
+        describe('nbfilteritems', () => {
+            it('nbfilteritems event', () => {
+                element.menus = MENUS;
+
+                const handler = jest.fn();
+                element.addEventListener('nbfilteritems', handler);
+
+                return Promise.resolve().then(() => {
+                    const menu = element.shadowRoot.querySelector(
+                        '[data-element-id="avonni-filter-menu"]'
+                    );
+                    menu.dispatchEvent(
+                        new CustomEvent('nbfilteritems', {
+                            detail: {
+                                name: MENUS[0].name,
+                                item: {}
+                            },
+                            bubbles: true
+                        })
+                    );
+
+                    expect(handler).toHaveBeenCalled();
+                    const call = handler.mock.calls[0][0];
+                    expect(call.detail.name).toBe(MENUS[0].name);
+                    expect(call.detail.item).toEqual({});
                     expect(call.bubbles).toBeFalsy();
                     expect(call.composed).toBeFalsy();
                     expect(call.cancelable).toBeFalsy();

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.css
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.css
@@ -1,0 +1,3 @@
+.avonni-filter-menu-group__wrapper_hidden {
+    visibility: hidden;
+}

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.html
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.html
@@ -1,13 +1,13 @@
 <template>
     <template if:true={isVertical}>
         <div if:true={showSelectedItems} class="slds-m-bottom_medium">
-            <c-pill-container
+            <avonni-pill-container
                 actions={pillActions}
                 items={selectedPills}
                 data-element-id="avonni-pill-container-vertical"
                 data-group-name="focusable-element"
                 onactionclick={handleSelectedItemRemove}
-            ></c-pill-container>
+            ></avonni-pill-container>
         </div>
     </template>
 
@@ -25,7 +25,7 @@
     >
         <template for:each={visibleMenus} for:item="menu">
             <li class={computedFiltersClass} key={menu.name}>
-                <c-filter-menu
+                <avonni-filter-menu
                     access-key={menu.accessKey}
                     alternative-text={menu.alternativeText}
                     apply-button-label={applyButtonLabel}
@@ -35,6 +35,7 @@
                     disabled={menu.disabled}
                     dropdown-alignment={menu.dropdownAlignment}
                     dropdown-nubbin={menu.dropdownNubbin}
+                    hide-apply-button={hideApplyButton}
                     hide-apply-reset-buttons={hideMenuApplyResetButtons}
                     hide-selected-items
                     icon-name={menu.iconName}
@@ -54,7 +55,7 @@
                     data-element-id="avonni-filter-menu"
                     data-group-name="focusable-element"
                     data-name={menu.name}
-                ></c-filter-menu>
+                ></avonni-filter-menu>
             </li>
         </template>
         <c-layout-item if:true={isOverflow} class="slds-text-align_right">
@@ -74,7 +75,7 @@
             >
                 <template for:each={hiddenMenus} for:item="menu">
                     <li class={computedFiltersClass} key={menu.name}>
-                        <c-filter-menu
+                        <avonni-filter-menu
                             access-key={menu.accessKey}
                             alternative-text={menu.alternativeText}
                             apply-button-label={applyButtonLabel}
@@ -102,7 +103,7 @@
                             data-element-id="avonni-filter-menu-overflow"
                             data-group-name="focusable-element"
                             data-name={menu.name}
-                        ></c-filter-menu>
+                        ></avonni-filter-menu>
                     </li>
                 </template>
             </c-button-popover>
@@ -110,14 +111,14 @@
     </ul>
 
     <div if:false={isVertical} class="slds-m-top_x-small">
-        <c-pill-container
+        <avonni-pill-container
             if:true={showSelectedItems}
             actions={pillActions}
             items={selectedPills}
             data-element-id="avonni-pill-container-horizontal"
             data-group-name="focusable-element"
             onactionclick={handleSelectedItemRemove}
-        ></c-pill-container>
+        ></avonni-pill-container>
     </div>
     <template if:true={showApplyResetButtons}>
         <lightning-button
@@ -128,6 +129,15 @@
             data-element-id="lightning-button-reset"
             data-group-name="focusable-element"
             onclick={handleResetClick}
+        ></lightning-button>
+        <lightning-button
+            if:false={hideApplyButton}
+            label={applyButtonLabel}
+            title={applyButtonLabel}
+            variant="brand"
+            data-element-id="lightning-button-apply"
+            data-group-name="focusable-element"
+            onclick={handleApplyClick}
         ></lightning-button>
     </template>
 </template>

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.html
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.html
@@ -67,7 +67,7 @@
                 label="More Filters"
                 icon-name="utility:filterList"
                 icon-position="right"
-                placement="right"
+                placement="auto"
                 popover-size="large"
                 variant="border-filled"
                 data-element-id="filter-menu-group-button-icon-popover"

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.html
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.html
@@ -1,29 +1,31 @@
 <template>
     <template if:true={isVertical}>
         <div if:true={showSelectedItems} class="slds-m-bottom_medium">
-            <avonni-pill-container
+            <c-pill-container
                 actions={pillActions}
                 items={selectedPills}
                 data-element-id="avonni-pill-container-vertical"
                 data-group-name="focusable-element"
                 onactionclick={handleSelectedItemRemove}
-            ></avonni-pill-container>
+            ></c-pill-container>
         </div>
     </template>
+
     <ul
         class={computedFiltersWrapperClass}
         data-element-id="ul"
         onapply={handleApply}
         onclose={handleClose}
         onloadmore={handleLoadMore}
+        onnbfilteritems={handleNbFilterItems}
         onopen={handleOpen}
         onreset={handleReset}
         onsearch={handleSearch}
         onselect={handleSelect}
     >
-        <template for:each={computedMenus} for:item="menu">
+        <template for:each={visibleMenus} for:item="menu">
             <li class={computedFiltersClass} key={menu.name}>
-                <avonni-filter-menu
+                <c-filter-menu
                     access-key={menu.accessKey}
                     alternative-text={menu.alternativeText}
                     apply-button-label={applyButtonLabel}
@@ -51,19 +53,70 @@
                     data-element-id="avonni-filter-menu"
                     data-group-name="focusable-element"
                     data-name={menu.name}
-                ></avonni-filter-menu>
+                ></c-filter-menu>
             </li>
         </template>
+        <c-layout-item lwc:if={isOverflow} class="slds-text-align_right">
+            <c-button-popover
+                class="
+                    slds-show_inline-block
+                    slds-p-left_x-small
+                    slds-text-align_left
+                "
+                label="More Filters"
+                icon-name="utility:filterList"
+                icon-position="right"
+                placement="right"
+                popover-size="large"
+                variant="border-filled"
+                data-element-id="filter-menu-group-button-icon-popover"
+            >
+                <template for:each={hiddenMenus} for:item="menu">
+                    <li class={computedFiltersClass} key={menu.name}>
+                        <c-filter-menu
+                            access-key={menu.accessKey}
+                            alternative-text={menu.alternativeText}
+                            apply-button-label={applyButtonLabel}
+                            button-variant={menu.buttonVariant}
+                            closed={menu.closed}
+                            collapsible={menu.collapsible}
+                            disabled={menu.disabled}
+                            dropdown-alignment={menu.dropdownAlignment}
+                            dropdown-nubbin={menu.dropdownNubbin}
+                            hide-apply-reset-buttons={hideMenuApplyResetButtons}
+                            hide-selected-items
+                            icon-name={menu.iconName}
+                            icon-size={menu.iconSize}
+                            is-loading={menu.isLoading}
+                            label={menu.label}
+                            loading-state-alternative-text={menu.loadingStateAlternativeText}
+                            name={menu.name}
+                            reset-button-label={resetButtonLabel}
+                            title={menu.title}
+                            type={menu.type}
+                            type-attributes={menu.typeAttributes}
+                            tooltip={menu.tooltip}
+                            value={menu.value}
+                            variant="vertical"
+                            data-element-id="avonni-filter-menu-overflow"
+                            data-group-name="focusable-element"
+                            data-name={menu.name}
+                        ></c-filter-menu>
+                    </li>
+                </template>
+            </c-button-popover>
+        </c-layout-item>
     </ul>
+
     <div if:false={isVertical} class="slds-m-top_x-small">
-        <avonni-pill-container
+        <c-pill-container
             if:true={showSelectedItems}
             actions={pillActions}
             items={selectedPills}
             data-element-id="avonni-pill-container-horizontal"
             data-group-name="focusable-element"
             onactionclick={handleSelectedItemRemove}
-        ></avonni-pill-container>
+        ></c-pill-container>
     </div>
     <template if:true={showApplyResetButtons}>
         <lightning-button

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.html
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.html
@@ -129,13 +129,5 @@
             data-group-name="focusable-element"
             onclick={handleResetClick}
         ></lightning-button>
-        <lightning-button
-            label={applyButtonLabel}
-            title={applyButtonLabel}
-            variant="brand"
-            data-element-id="lightning-button-apply"
-            data-group-name="focusable-element"
-            onclick={handleApplyClick}
-        ></lightning-button>
     </template>
 </template>

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.html
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.html
@@ -44,6 +44,7 @@
                     loading-state-alternative-text={menu.loadingStateAlternativeText}
                     name={menu.name}
                     reset-button-label={resetButtonLabel}
+                    show-selected-filter-value-count={showMenuSelectedFilterValueCount}
                     title={menu.title}
                     type={menu.type}
                     type-attributes={menu.typeAttributes}
@@ -56,7 +57,7 @@
                 ></c-filter-menu>
             </li>
         </template>
-        <c-layout-item lwc:if={isOverflow} class="slds-text-align_right">
+        <c-layout-item if:true={isOverflow} class="slds-text-align_right">
             <c-button-popover
                 class="
                     slds-show_inline-block

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.js
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.js
@@ -28,11 +28,13 @@ export default class FilterMenuGroup extends LightningElement {
     _applyButtonLabel = DEFAULT_APPLY_BUTTON_LABEL;
     _hideApplyResetButtons = false;
     _hideSelectedItems = false;
+    _isToggleButtonVariant = false;
     _menus = [];
     _resetButtonLabel = DEFAULT_RESET_BUTTON_LABEL;
     _value = {};
     _variant = MENU_VARIANTS.default;
     _searchBarWidth = 0;
+    _showSelectedFilterValueCount = false;
     _wrapperWidth = 0;
     _wrapperWidthWhenLastResized = 0;
 
@@ -111,6 +113,21 @@ export default class FilterMenuGroup extends LightningElement {
     }
 
     /**
+     * If present, each menu will have its button variant toggled between the border and outline-brand variants
+     *
+     * @type {boolean}
+     * @public
+     * @default false
+     */
+    @api
+    get isToggleButtonVariant() {
+        return this._isToggleButtonVariant;
+    }
+    set isToggleButtonVariant(value) {
+        this._isToggleButtonVariant = normalizeBoolean(value);
+    }
+
+    /**
      * Array of menu objects.
      *
      * @type {object[]}
@@ -163,6 +180,20 @@ export default class FilterMenuGroup extends LightningElement {
     set searchBarWidth(value) {
         this._searchBarWidth = value ?? 0;
         this.recomputeOverflow();
+    }
+
+    /**
+     * If present, the selected filter value and count are displayed in the label.
+     *
+     * @type {boolean}
+     * @default false
+     */
+    @api
+    get showSelectedFilterValueCount() {
+        return this._showSelectedFilterValueCount;
+    }
+    set showSelectedFilterValueCount(value) {
+        this._showSelectedFilterValueCount = normalizeBoolean(value);
     }
 
     /**
@@ -361,6 +392,15 @@ export default class FilterMenuGroup extends LightningElement {
     }
 
     /**
+     * True if the Selected Filter Value and Count should be displayed for each menu
+     *
+     * @type {boolean}
+     */
+    get showMenuSelectedFilterValueCount() {
+        return !this.isVertical && this.showSelectedFilterValueCount;
+    }
+
+    /**
      * Dynamically compute the visible menus based on the slice index.
      *
      * @type {object[]}
@@ -457,14 +497,14 @@ export default class FilterMenuGroup extends LightningElement {
         const pills = [];
         this.computedMenus.forEach((menu) => {
             menu.value = deepCopy(this.value[menu.name]);
-            if (!this.isVertical) {
+            if (this.isToggleButtonVariant) {
                 menu.buttonVariant = menu?._value.length
                     ? 'outline-brand'
                     : 'border';
             }
             pills.push(menu.selectedItems);
         });
-        if (!this.isVertical) {
+        if (!this.isToggleButtonVariant) {
             this.computedMenus = [...this.computedMenus];
         }
         if (this._hiddenMenusLength === 0) {

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.js
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.js
@@ -10,7 +10,7 @@ import { LightningElement, api } from 'lwc';
 import Menu from './menu';
 
 const DEFAULT_APPLY_BUTTON_LABEL = 'Apply';
-const DEFAULT_RESET_BUTTON_LABEL = 'Reset';
+const DEFAULT_RESET_BUTTON_LABEL = 'Clear selection';
 const MENU_VARIANTS = {
     valid: ['horizontal', 'vertical'],
     default: 'horizontal'
@@ -574,11 +574,9 @@ export default class FilterMenuGroup extends LightningElement {
             })
         );
 
-        if (this.hideApplyResetButtons) {
-            // Save the selection immediately
-            this.apply();
-            this.dispatchApply(menuName);
-        }
+        // Save the selection immediately
+        this.apply();
+        this.dispatchApply(menuName);
     }
 
     /**

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.js
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.js
@@ -764,6 +764,8 @@ export default class FilterMenuGroup extends LightningElement {
         }
         this.reset();
         this.dispatchReset();
+        this.apply();
+        this.dispatchApply();
     }
 
     /**

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.js
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.js
@@ -58,6 +58,12 @@ export default class FilterMenuGroup extends LightningElement {
         this._connected = true;
     }
 
+    renderedCallback() {
+        if (this.needsRecomputeHorizontal) {
+            this.recomputeOverflow();
+        }
+    }
+
     /*
      * ------------------------------------------------------------
      *  PRIVATE PROPERTIES

--- a/src/modules/base/filterMenuGroup/filterMenuGroup.js
+++ b/src/modules/base/filterMenuGroup/filterMenuGroup.js
@@ -30,10 +30,10 @@ export default class FilterMenuGroup extends LightningElement {
     _hideSelectedItems = false;
     _isToggleButtonVariant = false;
     _menus = [];
+    _offsetFilterWidth = 0;
     _resetButtonLabel = DEFAULT_RESET_BUTTON_LABEL;
     _value = {};
     _variant = MENU_VARIANTS.default;
-    _searchBarWidth = 0;
     _showSelectedFilterValueCount = false;
     _wrapperWidth = 0;
     _wrapperWidthWhenLastResized = 0;
@@ -113,11 +113,10 @@ export default class FilterMenuGroup extends LightningElement {
     }
 
     /**
-     * If present, each menu will have its button variant toggled between the border and outline-brand variants
+     * If present, each menu will have its button variant toggled between the border and outline-brand variants.
      *
      * @type {boolean}
      * @public
-     * @default false
      */
     @api
     get isToggleButtonVariant() {
@@ -149,6 +148,23 @@ export default class FilterMenuGroup extends LightningElement {
     }
 
     /**
+     * Width of the offset for the filter in pixels.
+     *
+     * @type {number}
+     * @public
+     * @default 0
+     */
+    @api
+    get offsetFilterWidth() {
+        return this._offsetFilterWidth;
+    }
+    set offsetFilterWidth(value) {
+        this._offsetFilterWidth =
+            typeof value === 'number' && value >= 0 ? value : 0;
+        this.recomputeOverflow();
+    }
+
+    /**
      * Label of the reset button.
      *
      * @type {string}
@@ -164,22 +180,6 @@ export default class FilterMenuGroup extends LightningElement {
             value && typeof value === 'string'
                 ? value.trim()
                 : DEFAULT_RESET_BUTTON_LABEL;
-    }
-
-    /**
-     * Width of the search bar in pixels. It is used to compute the overflow of the menu group.
-     *
-     * @type {number}
-     * @public
-     * @default 0
-     */
-    @api
-    get searchBarWidth() {
-        return this._searchBarWidth;
-    }
-    set searchBarWidth(value) {
-        this._searchBarWidth = value ?? 0;
-        this.recomputeOverflow();
     }
 
     /**
@@ -248,7 +248,8 @@ export default class FilterMenuGroup extends LightningElement {
         return this._wrapperWidth;
     }
     set wrapperWidth(value) {
-        this._wrapperWidth = value ?? 0;
+        this._wrapperWidth =
+            typeof value === 'number' && value >= 0 ? value : 0;
         if (this.needsRecomputeHorizontal) {
             this.recomputeOverflow();
         }
@@ -565,7 +566,7 @@ export default class FilterMenuGroup extends LightningElement {
         this._isCalculatingOverflow = true;
 
         requestAnimationFrame(() => {
-            let totalWidth = this.searchBarWidth;
+            let totalWidth = this.offsetFilterWidth;
             let sliceIndex = 0;
 
             this.listMenus.forEach((listMenu) => {

--- a/src/modules/base/storybookWrappers/filterMenu/infiniteLoading.html
+++ b/src/modules/base/storybookWrappers/filterMenu/infiniteLoading.html
@@ -9,6 +9,7 @@
         disabled={disabled}
         dropdown-alignment={dropdownAlignment}
         dropdown-nubbin={dropdownNubbin}
+        hide-apply-button={hideApplyButton}
         hide-apply-reset-buttons={hideApplyResetButtons}
         hide-selected-items={hideSelectedItems}
         icon-name={iconName}

--- a/src/modules/base/storybookWrappers/filterMenuGroup/filterMenuGroup.html
+++ b/src/modules/base/storybookWrappers/filterMenuGroup/filterMenuGroup.html
@@ -5,10 +5,12 @@
         hide-selected-items={hideSelectedItems}
         is-toggle-button-variant={isToggleButtonVariant}
         menus={menus}
+        offset-filter-width={offsetFilterWidth}
         reset-button-label={resetButtonLabel}
         show-selected-filter-value-count={showSelectedFilterValueCount}
         value={value}
         variant={variant}
+        wrapper-width={wrapperWidth}
         onloadmore={handleLoadMore}
     ></c-filter-menu-group>
 </template>

--- a/src/modules/base/storybookWrappers/filterMenuGroup/filterMenuGroup.html
+++ b/src/modules/base/storybookWrappers/filterMenuGroup/filterMenuGroup.html
@@ -3,8 +3,10 @@
         apply-button-label={applyButtonLabel}
         hide-apply-reset-buttons={hideApplyResetButtons}
         hide-selected-items={hideSelectedItems}
+        is-toggle-button-variant={isToggleButtonVariant}
         menus={menus}
         reset-button-label={resetButtonLabel}
+        show-selected-filter-value-count={showSelectedFilterValueCount}
         value={value}
         variant={variant}
         onloadmore={handleLoadMore}

--- a/src/modules/base/storybookWrappers/filterMenuGroup/filterMenuGroup.html
+++ b/src/modules/base/storybookWrappers/filterMenuGroup/filterMenuGroup.html
@@ -1,6 +1,7 @@
 <template>
     <c-filter-menu-group
         apply-button-label={applyButtonLabel}
+        hide-apply-button={hideApplyButton}
         hide-apply-reset-buttons={hideApplyResetButtons}
         hide-selected-items={hideSelectedItems}
         is-toggle-button-variant={isToggleButtonVariant}

--- a/src/modules/base/storybookWrappers/filterMenuGroup/filterMenuGroup.js
+++ b/src/modules/base/storybookWrappers/filterMenuGroup/filterMenuGroup.js
@@ -104,7 +104,9 @@ export default class FilterMenuGroup extends LightningElement {
     @api applyButtonLabel;
     @api hideApplyResetButtons;
     @api hideSelectedItems;
+    @api isToggleButtonVariant;
     @api resetButtonLabel;
+    @api showSelectedFilterValueCount;
     @api variant;
 
     _menus = [];

--- a/src/modules/base/storybookWrappers/filterMenuGroup/filterMenuGroup.js
+++ b/src/modules/base/storybookWrappers/filterMenuGroup/filterMenuGroup.js
@@ -105,9 +105,11 @@ export default class FilterMenuGroup extends LightningElement {
     @api hideApplyResetButtons;
     @api hideSelectedItems;
     @api isToggleButtonVariant;
+    @api offsetFilterWidth;
     @api resetButtonLabel;
     @api showSelectedFilterValueCount;
     @api variant;
+    @api wrapperWidth;
 
     _menus = [];
     _value = {};

--- a/src/modules/base/storybookWrappers/filterMenuGroup/filterMenuGroup.js
+++ b/src/modules/base/storybookWrappers/filterMenuGroup/filterMenuGroup.js
@@ -102,6 +102,7 @@ const LANGUAGES = [
 
 export default class FilterMenuGroup extends LightningElement {
     @api applyButtonLabel;
+    @api hideApplyButton;
     @api hideApplyResetButtons;
     @api hideSelectedItems;
     @api isToggleButtonVariant;


### PR DESCRIPTION
<!-- Are you sure you're ready to open a pull request? -->
<!-- Checkout the list first: https://avonnicreator.atlassian.net/wiki/spaces/LDG/pages/2140766209/Can+I+open+a+pull+request -->
<!-- Then use this template to explain what you did: -->

### Features
**Filter Menu**
- Added attribute `hideApplyButton`.
- Added attribute `showSelectedFilterValueCount`.
- Default value of attribute `resetButtonLabel` is now 'Clear selection' instead of 'Reset'.
- Display Selected Filter Value and Count in Label for Horizontal Filter.
- Display Number of Items for Horizontal Filter.

**Filter Menu Group**
- Added attribute `hideApplyButton`.
- Added attribute `isToggleButtonVariant`.
- Added attribute `showSelectedFilterValueCount`.
- Added attribute `offsetWidth`.
- Added attribute `wrapperWidth`.
- Default value of attribute `resetButtonLabel` is now 'Clear selection' instead of 'Reset'.
- Added Overflow Handling for Horizontal Filters with “More Filters” Option.

<!-- Don't forget to edit and remove what's unnecessary! -->
<!-- See the Release Notes for real examples: https://www.avonnicomponents.com/release-notes -->
