### PR TITLE
[fix] (ABC-1466): Fix input choice set colours in Salesforce mobile app

### DIFF
--- a/src/modules/base/inputChoiceSet/inputChoiceSet.js
+++ b/src/modules/base/inputChoiceSet/inputChoiceSet.js
@@ -1182,8 +1182,10 @@ export default class InputChoiceSet extends LightningElement {
             const color = label.dataset.color;
             if (!color) return;
             if (hasValue && !this.toggleVariant) {
-                label.style.backgroundColor = color;
-                label.style.borderColor = color;
+                if (this.buttonVariant) {
+                    label.style.backgroundColor = color;
+                    label.style.borderColor = color;
+                }
                 label.style.color = this.buttonVariant ? 'white' : color;
             } else {
                 label.style.backgroundColor = '';


### PR DESCRIPTION
### Fixes
**Input Choice Set**
- Fixed the checkbox colour when the component is used in the Salesforce App.
