### PR TITLE
[Bugfix] (ABC-1463): Tree - Parent noSlots stop allowing insert above and under child

### DIFF
--- a/src/modules/base/tree/__tests__/data.js
+++ b/src/modules/base/tree/__tests__/data.js
@@ -69,7 +69,6 @@ export const ITEMS = [
             {
                 label: 'First level',
                 name: 'firstLevel',
-                noSlots: true,
                 items: [
                     {
                         label: 'Second level',
@@ -144,6 +143,41 @@ export const ITEMS = [
         label: 'Simple unselectable',
         name: 'simpleUnselectable',
         unselectable: true
+    }
+];
+
+export const ITEMS_WITH_INVALID_SORTING_NO_SLOTS = [
+    {
+        label: 'No slots',
+        name: 'noSlots',
+        noSlots: true,
+        type: 'valid',
+        slottableTypes: ['invalidSorting']
+    },
+    {
+        label: 'Item to move',
+        name: 'itemToMove',
+        type: 'invalidSorting'
+    },
+    {
+        label: 'No slots with children',
+        name: 'noSlotsWithChildren',
+        noSlots: true,
+        items: [
+            {
+                label: 'First level no slots child',
+                name: 'firstLevelNoSlotsChild',
+                type: 'invalidSorting'
+            },
+            {
+                label: 'First level no slots child 2',
+                name: 'firstLevelNoSlotsChild2',
+                type: 'invalidSorting'
+            }
+        ],
+        type: 'valid',
+        slottableTypes: ['valid'],
+        expanded: true
     }
 ];
 

--- a/src/modules/base/tree/__tests__/tree.test.js
+++ b/src/modules/base/tree/__tests__/tree.test.js
@@ -4,7 +4,8 @@ import {
     ACTIONS,
     generateFakeRegisters,
     ITEMS,
-    ITEMS_WITH_INVALID_SORTING
+    ITEMS_WITH_INVALID_SORTING,
+    ITEMS_WITH_INVALID_SORTING_NO_SLOTS
 } from './data';
 
 // Not tested:
@@ -1454,9 +1455,9 @@ describe('Tree', () => {
             describe('Invalid sorting', () => {
                 it('Move an item inside another with noSlots', () => {
                     const fakeRegisters = generateFakeRegisters(
-                        ITEMS_WITH_INVALID_SORTING
+                        ITEMS_WITH_INVALID_SORTING_NO_SLOTS
                     );
-                    element.items = ITEMS_WITH_INVALID_SORTING;
+                    element.items = ITEMS_WITH_INVALID_SORTING_NO_SLOTS;
                     element.sortable = true;
 
                     jest.useFakeTimers();
@@ -1518,6 +1519,134 @@ describe('Tree', () => {
                                 composed: true
                             })
                         );
+                        expect(handler).toHaveBeenCalledTimes(0);
+                    });
+                });
+
+                it('Move an item inside another with noSlots, by being under one of its child', () => {
+                    const fakeRegisters = generateFakeRegisters(
+                        ITEMS_WITH_INVALID_SORTING_NO_SLOTS
+                    );
+                    element.items = ITEMS_WITH_INVALID_SORTING_NO_SLOTS;
+                    element.sortable = true;
+
+                    jest.useFakeTimers();
+                    const handler = jest.fn();
+                    element.addEventListener('change', handler);
+
+                    return Promise.resolve().then(() => {
+                        // Register the items, including the nested ones
+                        const items = element.shadowRoot.querySelectorAll(
+                            '[data-element-id="avonni-primitive-tree-item"]'
+                        );
+                        Object.values(fakeRegisters).forEach((register) => {
+                            items[0].dispatchEvent(
+                                new CustomEvent('privateregisteritem', {
+                                    bubbles: true,
+                                    detail: register
+                                })
+                            );
+                        });
+
+                        // Mouse down
+                        items[2].dispatchEvent(
+                            new CustomEvent('privatemousedown', {
+                                detail: {
+                                    name: ITEMS[2].name,
+                                    key: '3.2'
+                                },
+                                bubbles: true
+                            })
+                        );
+                        jest.runAllTimers();
+
+                        // Move to the bottom item
+                        const mouseMove = new CustomEvent('mousemove', {
+                            bubbles: true,
+                            composed: true
+                        });
+
+                        // Mouse to the bottom of the item
+                        mouseMove.clientY = 15;
+                        const tree = element.shadowRoot.querySelector(
+                            '[data-element-id="div-tree-wrapper"]'
+                        );
+                        tree.dispatchEvent(mouseMove);
+
+                        // Mouse on the center of the item
+                        mouseMove.clientY = 40;
+                        const setBorderCallback =
+                            fakeRegisters.firstLevelNoSlotsChild.setBorder;
+                        tree.dispatchEvent(mouseMove);
+                        expect(setBorderCallback).toHaveBeenCalled();
+                        expect(setBorderCallback.mock.calls[0][0]).toBe(
+                            'bottom'
+                        );
+                        expect(setBorderCallback.mock.calls[0][2]).toBeFalsy();
+
+                        jest.runAllTimers();
+                        expect(handler).toHaveBeenCalledTimes(0);
+                    });
+                });
+
+                it('Move an item inside another with noSlots, by being above one of its child', () => {
+                    const fakeRegisters = generateFakeRegisters(
+                        ITEMS_WITH_INVALID_SORTING_NO_SLOTS
+                    );
+                    element.items = ITEMS_WITH_INVALID_SORTING_NO_SLOTS;
+                    element.sortable = true;
+
+                    jest.useFakeTimers();
+                    const handler = jest.fn();
+                    element.addEventListener('change', handler);
+
+                    return Promise.resolve().then(() => {
+                        // Register the items, including the nested ones
+                        const items = element.shadowRoot.querySelectorAll(
+                            '[data-element-id="avonni-primitive-tree-item"]'
+                        );
+                        Object.values(fakeRegisters).forEach((register) => {
+                            items[0].dispatchEvent(
+                                new CustomEvent('privateregisteritem', {
+                                    bubbles: true,
+                                    detail: register
+                                })
+                            );
+                        });
+
+                        // Mouse down
+                        items[2].dispatchEvent(
+                            new CustomEvent('privatemousedown', {
+                                detail: {
+                                    name: ITEMS[2].name,
+                                    key: '3.2'
+                                },
+                                bubbles: true
+                            })
+                        );
+                        jest.runAllTimers();
+
+                        // Move to the bottom item
+                        const mouseMove = new CustomEvent('mousemove', {
+                            bubbles: true,
+                            composed: true
+                        });
+                        mouseMove.clientY = 15;
+                        const tree = element.shadowRoot.querySelector(
+                            '[data-element-id="div-tree-wrapper"]'
+                        );
+                        tree.dispatchEvent(mouseMove);
+
+                        // Mouse to the top of the item
+                        mouseMove.clientY = 30;
+                        const setBorderCallback =
+                            fakeRegisters.firstLevelNoSlotsChild.setBorder;
+                        tree.dispatchEvent(mouseMove);
+                        expect(setBorderCallback).toHaveBeenCalled();
+                        expect(setBorderCallback.mock.calls[0][0]).toBe('top');
+                        expect(setBorderCallback.mock.calls[0][2]).toBeFalsy();
+
+                        jest.runAllTimers();
                         expect(handler).toHaveBeenCalledTimes(0);
                     });
                 });
@@ -1612,10 +1741,10 @@ describe('Tree', () => {
                         });
 
                         // Mouse down
-                        items[2].dispatchEvent(
+                        items[1].dispatchEvent(
                             new CustomEvent('privatemousedown', {
                                 detail: {
-                                    name: ITEMS[2].name,
+                                    name: ITEMS[1].name,
                                     key: '3.2'
                                 },
                                 bubbles: true
@@ -1630,7 +1759,7 @@ describe('Tree', () => {
                         });
 
                         // Mouse to the bottom of the item
-                        mouseMove.clientY = 35;
+                        mouseMove.clientY = 15;
                         const tree = element.shadowRoot.querySelector(
                             '[data-element-id="div-tree-wrapper"]'
                         );
@@ -1694,7 +1823,7 @@ describe('Tree', () => {
                             bubbles: true,
                             composed: true
                         });
-                        mouseMove.clientY = 35;
+                        mouseMove.clientY = 15;
                         const tree = element.shadowRoot.querySelector(
                             '[data-element-id="div-tree-wrapper"]'
                         );

--- a/src/modules/base/tree/tree.js
+++ b/src/modules/base/tree/tree.js
@@ -902,7 +902,7 @@ export default class Tree extends LightningElement {
 
         // Parent
         const parentExists = !!parent;
-        const parentHasSlots = parentExists && !parent.noSlots;
+        const parentHasSlots = parentExists && !parent.treeNode.noSlots;
         const parentSupportsType =
             parentExists &&
             (parent.treeNode.slottableTypes.length === 0 ||


### PR DESCRIPTION
### Fixes
**Tree**
- Fixed an issue where sorting an item above or under the child of a parent item with `noSlots` was allowed.
